### PR TITLE
BUG Filter pages by LastEdited always returns an empty list

### DIFF
--- a/code/controllers/CMSSiteTreeFilter.php
+++ b/code/controllers/CMSSiteTreeFilter.php
@@ -194,11 +194,13 @@ class CMSSiteTreeFilter_Search extends CMSSiteTreeFilter {
 					break;
 
 				case 'LastEditedFrom':
-					$query->where("\"LastEdited\" >= '$SQL_val'");
+					$fromDate = new DateField(null, null, $SQL_val);
+					$query->where("\"LastEdited\" >= '{$fromDate->dataValue()}'");
 					break;
 
 				case 'LastEditedTo':
-					$query->where("\"LastEdited\" <= '$SQL_val'");
+					$toDate = new DateField(null, null, $SQL_val);
+					$query->where("\"LastEdited\" <= '{$toDate->dataValue()}'");
 					break;
 
 				case 'ClassName':


### PR DESCRIPTION
This is caused by the input date values entered by the user are passed into query without converting in a correct format first.

Please do not test this change with default date format in English (United States). Refer https://github.com/silverstripe/sapphire/pull/758
