### PR TITLE
FIX: SiteTree MenuTitle not updating properly

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2438,7 +2438,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @param string $value
 	 */
 	function setMenuTitle($value) {
-		if($value == $this->getField("Title")) {
+		if($value == $this->getField("Title") && $value == $this->getField("MenuTitle")) {
 			$this->setField("MenuTitle", null);
 		} else {
 			$this->setField("MenuTitle", $value);


### PR DESCRIPTION
If MenuTitle is changed back to the same as Title it is now updated properly.
