### PR TITLE
MINOR getEditForm should have the same signature as parent class

### DIFF
--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -20,7 +20,7 @@ class CMSFileAddController extends AssetAdmin {
 	 * @return Form
 	 * @todo what template is used here? AssetAdmin_UploadContent.ss doesn't seem to be used anymore
 	 */
-	public function getEditForm() {
+	public function getEditForm($id = null, $fields = null) {
 		Requirements::javascript(SAPPHIRE_DIR . '/javascript/AssetUploadField.js');
 		Requirements::css(SAPPHIRE_DIR . '/css/AssetUploadField.css');
 


### PR DESCRIPTION
When running PHP in strict mode php complains that the overridden method CMSFileAddController::getEditForm doesn't comply to the parent method.

```
Strict standards: Declaration of CMSFileAddController::getEditForm() should be compatible 
with that of LeftAndMain::getEditForm() in /home/stig/silverstripe.dev/cms/code/controllers/CMSFileAddController.php      
on line 45
```
