### PR TITLE
BUG Namespaces for CmsFormsContext and CmsUiContext are wrong

### DIFF
--- a/tests/behat/features/bootstrap/FeatureContext.php
+++ b/tests/behat/features/bootstrap/FeatureContext.php
@@ -5,8 +5,8 @@ namespace SilverStripe\Cms\Test\Behaviour;
 use SilverStripe\BehatExtension\Context\SilverStripeContext,
     SilverStripe\BehatExtension\Context\BasicContext,
     SilverStripe\BehatExtension\Context\LoginContext,
-    SilverStripe\Test\Behaviour\CmsFormsContext,
-    SilverStripe\Test\Behaviour\CmsUiContext;
+    SilverStripe\Framework\Test\Behaviour\CmsFormsContext,
+    SilverStripe\Framework\Test\Behaviour\CmsUiContext;
 
 // PHPUnit
 require_once 'PHPUnit/Autoload.php';


### PR DESCRIPTION
Correcting some of the namespaces in the behat cms tests
