### PR TITLE
Issue # 6852 URL Segment

### DIFF
--- a/code/forms/SiteTreeURLSegmentField.php
+++ b/code/forms/SiteTreeURLSegmentField.php
@@ -12,6 +12,12 @@
  */
 class SiteTreeURLSegmentField extends TextField {
 	
+	protected $template = 'SiteTreeURLSegmentField';
+	
+	static $secondaryinfo = false;
+	
+	static $urlprefix;
+	
 	static $allowed_actions = array(
 		'suggest'
 	);
@@ -39,8 +45,40 @@ class SiteTreeURLSegmentField extends TextField {
 		$idField = $this->getForm()->dataFieldByName('ID');
 		return ($idField && $idField->Value()) ? DataObject::get_by_id('SiteTree', $idField->Value()) : singleton('SiteTree');
 	}
+	
+	/**
+	 * @param string the secondary text to show
+	 */
+	function setSecondaryInfo($string){
+		if($string) self::$secondaryinfo = $string; 
+	}
+	
+	/**
+	 * @return string the secondary text to show in the template
+	 */
+	function getSecondaryInfo(){
+		return self::$secondaryinfo;
+	
+	}
+	
+	/**
+	 * @param the url that prefixes the page url segment field
+	 */
+	function setURLPrefix($url){
+		self::$urlprefix = $url;
+	}
+	
+	/**
+	 * @return the url prefixes the page url segment field to show in template
+	 */
+	function getURLPrefix(){
+		return self::$urlprefix;
+	}
+	
 
 	function Type() {
 		return 'text sitetreeurlsegment';
 	}
+	
+	
 }

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1830,8 +1830,12 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			(self::nested_urls() && $this->ParentID ? $this->Parent()->RelativeLink(true) : null)
 		);
 		
+		
+		
 		$url = (strlen($baseLink) > 36) ? "..." .substr($baseLink, -32) : $baseLink;
-		$urlHelper = sprintf("<span>%s</span>", $url);
+		$urlsegment = new SiteTreeURLSegmentField("URLSegment", $this->fieldLabel('URLSegment'));
+		$urlsegment->setURLPrefix($url);
+		$urlsegment->setSecondaryInfo(self::nested_urls() && count($this->Children()) ? $this->fieldLabel('LinkChangeNote'): false);
 		
 		$fields = new FieldList(
 			$rootTab = new TabSet("Root",
@@ -1841,10 +1845,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 					$htmlField = new HtmlEditorField("Content", _t('SiteTree.HTMLEDITORTITLE', "Content", PR_MEDIUM, 'HTML editor title'))
 				),
 				$tabMeta = new Tab('Metadata',
-					new SiteTreeURLSegmentField("URLSegment", $this->fieldLabel('URLSegment') . $urlHelper),
-					new LiteralField('LinkChangeNote', self::nested_urls() && count($this->Children()) ?
-						'<p>' . $this->fieldLabel('LinkChangeNote'). '</p>' : null
-					),
+					$urlsegment,
 					new HeaderField('MetaTagsHeader',$this->fieldLabel('MetaTagsHeader')),
 					new TextField("MetaTitle", $this->fieldLabel('MetaTitle')),
 					new TextareaField("MetaKeywords", $this->fieldLabel('MetaKeywords'), 1),
@@ -1880,6 +1881,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		return $fields;
 	}
+	
 	
 	/**
 	 * Returns fields related to configuration aspects on this record, e.g. access control.

--- a/lang/en_US.php
+++ b/lang/en_US.php
@@ -430,7 +430,7 @@ $lang['en_US']['SiteTree']['TABMETA'] = 'Metadata';
 $lang['en_US']['SiteTree']['TOPLEVEL'] = 'Site Content (Top Level)';
 $lang['en_US']['SiteTree']['TOPLEVELCREATORGROUPS'] = 'Top level creators';
 $lang['en_US']['SiteTree']['URLSegment'] = array(
-	'URL Segment',
+	'URL',
 	PR_MEDIUM,
 	'URL for this page'
 );

--- a/templates/forms/SiteTreeURLSegmentField.ss
+++ b/templates/forms/SiteTreeURLSegmentField.ss
@@ -1,0 +1,4 @@
+<span>$URLPrefix</span><input $AttributesHTML />/
+<% if $SecondaryInfo %>
+<p class="secondary-info">$SecondaryInfo</p>
+<% end_if %>


### PR DESCRIPTION
API CHANGE SiteTreeURLSegmentField has new methods to aid in displaying URL prefix and secondary information text. ENHANCEMENT new form field template for URLSegment in edit page.

More like the 2.4.x style URL Segment with url prefix on the same line as the field (more in context), long URL prefixes wrap around in the space and push the field along.

CSS style change in sapphire/admin pull request.
