### PR TITLE
BUGFIX Adding RedirectorPage.js to cms module (was in sapphire) and swapping out old behaviour.js usage

### DIFF
--- a/code/model/RedirectorPage.php
+++ b/code/model/RedirectorPage.php
@@ -118,7 +118,7 @@ class RedirectorPage extends Page {
 	}
 
 	function getCMSFields($params = null) {
-		Requirements::javascript(SAPPHIRE_DIR . "/javascript/RedirectorPage.js");
+		Requirements::javascript(CMS_DIR . '/javascript/RedirectorPage.js');
 		
 		$fields = parent::getCMSFields();
 		$fields->removeByName('Content', true);

--- a/javascript/RedirectorPage.js
+++ b/javascript/RedirectorPage.js
@@ -1,0 +1,24 @@
+(function($) {
+	$.entwine('ss', function($){
+		$('#Form_EditForm_RedirectionType input').entwine({
+			onmatch: function() {
+				var self = $(this);
+				if(self.attr('checked')) this.toggle();
+				this._super();
+			},
+			onclick: function() {
+				this.toggle();
+			},
+			toggle: function() {
+				if($(this).attr('value') == 'Internal') {
+					$('#ExternalURL').hide();
+					$('#LinkToID').show();
+				} else {
+					$('#ExternalURL').show();
+					$('#LinkToID').hide();
+				}
+			}
+		});
+	});
+})(jQuery);
+


### PR DESCRIPTION
Removed the RedirectorPage.js file from sapphire, and put it in cms with the RedirectorPage.php.

Removed the usage of behaviour.js here, now using entwine jQuery.

Please also merge the other pull request over at the sapphire module, which removes the RedirectorPage.js file from sapphire. https://github.com/silverstripe/sapphire/pull/295

Fixes this ticket: http://open.silverstripe.org/ticket/7119
