### PR TITLE
FIX: Stop MenuTitle updating tree on change

### DIFF
--- a/javascript/CMSMain.EditForm.js
+++ b/javascript/CMSMain.EditForm.js
@@ -130,40 +130,6 @@
 				updateURLFromTitle.hide();
 			}
 		});
-
-		/**
-		 * MenuTitle
-		 */
-		$('.cms-edit-form input[name=MenuTitle]').entwine({
-			onchange: function() {
-				this.updatedRelatedFields();
-			},
-
-			/**
-			 * Same as the onchange handler but callable as a method
-			 */
-			updatedRelatedFields: function() {
-				var menuTitle = this.val();
-				this.updateTreeLabel(menuTitle);
-			},
-
-			/**
-			 * Function: updatePanelLabels
-			 * 
-			 * Update the tree
-			 * (String) title
-			 */
-			updateTreeLabel: function(title) {
-				var pageID = $('.cms-edit-form input[name=ID]').val();
-
-				// only update immediate text element, we don't want to update all the nested ones
-				var treeItem = $('.item:first', $('.cms-tree').find("[data-id='" + pageID + "']"));
-				if (title && title != "") {
-					treeItem.text(title);
-				}
-			}
-
-		});
 	
 		/**
 		 * Class: .cms-edit-form .parentTypeSelector


### PR DESCRIPTION
If the MenuTitle is changed and the tree updates, not saving the changes to the page leaves the tree with the new title instead of the old, correct one (until a refresh). This also seems counter-intuitive anyway - suggesting to users that their updated MenuTitle has been saved before it actually has.
