### PR TITLE
FIXED: Compatibility issues with the Translatable module

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -202,8 +202,12 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		return $link;
 	}
 
-	function LinkPageAdd() {
-		return singleton("CMSPageAddController")->Link();
+	function LinkPageAdd($extraArguments = null) {
+		$link = singleton("CMSPageAddController")->Link();
+		$this->extend('updateLinkPageAdd', $link);
+		if($extraArguments)
+			$link = Controller::join_links ($link, $extraArguments);
+		return $link;
 	}
 	
 	/**

--- a/templates/Includes/CMSMain_TreeView.ss
+++ b/templates/Includes/CMSMain_TreeView.ss
@@ -22,7 +22,7 @@ $ExtraTreeTools
 	</div>
 	<% end_if %>
 
-	<div class="cms-tree" data-url-tree="$Link(getsubtree)" data-url-savetreenode="$Link(savetreenode)" data-url-updatetreenodes="$Link(updatetreenodes)" data-url-addpage="{$LinkPageAdd}AddForm/?action_doAdd=1&amp;ParentID=%s&amp;PageType=%s&amp;SecurityID=$SecurityID" data-url-editpage="$LinkPageEdit('%s')" data-hints="$SiteTreeHints">
+	<div class="cms-tree" data-url-tree="$Link(getsubtree)" data-url-savetreenode="$Link(savetreenode)" data-url-updatetreenodes="$Link(updatetreenodes)" data-url-addpage="{$LinkPageAdd('AddForm/?action_doAdd=1')}&amp;ParentID=%s&amp;PageType=%s&amp;SecurityID=$SecurityID" data-url-editpage="$LinkPageEdit('%s')" data-hints="$SiteTreeHints">
 		$SiteTreeAsUL
 	</div>
 </div>

--- a/templates/Includes/CMSPagesController_ContentToolActions.ss
+++ b/templates/Includes/CMSPagesController_ContentToolActions.ss
@@ -1,5 +1,5 @@
 <div class="cms-actions-row">
-	<a class="cms-page-add-button ss-ui-button ss-ui-action-constructive" data-icon="add" href="$LinkPageAdd" data-url-addpage="{$LinkPageAdd}?ParentID=%s"><% _t('CMSMain.AddNewButton', 'Add new') %></a>
+	<a class="cms-page-add-button ss-ui-button ss-ui-action-constructive" data-icon="add" href="$LinkPageAdd" data-url-addpage="{$LinkPageAdd('?ParentID=%s')}"><% _t('CMSMain.AddNewButton', 'Add new') %></a>
 </div>
 
 <div class="cms-content-batchactions">


### PR DESCRIPTION
FIXED: Issue where links within the CMS page list view would not be correctly generated.

E.g. when the Translatable module is used, page links for the "show children" action would come up as admin/pages/?locale=en_NZ?ParentID=21&view=list when they should be shown as admin/pages/?locale=en_NZ&ParentID=21&view=list.

This would not normally become apparent when using the CMS without certain modules, but the issue lies is the fragile concatentaion of urls.

This fix uses Controller::join_links to perform the necessary sanity check on urls and querystring arguments.
