### PR TITLE
BUGFIX: remove unnecessary class that breaks the tab opening.

### DIFF
--- a/templates/Includes/CMSSettingsController_Content.ss
+++ b/templates/Includes/CMSSettingsController_Content.ss
@@ -11,7 +11,7 @@
 				</h2>
 				<% if Fields.hasTabset %>
 					<% with Fields.fieldByName('Root') %>
-					<div class="cms-tabset cms-content-header-tabs ss-ui-tabs-nav">
+					<div class="cms-content-header-tabs">
 						<ul>
 						<% loop Tabs %>
 							<li<% if extraClass %> class="$extraClass"<% end_if %>><a href="#$id">$Title</a></li>


### PR DESCRIPTION
This class should be applied higher in the hierarchy so it also
includes panels - and it's already there too.
