### PR TITLE
Fix typo in function name

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -999,6 +999,13 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 	}
 
+	/**
+	 * @deprecated 3.0 Use prepopulate_permission_cache() instead
+	 */
+	static function prepopuplate_permission_cache($permission = 'CanEditType', $ids, $batchCallback = null) {
+		Deprecation::notice("3.0", "Use prepopulate_permission_cache instead.");
+		self::prepopulate_permission_cache($permission, $ids, $batchCallback);
+	}
 
 	/**
 	 * Pre-populate the cache of canEdit, canView, canDelete, canPublish permissions.


### PR DESCRIPTION
There was a function named "SiteTree::prepopuplate_permission_cache" which
should be "SiteTree::prepopulate_permission_cache".

Note that I found the function name also used in the silverstripe-cmsworkflow and sapphire projects.  I will send pull requests for each of those momentarily.
