### PR TITLE
fixed adding siteconfig translations

### DIFF
--- a/code/model/SiteConfig.php
+++ b/code/model/SiteConfig.php
@@ -203,8 +203,6 @@ class SiteConfig extends DataObject implements PermissionProvider {
 			
 			if($defaultConfig){					
 				return $defaultConfig->createTranslation($locale);
-				$siteConfig->Title = $defaultConfig->Title;
-				$siteConfig->Tagline = $defaultConfig->Tagline;
 			}			
 			
 			// TODO Copy view/edit group settings


### PR DESCRIPTION
translations were not added in the same translation group, and the
translation module didn't work. Also commited changes in the translation
module, which will need this commit.
