### PR TITLE
Solves Bug in SiteTree::isCurrent()

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -492,6 +492,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return bool
 	 */
 	public function isCurrent() {
+		if($this->class != Director::get_current_page()->class) return false;
 		return $this->ID ? $this->ID == Director::get_current_page()->ID : $this === Director::get_current_page();
 	}
 	


### PR DESCRIPTION
If you have a own controller for a part of a page, it's not enough to
compare just the ID of the current Object with `Direcetor::get_current_page()->ID` as this condition can be true for multiple Objects of different classes.

I added a simple test to see if also the class matches which solves the problem in my situation.

This is not a very solid solution i think, but in my case this just works fine. 
