### PR TITLE
NEW 7839 Support for documents as a file type in Files and images

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -336,6 +336,7 @@ JS
 			'mov' => _t('AssetAdmin.AppCategoryVideo', 'Video'),
 			'flash' => _t('AssetAdmin.AppCategoryFlash', 'Flash', 'The fileformat'),
 			'zip' => _t('AssetAdmin.AppCategoryArchive', 'Archive', 'A collection of files'),
+			'doc' => _t('AssetAdmin.AppCategoryDocument', 'Document')
 		);
 		$context->addField(
 			$typeDropdown = new DropdownField(

--- a/lang/en_GB.yml
+++ b/lang/en_GB.yml
@@ -8,6 +8,7 @@ en_GB:
     AppCategoryFlash: Flash
     AppCategoryImage: Image
     AppCategoryVideo: Video
+    AppCategoryDocument: Document
     BackToFolder: 'Back to folder'
     CREATED: Date
     CurrentFolderOnly: 'Limit to current folder?'

--- a/lang/fr.yml
+++ b/lang/fr.yml
@@ -8,6 +8,7 @@ fr:
     AppCategoryFlash: Flash
     AppCategoryImage: Image
     AppCategoryVideo: Vidéo
+    AppCategoryDocument: Document
     BackToFolder: 'Revenir au dossier'
     CREATED: Date
     CurrentFolderOnly: 'Limiter au dossier actuel ?'


### PR DESCRIPTION
Can we get a 'Document' file type in the search file type, that would return files like word docs, and such? 
See also https://github.com/silverstripe/sapphire/pull/769
