### PR TITLE
BUG Consistently use FormResponse in CMS JavaScript (fixes #8036)

### DIFF
--- a/code/AssetAdmin.php
+++ b/code/AssetAdmin.php
@@ -654,7 +654,8 @@ JS;
 		
 		$script .= "statusMessage('$message');";
 
-		return $script;
+		FormResponse::add($script);
+		return FormResponse::respond();
 	}
 	
 	public function removefile($request){
@@ -671,10 +672,12 @@ JS;
 			$file->destroy();
 
 			if(Director::is_ajax()) {
-				echo <<<JS
+				$js = <<<JS
 				$('Form_EditForm_Files').removeFile($fileID);
 				statusMessage('removed file', 'good');
 JS;
+				FormResponse::add($js);
+				return FormResponse::respond();
 			} else {
 				Director::redirectBack();
 			}

--- a/code/CommentAdmin.php
+++ b/code/CommentAdmin.php
@@ -148,11 +148,14 @@ class CommentAdmin extends LeftAndMain {
 				user_error("No comments in $commentList could be found!", E_USER_ERROR);
 			}
 
-			echo <<<JS
+			$js = <<<JS
 				$deleteList
 				$('Form_EditForm').getPageFromServer($('Form_EditForm_ID').value);
 				statusMessage("Deleted $numComments comments.");
 JS;
+			
+			FormResponse::add($js);
+			return FormResponse::respond();
 	}
 
 	function deleteall() {
@@ -168,10 +171,13 @@ JS;
 		}
 
 		$msg = sprintf(_t('CommentAdmin.DELETED', 'Deleted %s comments.'), $numComments);
-		echo <<<JS
+		$js = <<<JS
 				$('Form_EditForm').getPageFromServer($('Form_EditForm_ID').value);
 				statusMessage("$msg");
 JS;
+		
+		FormResponse::add($js);
+		return FormResponse::respond();
 
 	}
 
@@ -207,11 +213,13 @@ JS;
 			}
 
 			$msg = sprintf(_t('CommentAdmin.MARKEDSPAM', 'Marked %s comments as spam.'), $numComments);
-			echo <<<JS
+			$js = <<<JS
 				$deleteList
 				$('Form_EditForm').getPageFromServer($('Form_EditForm_ID').value);
 				statusMessage("$msg");
 JS;
+			FormResponse::add($js);
+			return FormResponse::respond();
 	}
 
 	function hammarked() {
@@ -247,11 +255,13 @@ JS;
 			}
 
 			$msg = sprintf(_t('CommentAdmin.MARKEDNOTSPAM', 'Marked %s comments as not spam.'), $numComments);
-			echo <<<JS
+			$js = <<<JS
 				$deleteList
 				$('Form_EditForm').getPageFromServer($('Form_EditForm_ID').value);
 				statusMessage("$msg");
 JS;
+			FormResponse::add($js);
+			return FormResponse::respond();
 	}
 
 	function acceptmarked() {
@@ -274,11 +284,14 @@ JS;
 			}
 
 			$msg = sprintf(_t('CommentAdmin.APPROVED', 'Accepted %s comments.'), $numComments);
-			echo <<<JS
+			$js = <<<JS
 				$deleteList
 				$('Form_EditForm').getPageFromServer($('Form_EditForm_ID').value);
 				statusMessage("Accepted $numComments comments.");
 JS;
+			
+			FormResponse::add($js);
+			return FormResponse::respond();
 	}
 
 	/**

--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -831,13 +831,14 @@ JS;
 	public function addTreeNodeJS($page, $select = false) {
 		$parentID = (int)$page->ParentID;
 		$title = Convert::raw2js($page->TreeTitle());
-		$response = <<<JS
+		$js = <<<JS
 var newNode = $('sitetree').createTreeNode($page->ID, "$title", "$page->class");
 var parentNode = $('sitetree').getTreeNodeByIdx($parentID); 
 if(parentNode) parentNode.appendTreeNode(newNode);
 JS;
-		$response .= ($select ? "newNode.selectTreeNode();\n" : "") ;
-		return $response;
+		$js .= ($select ? "newNode.selectTreeNode();\n" : "") ;
+		FormResponse::add($js);
+		return FormResponse::respond();
 	}
 	/**
 	 * Returns a javascript snippet to remove a tree node for the given page, if it exists.
@@ -846,7 +847,7 @@ JS;
 	 */
 	public function deleteTreeNodeJS($page) {
 		$id = $page->ID ? $page->ID : $page->OldID;
-		$response = <<<JS
+		$js = <<<JS
 var node = $('sitetree').getTreeNodeByIdx($id);
 if(node && node.parentTreeNode) node.parentTreeNode.removeTreeNode(node);
 $('Form_EditForm').closeIfSetTo($id);
@@ -857,7 +858,8 @@ JS;
 			$this->setCurrentPageID(null);
 		}
 		
