### PR TITLE
FIX Use RequestHandler::httpError() for all HTTP errors.

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -205,11 +205,10 @@ class ContentController extends Controller {
 	 * @uses ErrorPage::response_for()
 	 */
 	public function httpError($code, $message = null) {
-		if($this->request->isMedia() || !$response = ErrorPage::response_for($code)) {
-			parent::httpError($code, $message);
-		} else {
-			throw new SS_HTTPResponse_Exception($response);
-		}
+		// Don't use the HTML response for media requests
+		$response = $this->request->isMedia() ? null : ErrorPage::response_for($code);
+		// Failover to $message if the HTML response is unavailable / inappropriate
+		parent::httpError($code, $response ? $response : $message);
 	}
 
 	/**

--- a/code/controllers/ModelAsController.php
+++ b/code/controllers/ModelAsController.php
@@ -126,11 +126,8 @@ class ModelAsController extends Controller implements NestedController {
 				return $this->response;
 			}
 			
-			if($response = ErrorPage::response_for(404)) {
-				return $response;
-			} else {
-				$this->httpError(404, 'The requested page could not be found.');
-			}
+			$response = ErrorPage::response_for(404);
+			$this->httpError(404, $response ? $response : 'The requested page could not be found.');
 		}
 		
 		// Enforce current locale setting to the loaded SiteTree object


### PR DESCRIPTION
https://github.com/silverstripe/sapphire/pull/827 adds some extension points for catching HTTP errors such as 404.  This change fixes some issues where httpError() isn't used all the time.  Note that the aforementioned pull request will be necessary to ensure that it works properly.
