### PR TITLE
BUGFIX: Fixed AssetAdmin, error creating folder in root

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -407,7 +407,9 @@ JS
 		mkdir($record->FullPath);
 		chmod($record->FullPath, Filesystem::$file_create_mask);
 
-		return $this->redirect(Controller::join_links($this->Link('show'), $parentRecord->ID));
+		$redirectID = $parentRecord ? $parentRecord->ID : 0;
+
+		return $this->redirect(Controller::join_links($this->Link('show'), $redirectID));
 	}
 
 	/**


### PR DESCRIPTION
Fixed error while creating folder in root, now the user is redirected to the root if no parentRecord exists, fixes #6963.
