### PR TITLE
BUGFIX Removed double check of find_old_page() in ModelAsController

### DIFF
--- a/code/controllers/ModelAsController.php
+++ b/code/controllers/ModelAsController.php
@@ -104,7 +104,7 @@ class ModelAsController extends Controller implements NestedController {
 			// If a root page has been renamed, redirect to the new location.
 			// See ContentController->handleRequest() for similiar logic.
 			$redirect = self::find_old_page($URLSegment);
-			if($redirect = self::find_old_page($URLSegment)) {
+			if($redirect) {
 				$params = $request->getVars();
 				if(isset($params['url'])) unset($params['url']);
 				$this->response = new SS_HTTPResponse();


### PR DESCRIPTION
Remove double up of self::find_old_page() call in ModelAsController. As far as I can tell, it's not required to call it twice and has a slight performance penalty.
