### PR TITLE
BUGFIX: Fixes #6809.

### DIFF
--- a/javascript/CMSMain.EditForm.js
+++ b/javascript/CMSMain.EditForm.js
@@ -80,12 +80,22 @@
 				var self = this;
 		
 				this.bind('change', function(e) {
+					self.updatePageTitleHeading();
 					self.updateURLSegment(jQuery('.cms-edit-form input[name=URLSegment]'));
 					// TODO We should really user-confirm these changes
 					self.parents('form').find('input[name=MetaTitle], input[name=MenuTitle]').val(self.val());
 				});
 				
 				this._super();
+			},
+			
+			/**
+			 * Function: updatePageTitleHeading
+			 * 
+			 * Update the page title heading when page title changes
+			 */
+			updatePageTitleHeading: function() {
+				$('#page-title-heading').html(this.val());
 			},
 	
 			/**


### PR DESCRIPTION
Small change to update the page title heading on change of page title in the edit page form.

Dependant on this pull request:
https://github.com/silverstripe/sapphire/pull/135

this commin in that pull request:
https://github.com/frankmullenger/sapphire/commit/5470fd54e4667385e2796d8abcccd180b498e42d
