### PR TITLE
BUG Remove .ss-tabset class from CMS tabs to prevent rogue ajax load (#7...

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -285,7 +285,9 @@ JS
 		// TODO Can't merge $FormAttributes in template at the moment
 		$form->addExtraClass('cms-edit-form cms-panel-padded center ' . $this->BaseCSSClasses());
 		$form->setAttribute('data-pjax-fragment', 'CurrentForm');
-		$form->Fields()->findOrMakeTab('Root')->setTemplate('CMSTabSet');
+		
+		// Tab nav in CMS is rendered through separate template
+		$form->Fields()->findOrMakeTab('Root')->setTemplate('CMSTabSet')->removeExtraClass('ss-tabset');
 
 		$this->extend('updateEditForm', $form);
 

--- a/code/controllers/CMSSettingsController.php
+++ b/code/controllers/CMSSettingsController.php
@@ -30,7 +30,10 @@ class CMSSettingsController extends LeftAndMain {
 		$form->addExtraClass('cms-edit-form cms-panel-padded center');
 		// don't add data-pjax-fragment=CurrentForm, its added in the content template instead
 
-		if($form->Fields()->hasTabset()) $form->Fields()->findOrMakeTab('Root')->setTemplate('CMSTabSet');
+		// Tab nav in CMS is rendered through separate template
+		if($form->Fields()->hasTabset()) {
+			$form->Fields()->findOrMakeTab('Root')->setTemplate('CMSTabSet')->removeExtraClass('ss-tabset');
+		}
 		$form->setHTMLID('Form_EditForm');
 		$form->loadDataFrom($siteConfig);
 		$form->setTemplate($this->getTemplatesWithSuffix('_EditForm'));


### PR DESCRIPTION
...980)

he existence of .ss-tabset triggers JS which applies $.tabs(),
and in turn interprets the first available link as the tab navigation.
jQuery UI subsequently tries to ajax-load this link, which is not
desired. Instead, $.tabs() should _only_ be applied to a container
DOM element with .cms-tabset applied.

Relies on https://github.com/silverstripe/sapphire/pull/912
