### PR TITLE
MINOR Skipping test when PHP Version is lower than 5.3.2

### DIFF
--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -829,6 +829,10 @@ class SiteTreeTest extends SapphireTest {
 	}
 	
 	function testClassDropdown() {
+		if(version_compare(PHP_VERSION, '5.3.2', '<')){
+			// @link http://www.php.net/manual/en/reflectionmethod.setaccessible.php
+			$this->markTestSkipped('Need PHP 5.3.2 to run this test.');
+		}
 		$sitetree = new SiteTree();
 		$method = new ReflectionMethod($sitetree, 'getClassDropdown');
 		$method->setAccessible(true);


### PR DESCRIPTION
ReflectionMethod#setAccessible was released in PHP Version 5.3.2
