### PR TITLE
Fixes to method arguments in cms classes for E_STRICT support

### DIFF
--- a/code/controllers/CMSSettingsController.php
+++ b/code/controllers/CMSSettingsController.php
@@ -9,7 +9,7 @@ class CMSSettingsController extends CMSMain {
 		/**
 	 * @return Form
 	 */
-	function getEditForm($id = null) {
+	function getEditForm($id = null, $fields = null) {
 		$siteConfig = SiteConfig::current_site_config();
 		$fields = $siteConfig->getCMSFields();
 
@@ -54,7 +54,7 @@ class CMSSettingsController extends CMSMain {
 		return false;
 	}
 
-	function Breadcrumbs() {
+	function Breadcrumbs($unlinked = false) {
 		return new ArrayList(array(
 			new ArrayData(array(
 				'Title' => $this->SectionTitle(),

--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -133,7 +133,7 @@ class ContentController extends Controller {
 	 *
 	 * @return SS_HTTPResponse
 	 */
-	public function handleRequest(SS_HTTPRequest $request, DataModel $model) {
+	public function handleRequest(SS_HTTPRequest $request, DataModel $model = null) {
 		$child  = null;
 		$action = $request->param('Action');
 		$this->setModel($model);

--- a/code/controllers/RootURLController.php
+++ b/code/controllers/RootURLController.php
@@ -101,7 +101,7 @@ class RootURLController extends Controller {
 	 * @param SS_HTTPRequest $request
 	 * @return SS_HTTPResponse
 	 */
-	public function handleRequest(SS_HTTPRequest $request, DataModel $model) {
+	public function handleRequest(SS_HTTPRequest $request, DataModel $model = null) {
 		self::$is_at_root = true;
 		$this->setModel($model);
 		

--- a/code/controllers/SilverStripeNavigator.php
+++ b/code/controllers/SilverStripeNavigator.php
@@ -193,7 +193,7 @@ class SilverStripeNavigatorItem_CMSLink extends SilverStripeNavigatorItem {
 		return (Controller::curr() instanceof CMSMain);
 	}
 	
-	function canView() {
+	function canView($member = null) {
 		// Don't show in CMS
 		return !(Controller::curr() instanceof CMSMain);
 	}
@@ -223,7 +223,7 @@ class SilverStripeNavigatorItem_StageLink extends SilverStripeNavigatorItem {
 		return Controller::join_links($this->record->AbsoluteLink(), '?stage=Stage');
 	}
 	
-	function canView() {
+	function canView($member = null) {
 		return ($this->record->hasExtension('Versioned') && $this->getDraftPage());
 	}
 	
@@ -267,7 +267,7 @@ class SilverStripeNavigatorItem_LiveLink extends SilverStripeNavigatorItem {
 		return Controller::join_links($this->record->AbsoluteLink(), '?stage=Live');
 	}
 	
-	function canView() {
+	function canView($member = null) {
 		return ($this->record->hasExtension('Versioned') && $this->getLivePage());
 	}
 	
@@ -309,7 +309,7 @@ class SilverStripeNavigatorItem_ArchiveLink extends SilverStripeNavigatorItem {
 		return $this->record->AbsoluteLink() . '?archiveDate=' . $date;
 	}
 	
-	function canView() {
+	function canView($member = null) {
 		return ($this->record->hasExtension('Versioned') && $this->isArchived());
 	}
 	

--- a/code/model/ErrorPage.php
+++ b/code/model/ErrorPage.php
@@ -127,8 +127,8 @@ class ErrorPage extends Page {
 		}
 	}
 
-	function getCMSFields() {
-		$fields = parent::getCMSFields();
+	function getCMSFields($params = null) {
+		$fields = parent::getCMSFields($params);
 		
 		$fields->addFieldToTab(
 			"Root.Main", 

--- a/code/model/RedirectorPage.php
+++ b/code/model/RedirectorPage.php
@@ -115,7 +115,7 @@ class RedirectorPage extends Page {
 		}
 	}
 
-	function getCMSFields() {
+	function getCMSFields($params = null) {
 		Requirements::javascript(SAPPHIRE_DIR . "/javascript/RedirectorPage.js");
 		
 		$fields = parent::getCMSFields();

--- a/code/model/SiteConfig.php
+++ b/code/model/SiteConfig.php
@@ -41,7 +41,7 @@ class SiteConfig extends DataObject implements PermissionProvider {
 	 *
 	 * @return FieldList
 	 */
-	function getCMSFields() {
+	function getCMSFields($params = null) {
 		Requirements::javascript(CMS_DIR . "/javascript/SitetreeAccess.js");
 
 		$groupsMap = DataList::create('Group')->map('ID', 'Breadcrumbs')->toArray();

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1013,9 +1013,6 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	static function prepopulate_permission_cache($permission = 'CanEditType', $ids, $batchCallback = null) {
 		if(!$batchCallback) $batchCallback = "SiteTree::can_{$permission}_multiple";
 		
-		//PHP 5.1 requires an array rather than a string for the call_user_func function
-		$batchCallback=explode('::', $batchCallback);
-		
 		if(is_callable($batchCallback)) {
 			call_user_func($batchCallback, $ids, Member::currentUserID(), false);
 		} else {
@@ -1754,7 +1751,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 *
 	 * @return FieldList The fields to be displayed in the CMS.
 	 */
-	function getCMSFields() {
+	function getCMSFields($params = null) {
 		require_once("forms/Form.php");
 		// Status / message
 		// Create a status message for multiple parents

--- a/code/model/SiteTreeFileExtension.php
+++ b/code/model/SiteTreeFileExtension.php
@@ -5,7 +5,7 @@
  */
 class SiteTreeFileExtension extends DataExtension {
 	
-	function extraStatics() {
+	function extraStatics($class = null, $extension = null) {
 		return array(
 			'belongs_many_many' => array(
 				"BackLinkTracking" => "SiteTree",

--- a/code/model/SiteTreeFolderExtension.php
+++ b/code/model/SiteTreeFolderExtension.php
@@ -1,13 +1,6 @@
 <?php
 class SiteTreeFolderExtension extends DataExtension {
-	
-	function updateCMSFields(&$fields) {
-		// TODO commenting out unused files tab till bugs are fixed
-		// $fields->push(new Tab("UnusedFiles", _t('Folder.UNUSEDFILESTAB', "Unused files"),
-		// 	new Folder_UnusedAssetsField($this)
-		// ));
-	}
-	
+
 	/**
      * Looks for files used in system and create where clause which contains all ID's of files.
      * 

--- a/code/reports/Report.php
+++ b/code/reports/Report.php
@@ -378,11 +378,11 @@ class SS_Report_FakeQuery extends SQLQuery {
 		$this->sortColMethod = $sortColMethod;
 	}
 
-	function limit($limit) {
+	function limit($limit, $offset = 0) {
 		$this->limit = $limit;
 	}
 	
-	function unlimitedRowCount() {
+	function unlimitedRowCount($column = null) {
 		$source = $this->obj->{$this->method}($this->params, null, null);
 		return $source ? $source->Count() : 0;
 	}
@@ -511,8 +511,8 @@ abstract class SS_ReportWrapper extends SS_Report {
 		return $this->baseReport->description();
 	}
 
-	function canView() {
-		return $this->baseReport->canView();
+	function canView($member = null) {
+		return $this->baseReport->canView($member);
 	}
 	
 }

--- a/code/widgets/Widget.php
+++ b/code/widgets/Widget.php
@@ -34,7 +34,7 @@ class Widget extends DataObject {
 	static $cmsTitle = "Name of this widget";
 	static $description = "Description of what this widget does.";
 	
-	function getCMSFields() {
+	function getCMSFields($params = null) {
 		$fields = new FieldList();
 		$this->extend('updateCMSFields', $fields);
 		return $fields;
@@ -226,7 +226,7 @@ class Widget_Controller extends Controller {
  * @subpackage widgets
  */
 class Widget_TreeDropdownField extends TreeDropdownField {
-	function FieldHolder() {}
-	function Field() {}
+	function FieldHolder($properties = array()) {}
+	function Field($properties = array()) {}
 }
 

--- a/tests/model/SiteTreeBacklinksTest.php
+++ b/tests/model/SiteTreeBacklinksTest.php
@@ -243,7 +243,7 @@ class SiteTreeBacklinksTest extends SapphireTest {
 }
 
 class SiteTreeBacklinksTest_DOD extends DataExtension implements TestOnly {
-	function extraStatics() {
+	function extraStatics($class = null, $extension = null) {
 		return array(
 			'db' => array(
 				'ExtraContent' => 'HTMLText',
@@ -251,7 +251,7 @@ class SiteTreeBacklinksTest_DOD extends DataExtension implements TestOnly {
 		);
 	}
 	
-	function updateCMSFields(&$fields) {
+	function updateCMSFields(FieldList $fields) {
 		$fields->addFieldToTab("Root.Content", new HTMLEditorField("ExtraContent"));
 	}
 }

--- a/tests/model/VirtualPageTest.php
+++ b/tests/model/VirtualPageTest.php
@@ -607,7 +607,7 @@ class VirtualPageTest_VirtualPageSub extends VirtualPage implements TestOnly {
 }
 
 class VirtualPageTest_PageExtension extends DataExtension implements TestOnly {
-	function extraStatics() {
+	function extraStatics($class = null, $extension = null) {
 		return array(
 			'db' => array(
 				// These fields are just on an extension to simulate shared properties between Page and VirtualPage.

--- a/tests/widgets/WidgetAreaEditorTest.php
+++ b/tests/widgets/WidgetAreaEditorTest.php
@@ -460,7 +460,7 @@ class WidgetAreaEditorTest_TestWidget extends Widget implements TestOnly {
 	static $db = array(
 		'Title' => 'Varchar'
 	);
-	public function getCMSFields() {
+	public function getCMSFields($params = null) {
 		$fields = new FieldList();
 		$fields->push(new TextField('Title'));
 		return $fields;


### PR DESCRIPTION
Fixing CMS classes to match argument signatures of the parent. This goes along with core fixes in silverstripe/silverstripe-cms/#273, silverstripe/silverstripe-cms/#275. See those pull requests for more information.
