### PR TITLE
BUG SiteTree_Information.ss was not making use if i18n translations

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -320,6 +320,8 @@ en:
     HTMLEDITORTITLE: Content
     INHERIT: 'Inherit from parent page'
     LASTUPDATED: 'Last Updated'
+    LASTSAVED: 'Last saved'
+    LASTPUBLISHED: 'Last published'
     LINKCHANGENOTE: 'Changing this page''s link will also affect the links of all child pages.'
     MENUTITLE: 'Navigation label'
     METADESC: 'Meta Description'

--- a/lang/en_GB.yml
+++ b/lang/en_GB.yml
@@ -328,6 +328,8 @@ en_GB:
     HTMLEDITORTITLE: Content
     INHERIT: 'Inherit from parent page'
     LASTUPDATED: 'Last Updated'
+    LASTSAVED: 'Last saved'
+    LASTPUBLISHED: 'Last published'
     LINKCHANGENOTE: 'Changing this page''s link will also affect the links of all child pages.'
     MENUTITLE: 'Navigation label'
     METADESC: Description

--- a/templates/SiteTree_Information.ss
+++ b/templates/SiteTree_Information.ss
@@ -1,9 +1,9 @@
 <div class='cms-sitetree-information'>
-	<p class="meta-info"><% _t('LASTSAVED', 'Last saved') %> $LastEdited.Ago(0)
+	<p class="meta-info"><% _t('SiteTree.LASTSAVED', 'Last saved') %> $LastEdited.Ago(0)
 	<% if ExistsOnLive %>
-		<br /><% _t('LASTPUBLISHED', 'Last published') %> $Live.LastEdited.Ago(0)
+		<br /><% _t('SiteTree.LASTPUBLISHED', 'Last published') %> $Live.LastEdited.Ago(0)
 	<% else %>
-		<br /><em><% _t('NOTPUBLISHED', 'Not published') %></em>
+		<br /><em><% _t('SiteTree.NOTPUBLISHED', 'Not published') %></em>
 	<% end_if %>
 	</p>
 </div>


### PR DESCRIPTION
Whilst looking at open ticket 8151 it was discovered that this template was not making use of the i18n translations
