### PR TITLE
BUGFIX: Prevent JS errors when widget area is loaded (note: doesn't actually fix it fully yet)

### DIFF
--- a/code/widgets/WidgetAreaEditor.php
+++ b/code/widgets/WidgetAreaEditor.php
@@ -21,6 +21,8 @@ class WidgetAreaEditor extends FormField {
 	
 	function FieldHolder() {
 		Requirements::css(CMS_DIR . '/css/WidgetAreaEditor.css');
+		Requirements::javascript(THIRDPARTY_DIR . "/prototype/prototype.js");
+		Requirements::javascript(THIRDPARTY_DIR . '/behaviour/behaviour.js');
 		Requirements::javascript(CMS_DIR . '/javascript/WidgetAreaEditor.js');
 
 		return $this->renderWith("WidgetAreaEditor");


### PR DESCRIPTION
This was part of getting blog module working in an alpha state.   This, at least, prevents the bugs in widget from being so severe that they prevent the loading of the CMS. ;-)
