### PR TITLE
BUGFIX: Correct formatting of CMS installer messages

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -164,7 +164,7 @@ en:
     PUBLISHEDSITE: 'Published Site'
     Password: Password
     PostInstallTutorialIntro: 'This website is a simplistic version of a SilverStripe 2 site. To extend this, please take a look at {link}.'
-    StartEditing: 'You can start editing your site\''s content by opening <a href="{link}">the CMS</a>.'
+    StartEditing: 'You can start editing your site’s content by opening <a href="{link}">the CMS</a>.'
     UnableDeleteInstall: 'Unable to delete installation files. Please delete the files below manually'
     VIEWPAGEIN: 'View Page in:'
   ErrorPage:

--- a/templates/Includes/Install_deleteinstallfiles.ss
+++ b/templates/Includes/Install_deleteinstallfiles.ss
@@ -13,7 +13,7 @@
 		<%t ContentController.InstallFilesDeleted "Installation files have been successfully deleted." %>
 	</p>
 	<p style="margin: 1em 0">
-		<%t ContentController.StartEditing 'You can start editing your site\'s content by opening <a href="{link}">the CMS</a>.' link="admin/" %>. 
+		<%t ContentController.StartEditing 'You can start editing your site’s content by opening <a href="{link}">the CMS</a>.' link="admin/" %>
 		<br />
 		&nbsp; &nbsp; <%t ContentController.Email "Email" %>: $Username<br />
 		&nbsp; &nbsp; <%t ContentController.Password "Password" %>: $Password<br />

--- a/templates/Includes/Install_successfullyinstalled.ss
+++ b/templates/Includes/Install_successfullyinstalled.ss
@@ -7,7 +7,7 @@
 <% end_if %>
 
 <p>
-	<%t ContentController.StartEditing 'You can start editing your site\'s content by opening <a href="{link}">the CMS</a>.' link="admin/" %> 
+	<%t ContentController.StartEditing 'You can start editing your site’s content by opening <a href="{link}">the CMS</a>.' link="admin/" %> 
 	<br />
 	&nbsp; &nbsp; <%t ContentController.Email "Email" %>: $Username<br />
 	&nbsp; &nbsp; <%t ContentController.Password "Password" %>: $Password<br />


### PR DESCRIPTION
Removed extraneous backslash and period in the messages that say "You can start editing your site’s content by opening the CMS."
