### PR TITLE
BUG: Add "add new" button to Pages list view (fixes 7649)

### DIFF
--- a/templates/Includes/CMSMain_ListView.ss
+++ b/templates/Includes/CMSMain_ListView.ss
@@ -1,5 +1,5 @@
 <div class="cms-content-toolbar">
-	<%--<% include CMSPagesController_ContentToolActions %>--%>
+	<% include CMSPagesController_ContentToolActions %>
 </div>
 
 <div class="ss-dialog cms-page-add-form-dialog cms-dialog-content" id="cms-page-add-form" title="<% _t('CMSMain.AddNew', 'Add new page') %>">

--- a/templates/Includes/CMSMain_TreeView.ss
+++ b/templates/Includes/CMSMain_TreeView.ss
@@ -1,4 +1,5 @@
 <div class="cms-content-toolbar">
+	<% include CMSPagesController_ContentToolActions %>
 	<% include CMSPagesController_ContentToolbar %>
 </div>
 

--- a/templates/Includes/CMSPagesController_ContentToolActions.ss
+++ b/templates/Includes/CMSPagesController_ContentToolActions.ss
@@ -2,6 +2,3 @@
 	<a class="cms-page-add-button ss-ui-button ss-ui-action-constructive" data-icon="add" href="$LinkPageAdd" data-url-addpage="{$LinkPageAdd}?ParentID=%s"><% _t('CMSMain.AddNewButton', 'Add new') %></a>
 </div>
 
-<div class="cms-content-batchactions">
-	$BatchActionsForm
-</div>

--- a/templates/Includes/CMSPagesController_ContentToolbar.ss
+++ b/templates/Includes/CMSPagesController_ContentToolbar.ss
@@ -1,3 +1,7 @@
+<div class="cms-content-batchactions">
+	$BatchActionsForm
+</div>
+
 <div class="cms-tree-view-modes">
 	<span><% _t("TreeTools.DisplayLabel","Display:") %></span>
 	<% if CanOrganiseSitetree %> 
@@ -11,4 +15,4 @@
 		<label for="view-mode-multiselect"><% _t("MULTISELECT","Multi-selection") %></label>
 	</div>
 </div>
-<% include CMSPagesController_ContentToolActions %>
+


### PR DESCRIPTION
Rearranged the templates around CMSPagesController_ContentToolbar and
uncommented the toolbar from the pages list view so the add new button
would be included with including actions that aren't applicable to the
gridfield.

Originally this pull request: https://github.com/silverstripe/silverstripe-cms/pull/173

Linked to css here: https://github.com/silverstripe/sapphire/pull/684/commits
