### PR TITLE
BUG Prevent error when searching for files in all categories.

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -119,7 +119,7 @@ JS
 		}
 
 		// Category filter
-		if(isset($params['AppCategory'])) {
+		if(isset($params['AppCategory']) && isset(File::$app_categories[$params['AppCategory']])) {
 			$exts = File::$app_categories[$params['AppCategory']];
 			$categorySQLs = array();
 			foreach($exts as $ext) $categorySQLs[] = '"File"."Name" LIKE \'%.' . $ext . '\'';


### PR DESCRIPTION
The File::$app_categories does not have an entry for "all" which is
represented by empty string.
