### PR TITLE
fixing random changing of access tab radio buttons when refreshing the CMS

### DIFF
--- a/javascript/LeftAndMain.js
+++ b/javascript/LeftAndMain.js
@@ -7,6 +7,13 @@ if(typeof(jQuery) != 'undefined') {
 		$(document).ready(function() {
 			window.onresize(true);
 		});
+
+		//Turn off autocomplete to fix the access tab randomly switching radio buttons in Firefox when refresh the page
+		// with an anchor tag in the URL. E.g: /admin#Root_Access
+		//Autocomplete in the CMS also causes strangeness in other browsers, so this turns it off for all browsers.
+		//see the following for demo and explanation of the Firefox bug:
+		//  http://www.ryancramer.com/journal/entries/radio_buttons_firefox/
+		$("#Form_EditForm").attr("autocomplete", "off");
 	})(jQuery);
 }
 


### PR DESCRIPTION
BUGFIX: fixing random changing of access tab radio buttons when refreshing the CMS with a URL such as /admin#Root_Access in Firefox.
