### PR TITLE
ENHANCEMENT Indicate which file extensions are allowed to be uploaded

### DIFF
--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -72,12 +72,22 @@ class CMSFileAddController extends LeftAndMain {
 			$uploadField->setFolderName(ASSETS_DIR);
 		}
 
+		$exts = $uploadField->getValidator()->getAllowedExtensions();
+		asort($exts);
+
 		$form = new Form(
 			$this,
 			'getEditForm',
 			new FieldList(
 				$uploadField,
-				new LiteralField('AllowedExtensions', sprintf('<p>Allowed extensions: %s</p>', implode('</em>, <em>', $uploadField->getValidator()->getAllowedExtensions()))),
+				new LiteralField(
+					'AllowedExtensions',
+					sprintf(
+						'<p>%s: %s</p>',
+						_t('AssetAdmin.ALLOWEDEXTS', 'Allowed extensions'),
+						implode('<em>, </em>', $exts)
+					)
+				),
 				new HiddenField('ID')
 			),
 			new FieldList()


### PR DESCRIPTION
When uploading a file to a folder, show which file extensions are permitted to be uploaded through `UploadField->getValidator()->getAllowedExtensions()`

This is for http://open.silverstripe.org/ticket/6905
