### PR TITLE
FIX 7819

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -95,7 +95,7 @@ JS
 		// Don't filter list when a detail view is requested,
 		// to avoid edge cases where the filtered list wouldn't contain the requested
 		// record due to faulty session state (current folder not always encoded in URL, see #7408).
-		if($this->request->param('ID') == 'field') {
+		if(!$folder->ID && ($this->request->param('ID') == 'field')) {
 			return $list;
 		}
 


### PR DESCRIPTION
When doing a search or a sort on the assets table, the results are for the entire assets, even if the user drilled down into a specific folder. Check if the current folder ID is in the url before assuming the list should not filter by folder ID
