### PR TITLE
BUG: Fixed pagination functionality on root assets folder

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -95,7 +95,7 @@ JS
 		// Don't filter list when a detail view is requested,
 		// to avoid edge cases where the filtered list wouldn't contain the requested
 		// record due to faulty session state (current folder not always encoded in URL, see #7408).
-		if(!$folder->ID && ($this->request->param('ID') == 'field')) {
+		if(!$folder->ID && $this->request->requestVar('ID') === null && ($this->request->param('ID') == 'field')) {
 			return $list;
 		}
 


### PR DESCRIPTION
Moving to another page in the GridField for the root assets folder in AssetAdmin
caused all files to be displayed. This was caused by the functionality that tries
to fix some edge cases for detail view kicked in and didn't filter the list properly.

Fixed by making the edge case detection a little more specific (i.e. checking if
a numeric ID was sent as a request variable).
