### PR TITLE
BUG Session namespace sharing for CMS controllers (#7815)

### DIFF
--- a/code/controllers/CMSPageEditController.php
+++ b/code/controllers/CMSPageEditController.php
@@ -9,4 +9,6 @@ class CMSPageEditController extends CMSMain {
 	static $url_rule = '/$Action/$ID/$OtherID';
 	static $url_priority = 41;
 	static $required_permission_codes = 'CMS_ACCESS_CMSMain';
+	static $session_namespace = 'CMSMain';
+
 }

--- a/code/controllers/CMSPageHistoryController.php
+++ b/code/controllers/CMSPageHistoryController.php
@@ -11,6 +11,7 @@ class CMSPageHistoryController extends CMSMain {
 	static $url_priority = 42;
 	static $menu_title = 'History';
 	static $required_permission_codes = 'CMS_ACCESS_CMSMain';
+	static $session_namespace = 'CMSMain';
 	
 	static $allowed_actions = array(
 		'VersionsForm',

--- a/code/controllers/CMSPageSettingsController.php
+++ b/code/controllers/CMSPageSettingsController.php
@@ -9,6 +9,7 @@ class CMSPageSettingsController extends CMSMain {
 	static $url_rule = '/$Action/$ID/$OtherID';
 	static $url_priority = 42;
 	static $required_permission_codes = 'CMS_ACCESS_CMSMain';
+	static $session_namespace = 'CMSMain';
 		
 	function getEditForm($id = null, $fields = null) {
 		$record = $this->getRecord($id ? $id : $this->currentPageID());

--- a/code/controllers/CMSPagesController.php
+++ b/code/controllers/CMSPagesController.php
@@ -10,6 +10,7 @@ class CMSPagesController extends CMSMain {
 	static $url_priority = 40;
 	static $menu_title = 'Pages';	
 	static $required_permission_codes = 'CMS_ACCESS_CMSMain';
+	static $session_namespace = 'CMSMain';
 
 	function LinkPreview() {
 		return false;
@@ -20,14 +21,6 @@ class CMSPagesController extends CMSMain {
 	 */
 	public function ViewState() {
 		return $this->request->getVar('view');
-	}
-
-	/**
-	 * Doesn't deal with a single record, and we need
-	 * to avoid session state from previous record edits leaking in here.
-	 */
-	public function currentPageID() {
-		return false;
 	}
 
 	public function isCurrentPage(DataObject $record) {


### PR DESCRIPTION
Relies on https://github.com/silverstripe/sapphire/pull/752

Ideally we could do this without session, but pragmatically
we still need it, because of the inflexible routing system,
and because of performance considerations.

Example: The tree is lazy loaded via a generic  URL (admin/pages/treeview).
While we could add ?ID=<currentpage> to make the view (more or less) stateless,
it would trigger a full tree reload on every tree navigation action.
Instead, we assume that all "reachable" nodes are already cached,
and simply mark a different one as current. 

For this to work, we need shared session state between CMS controllers,
because the current record is set in CMSPageEditController (admin/pages/edit/show/<ID>),
but the tree is rendered through CMSPagesController (admin/pages/treeview)

See http://open.silverstripe.org/ticket/7815 for detail.
