### PR TITLE
BUG Remove handwritten SQL and use the ORM.

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1709,27 +1709,15 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	/**
 	 * Return the number of {@link DependentPages()}
 	 * 
+	 * @deprecated 3.1 Use DependentPages()->Count() instead.
+	 *
 	 * @param $includeVirtuals Set to false to exlcude virtual pages.
 	 */
 	public function DependentPagesCount($includeVirtuals = true) {
-		$links = DB::query("SELECT COUNT(*) FROM \"SiteTree_LinkTracking\" 
-			INNER JOIN \"SiteTree\" ON \"SiteTree\".\"ID\" = \"SiteTree_LinkTracking\".\"SiteTreeID\"
-			WHERE \"ChildID\" = $this->ID ")->value();
-		if($includeVirtuals && class_exists('VirtualPage')) {
-			$virtuals = DB::query("SELECT COUNT(*) FROM \"VirtualPage\" 
-			INNER JOIN \"SiteTree\" ON \"SiteTree\".\"ID\" = \"VirtualPage\".\"ID\"
-			WHERE \"CopyContentFromID\" = $this->ID")->value();
-		} else {
-			$virtuals = 0;
-		}
-		$redirectors = DB::query("SELECT COUNT(*) FROM \"RedirectorPage\" 
-			INNER JOIN \"SiteTree\" ON \"SiteTree\".\"ID\" = \"RedirectorPage\".\"ID\"
-			WHERE \"RedirectionType\" = 'Internal' AND \"LinkToID\" = $this->ID")->value();
-			
-			
-		return 0 + $links + $virtuals + $redirectors;
+		Deprecation::notice('3.1', 'Use SiteTree->DependentPages()->Count() instead.');
+		return $this->DependentPages($includeVirtuals)->Count();
 	}
-	
+
 	/**
 	 * Return all virtual pages that link to this page
 	 */
@@ -1803,7 +1791,8 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$dependentTable = new LiteralField('DependentNote', '<p></p>');
 		
 		// Create a table for showing pages linked to this one
-		$dependentPagesCount = $this->DependentPagesCount();
+		$dependentPages = $this->DependentPages();
+		$dependentPagesCount = $dependentPages->Count();
 		if($dependentPagesCount) {
 			$dependentColumns = array(
 				'Title' => $this->fieldLabel('Title'),
@@ -1816,7 +1805,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$dependentTable = GridField::create(
 				'DependentPages',
 				false,
-				$this->DependentPages()
+				$dependentPages
 			);
 			$dependentTable->getConfig()->getComponentByType('GridFieldDataColumns')
 				->setFieldFormatting(array(


### PR DESCRIPTION
The custom SQL does not take subsites into account and breaks the CMS
on certain pages - under some circumstances the custom count will return
1 or more, while the set will be in fact empty because of augmentation.

With three dependent-pages and 3 minute benchmark, it looks like there is no performance hit:

BEFORE:
  50%    612
  66%    622
  75%    686
  80%    688
  90%    694
  95%    699
  98%    768
  99%   1054
 100%   1710 (longest request)

AFTER
  50%    605
  66%    616
  75%    675
  80%    680
  90%    685
  95%    693
  98%    762
  99%   1027
 100%   1040 (longest request)
