### PR TITLE
ENHANCEMENT Allow Breadcrumbs title to be overridable

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -633,16 +633,27 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
  			&& (!$stopAtPageType || $page->ClassName != $stopAtPageType)
  		) {
 			if($showHidden || $page->ShowInMenus || ($page->ID == $this->ID)) { 
+				$title = $this->getBreadcrumbTitle($page);
 				if(($page->ID == $this->ID) || $unlinked) {
-				 	$parts[] = Convert::raw2xml($page->Title);
+					$parts[] = $title;
 				} else {
-					$parts[] = ("<a href=\"" . $page->Link() . "\">" . Convert::raw2xml($page->Title) . "</a>"); 
+					$parts[] = ("<a href=\"" . $page->Link() . "\">" . $title . "</a>");
 				}
 			}
 			$page = $page->Parent;
 		}
 
 		return implode(self::$breadcrumbs_delimiter, array_reverse($parts));
+	}
+
+	/**
+	 * Get the default breadcrumb title for a page.  This can be overridden as needed by
+	 * subclasses of SiteTree.  Defaults to the escaped page title.
+	 *
+	 * @param SiteTree $page the page to get the title for
+	 */
+	public function getBreadcrumbTitle(&$page) {
+		return Convert::raw2xml($page->Title);
 	}
 
 	/**


### PR DESCRIPTION
Allow subclasses of SiteTree to override the method that gets the breadcrumb
title to show for a given page so that users can potentially use the navigation
title or an unescaped title if they choose to do so.

This is the equivalent of https://github.com/silverstripe/sapphire/pull/181, but for the master branch of development (which moved the modified files into silverstripe-cms rather than sapphire).
