### PR TITLE
FIX Dont refer to framework module in config rules

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,6 +1,7 @@
 ---
 Name: modelascontrollerroutes
-After: framework/routes#rootroutes
+Before: '*'
+After: '#rootroutes'
 ---
 Director:
   rules:
@@ -8,7 +9,7 @@ Director:
     '$URLSegment//$Action/$ID/$OtherID': 'ModelAsController'
 ---
 Name: legacycmsroutes
-After: framework/routes#adminroutes
+After: '#adminroutes'
 ---
 Director:
   rules:


### PR DESCRIPTION
Might be called sapphire instead, in which case routing rules
will end up in the wrong place

Needs https://github.com/silverstripe/sapphire/pull/743 in sapphire first