-		return $response;
+		FormResponse::add($js);
+		return FormResponse::respond();
 	}
 
 	/**

--- a/javascript/AssetAdmin.js
+++ b/javascript/AssetAdmin.js
@@ -321,7 +321,6 @@ addfolder.prototype = {
 		return false;
 	},
 	onSuccess: function(response) {
-		Ajax.Evaluator(response);
 		// Make it possible to drop files into the new folder
 		DropFileItem.applyTo('#sitetree li');
 	},
@@ -456,7 +455,6 @@ var deletefolder = {
 	},
 	
 	submit_success: function(response) {
-		Ajax.Evaluator(response);
 		treeactions.closeSelection($('deletepage'));
 	}
 };

--- a/javascript/CMSMain_left.js
+++ b/javascript/CMSMain_left.js
@@ -131,7 +131,6 @@ addpageclass.prototype = {
 
 			var suffix = _NEW_PAGES[parentID]++;
 			Ajax.SubmitForm(_HANDLER_FORMS.addpage, "action_addpage", {
-				onSuccess : Ajax.Evaluator,
 				onFailure : function(response) { if (response.status == 403) {
 					alert('You cannot add that page at that location.');
 				}},
@@ -592,7 +591,6 @@ publishpage.prototype = {
 		// Submit form
 		Ajax.SubmitForm(this, null, {
 			onSuccess :  function(response) {
-				Ajax.Evaluator(response);
 				$('batchactions_go').className = '';
 				batchActionGlobals.deselectAll();
 			},
@@ -639,7 +637,6 @@ deletepage.prototype = {
 				$('Form_DeleteItemsForm_action_deleteitems').className = 'loading';
 				Ajax.SubmitForm(this, null, {
 					onSuccess : function(response) {
-						Ajax.Evaluator(response);
 						$('Form_DeleteItemsForm_action_deleteitems').className = '';
 						treeactions.closeSelection($('batchactions'));
 					},

--- a/javascript/CMSMain_right.js
+++ b/javascript/CMSMain_right.js
@@ -8,7 +8,6 @@ function action_revert_right() {
 	$('Form_EditForm_action_revert').value = ss.i18n._t('CMSMAIN.RESTORING');
 	$('Form_EditForm_action_revert').className = 'action loading';
 	Ajax.SubmitForm('Form_EditForm', 'action_revert', {
-		onSuccess : Ajax.Evaluator,
 		onFailure : function(response) {
 			errorMessage(ss.i18n._t('CMSMAIN.ERRORREVERTING'), response);
 		}

--- a/javascript/LeftAndMain.js
+++ b/javascript/LeftAndMain.js
@@ -302,7 +302,6 @@ function prepareAjaxActions(actions, formName, tabName) {
 			} else {
 				statusMessage('...');
 				Ajax.SubmitForm(this.ownerForm, this.name, {
-					onSuccess: Ajax.Evaluator,
 					onFailure: ajaxErrorHandler
 				});
 			}
@@ -333,7 +332,6 @@ function ajaxSubmitForm(automated, callAfter, form, action, verb) {
 		statusMessage(verb + '...', '', true);
 
 		var success = function(response) {
-			Ajax.Evaluator(response);
 			if(callAfter) callAfter();
 		}
 
@@ -364,10 +362,6 @@ function ajaxSubmitFieldSet(href, fieldSet, extraData) {
 	// Send request
 	new Ajax.Request(href, {
 		method : 'post', postBody : data,
-		onSuccess : function(response) {
-			//alert(response.responseText);
-			Ajax.Evaluator(response);
-		},
 		onFailure : function(response) {
 			alert(response.responseText);
 			//errorMessage('Error: ', response);
@@ -382,7 +376,6 @@ function ajaxLink(href) {
 	// Send request
 	new Ajax.Request(href + (href.indexOf("?") == -1 ? "?" : "&") + "ajax=1", {
 		method : 'get',
-		onSuccess : Ajax.Evaluator,
 		onFailure : ajaxErrorHandler
 	});
 }

--- a/javascript/LeftAndMain_left.js
+++ b/javascript/LeftAndMain_left.js
@@ -286,7 +286,6 @@ TreeNodeAPI.prototype = {
 
 		new Ajax.Request(url, {
 			method : 'get',
-			onSuccess : Ajax.Evaluator,
 			onFailure : function(response) {
 				errorMessage('Error: ', response);
 			}
@@ -297,7 +296,6 @@ TreeNodeAPI.prototype = {
 		var url = baseHref() + 'admin/duplicatewithchildren/' + this.getIdx() + '?ajax=1&SecurityID=' + token;
 		new Ajax.Request(url, {
 			method : 'get',
-			onSuccess : Ajax.Evaluator,
 			onFailure : function(response) {
 				errorMessage('Error: ', response);
 			}
@@ -431,7 +429,6 @@ SiteTreeNode.prototype = {
 		new Ajax.Request(SiteTreeHandlers.parentChanged_url, {
 			method : 'post', 
 			postBody : 'ID=' + node.getIdx() + '&ParentID=' + newParent.getIdx() + '&CurrentlyOpenPageID=' + currentlyOpenPageID + '&SecurityID=' + token,
-			onSuccess : Ajax.Evaluator,
 			onFailure : function(response) {
 				errorMessage('error saving parent', response);
 			}

--- a/javascript/LeftAndMain_right.js
+++ b/javascript/LeftAndMain_right.js
@@ -103,7 +103,7 @@ CMSForm.prototype = {
 		}
 
 		if(response && evalResponse) {
-			Ajax.Evaluator(response);
+			// no-op, has already been evaluated by prototype.js
 		} else {
 			this.innerHTML = rightHTML;
 		}
@@ -178,8 +178,6 @@ CMSForm.prototype = {
 		}
 		
 		var success = function(response) {
-			Ajax.Evaluator(response);
-			
 			__form.resetElements();
 			if(__callAfter) __callAfter();
 			if(__form.notify && __form.elements.ID != undefined) __form.notify('PageSaved', __form.elements.ID.value);

--- a/javascript/PageCommentInterface.js
+++ b/javascript/PageCommentInterface.js
@@ -66,8 +66,7 @@ PageCommentInterface.prototype = {
 					//need to check if there is actually a spam question to change first
 					if(form.elements.Math){
 						new Ajax.Request(document.getElementsByTagName('base')[0].href+'PageCommentInterface_Controller/newspamquestion', {
-							onSuccess: loadSpamQuestion,
-							onFailure: Ajax.Evaluator
+							onSuccess: loadSpamQuestion
 						});
 					}
 					

--- a/javascript/SecurityAdmin_left.js
+++ b/javascript/SecurityAdmin_left.js
@@ -25,7 +25,6 @@ var addgroup = {
 		var st = $('sitetree');
 		$('addgroup_options').elements.ParentID.value = st.firstSelected() ? st.getIdxOf(st.firstSelected()) : 0;
 		Ajax.SubmitForm('addgroup_options', null, {
-			onSuccess : Ajax.Evaluator,
 			onFailure : function(response) {
 				errorMessage('Error adding page', response);
 			}
@@ -113,8 +112,6 @@ var deletegroup = {
 	
 				Ajax.SubmitForm('deletegroup_options', null, {
 					onSuccess : function(response) {
-						Ajax.Evaluator(response);
-	
 						var sel;
 						if((sel = $('sitetree').firstSelected()) && sel.parentNode) sel.addNodeClass('current');
 						else $('Form_EditForm').innerHTML = "";

--- a/javascript/TranslationTab.js
+++ b/javascript/TranslationTab.js
@@ -11,10 +11,7 @@ Behaviour.register({
 				url += "&locale=" + $('Form_EditForm_Locale').value;
 				url += "&SecurityID=" + $$('input[name=SecurityID]')[0].value;
 				
-				new Ajax.Request( url, {
-					onSuccess: Ajax.Evaluator,
-					onFailure: Ajax.Evaluator
-				});
+				new Ajax.Request(url);
 				
 				return false;
 			}


### PR DESCRIPTION
See http://open.silverstripe.org/ticket/8036

Regression caused by a security fix in 9bf3ae9a190. The whole point of that change was to set the content-type to 'text/json', so we can't revert it without re-introducing the security hole.
But this also meant that `Ajax.Evaluator` was triggered twice: Once in the (hacked up) prototype.js global ajax handling, and once through the various `onSuccess` callbacks on individual ajax requests.
So we're not dealing with two ajax responses, the same response is eval'ed twice.

I've fixed this by removing all those individual calls to `Ajax.Evaluator`,
and consistently using `FormResponse` to return content (some UIs used `echo`).

This change has some potential to further break CMS behaviour.
I've tested each altered feature (adding and batch-deleting pages/files/folders, reverting a page to live, creating a translation, handling comments in CommentAdmin, submitting a new comment on the website, etc). - would feel better if somebody else could do a sanity check though.

@sminnee @hafriedlander So this warrants a 2.4.9 release, correct?
