### PR TITLE
Trac 7280: remove a 'Go' button with '-->' seen in the pages listview

### DIFF
--- a/templates/Includes/CMSMain_ListView.ss
+++ b/templates/Includes/CMSMain_ListView.ss
@@ -1,7 +1,5 @@
 <div class="cms-content-toolbar">
-	<!--
-	<% include CMSPagesController_ContentToolActions %>
-	-->
+	<%--<% include CMSPagesController_ContentToolActions %>--%>
 </div>
 
 <div class="ss-dialog cms-page-add-form-dialog cms-dialog-content" id="cms-page-add-form" title="<% _t('CMSMain.AddNew', 'Add new page') %>">

--- a/templates/SSReportTableField_printable.ss
+++ b/templates/SSReportTableField_printable.ss
@@ -6,7 +6,7 @@
 <title>Print</title>
 </head>
 
-<!-- <body onload="window.print();"> -->
+<%-- <body onload="window.print();"> --%>
 <body>
 	<% control Form.Controller %>
 		<h1 style="margin-bottom: 0">$CurrentReport.Title</h1>


### PR DESCRIPTION
If a block html code need to be commented out but not removed, use <%-- --%> rather than <!-- -->, especially this block contains a form or other $variables, that potentially resulted nested HTML Comment Tag such as this <!-- some code 1 <!-- some code 2 --> some code 3 -->, then 'some code 3' will be still executed and could mess up the whole lay out by unmateched html tags. the last '-->' just maintained in the final html.
