### PR TITLE
BUGFIX Page location radio buttons update ParentID accordingly

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1902,13 +1902,13 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 						$this->fieldLabel('ClassName'), 
 						$this->getClassDropdown()
 					),
-					
-					new OptionsetField("ParentType", _t("SiteTree.PAGELOCATION", "Page location"), array(
-						"root" => _t("SiteTree.PARENTTYPE_ROOT", "Top-level page"),
-						"subpage" => _t("SiteTree.PARENTTYPE_SUBPAGE", "Sub-page underneath a parent page (choose below)"),
-					)),
-					$parentIDField = new TreeDropdownField("ParentID", $this->fieldLabel('ParentID'), 'SiteTree', 'ID', 'MenuTitle'),
-					
+					$parentTypeSelector = new CompositeField(
+						new OptionsetField("ParentType", _t("SiteTree.PAGELOCATION", "Page location"), array(
+							"root" => _t("SiteTree.PARENTTYPE_ROOT", "Top-level page"),
+							"subpage" => _t("SiteTree.PARENTTYPE_SUBPAGE", "Sub-page underneath a parent page (choose below)"),
+						)),
+						$parentIDField = new TreeDropdownField("ParentID", $this->fieldLabel('ParentID'), 'SiteTree', 'ID', 'MenuTitle')
+					),
 					new CheckboxField("ShowInMenus", $this->fieldLabel('ShowInMenus')),
 					new CheckboxField("ShowInSearch", $this->fieldLabel('ShowInSearch')),
 					new LiteralField(
@@ -1944,6 +1944,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		 * or its descendents, as this causes vanishing bugs.
 		 */
 		$parentIDField->setFilterFunction(create_function('$node', "return \$node->ID != {$this->ID};"));
+		$parentTypeSelector->addExtraClass('parentTypeSelector');
 		
 		$tabBehaviour->setTitle(_t('SiteTree.TABBEHAVIOUR', "Behavior"));
 		$tabAccess->setTitle(_t('SiteTree.TABACCESS', "Access"));
@@ -2717,5 +2718,3 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	}
 
 }
-
-?>

--- a/javascript/CMSMain.EditForm.js
+++ b/javascript/CMSMain.EditForm.js
@@ -136,6 +136,9 @@
 			onmatch : function() {
 				var self = this;
 				this.find(':input[name=ParentType]').bind('click', function(e) {self._toggleSelection(e);});
+				this.find('.TreeDropdownField').bind('change', function(e) {self._changeParentId(e);});
+				
+				this._changeParentId();
 				this._toggleSelection();
 				
 				this._super();
@@ -151,8 +154,22 @@
 				var selected = this.find(':input[name=ParentType]:checked').val();
 				// reset parent id if 'root' radiobutton is selected
 				if(selected == 'root') this.find(':input[name=ParentID]').val(0);
+				// otherwise use the old value
+				else this.find(':input[name=ParentID]').val(this.find('#Form_EditForm_ParentType_subpage').data('parentIdValue'));
 				// toggle tree dropdown based on selection
 				this.find('#ParentID').toggle(selected != 'root');
+			},
+			
+			/**
+			 * Function: _changeParentId
+			 * 
+			 * Parameters:
+			 *  (Event) e
+			 */
+			_changeParentId: function(e) {
+				var value = this.find(':input[name=ParentID]').val();
+				// set a data attribute so we know what to use in _toggleSelection
+				this.find('#Form_EditForm_ParentType_subpage').data('parentIdValue', value);
 			}
 		});
 


### PR DESCRIPTION
The changes to SiteTree wrap the two fields in the div that the JS is expecting.

The changes to the JS store the ParentID as a data attribute on the subpage button, which is then used to set ParentID when switching from root to subpage.
