### PR TITLE
BUG: Filter in asset grid appears in incorrect place

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -140,8 +140,8 @@ JS
 		// File listing
 		$gridFieldConfig = GridFieldConfig::create()->addComponents(
 			new GridFieldToolbarHeader(),
-			new GridFieldFilterHeader(),
 			new GridFieldSortableHeader(),
+			new GridFieldFilterHeader(),			
 			new GridFieldDataColumns(),
 			new GridFieldPaginator(15),
 			new GridFieldEditButton(),


### PR DESCRIPTION
Moved the filter component in the asset gridfield to after the sortable header
