### PR TITLE
BUG Check for the parameter existence.

### DIFF
--- a/code/search/SearchForm.php
+++ b/code/search/SearchForm.php
@@ -172,7 +172,8 @@ class SearchForm extends Form {
 		// legacy usage: $data was defaulting to $_REQUEST, parameter not passed in doc.silverstripe.org tutorials
 		if(!isset($data)) $data = $_REQUEST;
 		
-		return Convert::raw2xml($data['Search']);
+		// The form could be rendered without the search being done, so check for that.
+		if (isset($data['Search'])) return Convert::raw2xml($data['Search']);
 	}
 	
 	/**


### PR DESCRIPTION
The specific situation is if the SearchForm.ss is overriden, and the
$SearchQuery parameter is used in the template. This will throw a Notice
in case the form is rendered without searching.
