### PR TITLE
Multibyte urlsegment

### DIFF
--- a/code/forms/SiteTreeURLSegmentField.php
+++ b/code/forms/SiteTreeURLSegmentField.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @package cms
+ * @subpackage forms
+ */
+
+/**
+ * Used to edit the SiteTree->URLSegment property, and suggest input based on the serverside rules
+ * defined through {@link SiteTree->generateURLSegment()} and {@link URLSegmentFilter}.
+ * 
+ * Note: The actual conversion for saving the value takes place in the model layer.
+ */
+class SiteTreeURLSegmentField extends TextField {
+	
+	static $allowed_actions = array(
+		'suggest'
+	);
+	
+	function suggest($request) {
+		if(!$request->getVar('value')) return $this->httpError(405);
+		$page = $this->getPage();
+
+		// Same logic as SiteTree->onBeforeWrite
+		$page->URLSegment = $page->generateURLSegment($request->getVar('value'));
+		$count = 2;
+		while(!$page->validURLSegment()) {
+			$page->URLSegment = preg_replace('/-[0-9]+$/', null, $page->URLSegment) . '-' . $count;
+			$count++;
+		}
+		
+		Controller::curr()->getResponse()->addHeader('Content-Type', 'application/json');
+		return Convert::raw2json(array('value' => $page->URLSegment));
+	}
+		
+	/**
+	 * @return SiteTree
+	 */
+	function getPage() {
+		$idField = $this->getForm()->dataFieldByName('ID');
+		return ($idField && $idField->Value()) ? DataObject::get_by_id('SiteTree', $idField->Value()) : singleton('SiteTree');
+	}
+}

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1385,7 +1385,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if((!$this->URLSegment || $this->URLSegment == 'new-page') && $this->Title) {
 			$this->URLSegment = $this->generateURLSegment($this->Title);
 		} else if($this->isChanged('URLSegment')) {
-			$filter = Object::create('URLPathFilter');
+			$filter = Object::create('URLSegmentFilter');
 			$this->URLSegment = $filter->filter($this->URLSegment);
 			// If after sanitising there is no URLSegment, give it a reasonable default
 			if(!$this->URLSegment) $this->URLSegment = "page-$this->ID";
@@ -1578,7 +1578,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return string Generated url segment
 	 */
 	function generateURLSegment($title){
-		$filter = Object::create('URLPathFilter');
+		$filter = Object::create('URLSegmentFilter');
 		$t = $filter->filter($title);
 		
 		// Fallback to generic page name if path is empty (= no valid, convertable characters)
@@ -1828,7 +1828,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 					new HtmlEditorField("Content", _t('SiteTree.HTMLEDITORTITLE', "Content", PR_MEDIUM, 'HTML editor title'))
 				),
 				$tabMeta = new Tab('Metadata',
-					new TextField("URLSegment", $this->fieldLabel('URLSegment') . $urlHelper),
+					new SiteTreeURLSegmentField("URLSegment", $this->fieldLabel('URLSegment') . $urlHelper),
 					new LiteralField('LinkChangeNote', self::nested_urls() && count($this->Children()) ?
 						'<p>' . $this->fieldLabel('LinkChangeNote'). '</p>' : null
 					),


### PR DESCRIPTION
In short: Allow unicode characters in SilverStripe URL paths = URLSegment (unrelated to domains or query parameters).

Client request from an internal ticket: http://helpdesk.silverstripe.com/tickets/6756
Also rewrite the same change a bit differently for post-2.4: https://github.com/chillu/silverstripe-cms/commit/96421367b1764323ae87d2b2778d26207e0c987b

The underlying datamodel changes mean that we can't easily adapt the existing JS logic, which hardcodes a single regex. You can customize these rules on the server, meaning the client logic doesn't match any longer.  I think its overkill to get the clientside to match up via JS, and used an ajax call instead. That has the disadvantage of being async though, so we can't prompt the user about "Do you want to change your URL from X to Y?" without risking a disruptive dialog seconds after the user action. I've made this a generic "Do you want to update the URL from your new page title?", which actually matches the 2.4 behaviour. Acceptable UX?

SiteTreeURLSegmentField seems a bit extreme, we originally had UniqueRestrictedTextField for this, now deprecated. AjaxUniqueTextField is still in there, but also still on behaviour.js etc. - is it OK to use a highly specialized field here?
