### PR TITLE
FIX 7856 

### DIFF
--- a/javascript/CMSMain.AddForm.js
+++ b/javascript/CMSMain.AddForm.js
@@ -55,6 +55,10 @@
 				}
 				selectedEl.setSelected(true);
 				selectedEl.siblings().setSelected(false);
+
+				// Disable the "Create" button if none of the pagetypes are available
+				var buttonState = (this.find('#PageType li:not(.disabled)').length) ? 'enable' : 'disable';
+				this.find('button[name=action_doAdd]').button(buttonState);
 			}
 		});
 		


### PR DESCRIPTION
Show the Create button as disabled if no pagetypes are available for page creation. This doesn't stop the button from firing events though, which is surprising. Another pull request to stop the button from firing events will also be logged in the sapphire project
