### PR TITLE
BUGFIX Prevent unbounded recursion in admin/pages

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1132,7 +1132,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 					if($groupedByParent) {
 						$groupedByParent = array_diff_key($groupedByParent,$handledIds);
-						$actuallyInherited = self::batch_permission_check(array_keys($groupedByParent), $memberID, $typeField, $groupJoinTable, $siteConfigMethod);
+						$actuallyInherited = self::batch_permission_check(array_keys($groupedByParent), $memberID, $typeField, $groupJoinTable, $siteConfigMethod, 'CMS_ACCESS_CMSMain', true, $handledIds);
 						if($actuallyInherited) {
 							$parentIDs = array_keys(array_filter($actuallyInherited));
 							foreach($parentIDs as $parentID) {

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1044,9 +1044,10 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @param String $siteConfigMethod Method to call on {@link SiteConfig} for toplevel items, e.g. "canEdit"
 	 * @param String $globalPermission If the member doesn't have this permission code, don't bother iterating deeper.
 	 * @param Boolean $useCached
+	 * @param Array $handledIds
 	 * @return Array An map of {@link SiteTree} ID keys, to boolean values
 	 */
-	static public function batch_permission_check($ids, $memberID, $typeField, $groupJoinTable, $siteConfigMethod, $globalPermission = 'CMS_ACCESS_CMSMain', $useCached = true) {
+	static public function batch_permission_check($ids, $memberID, $typeField, $groupJoinTable, $siteConfigMethod, $globalPermission = 'CMS_ACCESS_CMSMain', $useCached = true, $handledIds = null) {
 		// Sanitise the IDs
 		$ids = array_filter($ids, 'is_numeric');
 		
@@ -1121,6 +1122,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 						if($item->ParentID) {
 							if(!isset($groupedByParent[$item->ParentID])) $groupedByParent[$item->ParentID] = array();
 							$groupedByParent[$item->ParentID][] = $item->ID;
+							$handledIds[$item->ID] = $item->ID;
 						} else {
 							// Might return different site config based on record context, e.g. when subsites module is used
 							$siteConfig = $item->getSiteConfig();
@@ -1129,6 +1131,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 					}
 
 					if($groupedByParent) {
+						$groupedByParent = array_diff_key($groupedByParent,$handledIds);
 						$actuallyInherited = self::batch_permission_check(array_keys($groupedByParent), $memberID, $typeField, $groupJoinTable, $siteConfigMethod);
 						if($actuallyInherited) {
 							$parentIDs = array_keys(array_filter($actuallyInherited));


### PR DESCRIPTION
One of our clients was editing their site tree in this way and caused us to discover and fix this bug, so we are sharing the love:
## To Reproduce:

WARNING: this bug results in unbounded recursion, so ensure you have sensible memory/stack limits
1. Enter the site tree, create and publish a page heirarchy with one the child of the other.
2. Change the staged versions of these pages such that the child page is now the parent page.
3. Attempt to view the cms page /admin/pages, this is where the bug results.
## Resolution

The branch to pull fixes the problem by ensuring that a list of handled IDs is kept, so generating the sitetree won't attempt to render an infinite heirarchy.
