### PR TITLE
asset admin uploading into root folder

### DIFF
--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -68,8 +68,6 @@ class CMSFileAddController extends LeftAndMain {
 			// The Upload class expects a folder relative *within* assets/
 			$path = preg_replace('/^' . ASSETS_DIR . '\//', '', $folder->getFilename());
 			$uploadField->setFolderName($path);
-		} else {
-			$uploadField->setFolderName(ASSETS_DIR);
 		}
 
 		$exts = $uploadField->getValidator()->getAllowedExtensions();


### PR DESCRIPTION
Files uploaded into the root of asset admin should be uploaded into the default uploads folder, as defined on Upload::$uploads_folder. Currently, files are being uploaded to /assets/assets

http://open.silverstripe.org/ticket/7773
