### PR TITLE
ENHANCEMENT Allow the homepage to have a different URL

### DIFF
--- a/code/controllers/RootURLController.php
+++ b/code/controllers/RootURLController.php
@@ -55,6 +55,16 @@ class RootURLController extends Controller {
 	}
 	
 	/**
+	 * Set the URL Segment used for your homepage when it is created by dev/build.
+	 * This allows you to use home page URLs other than the default "home".
+	 *
+	 * @param string $urlsegment the URL segment for your home page
+	 */
+	public static function set_default_homepage_link($urlsegment = "home") {
+		self::$default_homepage_link = $urlsegment;
+	}
+
+	/**
 	 * Gets the link that denotes the homepage if there is not one explicitly defined for this HTTP_HOST value.
 	 *
 	 * @return string

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1328,11 +1328,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		
 		// default pages
 		if($this->class == 'SiteTree' && self::get_create_default_pages()) {
-			if(!SiteTree::get_by_link('home')) {
+			if(!SiteTree::get_by_link(RootURLController::get_default_homepage_link())) {
 				$homepage = new Page();
 				$homepage->Title = _t('SiteTree.DEFAULTHOMETITLE', 'Home');
 				$homepage->Content = _t('SiteTree.DEFAULTHOMECONTENT', '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>. You can now access the <a href="http://doc.silverstripe.org">developer documentation</a>, or begin <a href="http://doc.silverstripe.org/doku.php?id=tutorials">the tutorials.</a></p>');
-				$homepage->URLSegment = 'home';
+				$homepage->URLSegment = RootURLController::get_default_homepage_link();
 				$homepage->Sort = 1;
 				$homepage->write();
 				$homepage->publish('Stage', 'Live');


### PR DESCRIPTION
If you changed the URL segment for your homepage to anything other than 'home'
a new homepage would be created every time you ran a dev/build.  This commit
allows you to call RootURLController::set_default_homepage_link('something');
to change the URL segment for your homepage to 'something'.  After doing this
the dev/build process will no longer create a homepage if you already have a
page with 'something' as the URL segment.

There was a discussion of needing this at
http://www.silverstripe.org/general-questions/show/12253

This is the equivalent of https://github.com/silverstripe/sapphire/pull/182, but for the master branch of development (which moved the modified files into silverstripe-cms rather than sapphire).
