### PR TITLE
Fixing issue #7902. Users with limited rights can't access "Settings" in the CMS

### DIFF
--- a/code/controllers/CMSSettingsController.php
+++ b/code/controllers/CMSSettingsController.php
@@ -6,7 +6,8 @@ class CMSSettingsController extends LeftAndMain {
 	static $menu_priority = -1;
 	static $menu_title = 'Settings';
 	static $tree_class = 'SiteConfig';
-
+	static $required_permission_codes = array('EDIT_SITECONFIG');
+	
 	public function getResponseNegotiator() {
 		$neg = parent::getResponseNegotiator();
 		$controller = $this;


### PR DESCRIPTION
See: http://open.silverstripe.org/ticket/7902

This fix sets the required permissions for `CMSSettingsController` to `EDIT_SITECONFIG` which is the proper permission to use.
