### PR TITLE
make sure button text does not wrap

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -10,6 +10,7 @@
 .CMSPageHistoryController ins { background-color: #DFD; padding: 2px; text-decoration: none; }
 .CMSPageHistoryController del { background-color: #FDD; padding: 2px; color: #ff4444; }
 
+.cms .ui-button-text { white-space: nowrap; }
 /** -------------------------------------------- Tree View (collapsed for sidebar) -------------------------------------------- */
 #cms-content-treeview .cms-tree-expand-trigger { display: none; }
 


### PR DESCRIPTION
the text on cms buttons tends to wrap, causing some buttons
to be double the height than others ... 
this does look rather odd in the admin ui ... 

observed on chrome in ubuntu 12.04
