### PR TITLE
BUGFIX: Add batch handler status messages (fixes #7427)

### DIFF
--- a/code/batchactions/CMSBatchActions.php
+++ b/code/batchactions/CMSBatchActions.php
@@ -78,7 +78,7 @@ class CMSBatchAction_Delete extends CMSBatchAction {
 
 		}
 
-		return Convert::raw2json($status);
+		return $this->response(_t('CMSBatchActions.DELETED_DRAFT_PAGES', 'Deleted %d pages from draft site, %d failures'), $status);
 	}
 
 	function applicablePages($ids) {
@@ -123,7 +123,7 @@ class CMSBatchAction_DeleteFromLive extends CMSBatchAction {
 
 		}
 
-		return Convert::raw2json($status);
+		return $this->response(_t('CMSBatchActions.DELETED_PAGES', 'Deleted %d pages from published site, %d failures'), $status);
 	}
 
 	function applicablePages($ids) {


### PR DESCRIPTION
7427 was mostly fixed by Ingos previous patch. But two batch actions, delete from draft site and delete from published site werent returning status messages. 

Abstracted out the status preperation code that the batch actions that were returning status messages were using, and used that to add status messages to the problem two.

(Paired with pull request to Framework - https://github.com/silverstripe/sapphire/pull/563)
