### PR TITLE
Trac 7164: TreeDropdownField doesn't show page icons 

### DIFF
--- a/code/controllers/CMSPageAddController.php
+++ b/code/controllers/CMSPageAddController.php
@@ -51,7 +51,9 @@ class CMSPageAddController extends CMSPageEditController {
 					"child//$childTitle" => $parentField = new TreeDropdownField(
 						"ParentID", 
 						"",
-						'SiteTree'
+						'SiteTree',
+						'ID',
+						'TreeTitle'
 					)
 				)
 			),


### PR DESCRIPTION
Add page icons to the tree node in TreeDropdownField in page add form.
