### PR TITLE
BUG: Allow Multiple SiteTreeURLSegmentField's on Page

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1822,6 +1822,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$url = (strlen($baseLink) > 36) ? "..." .substr($baseLink, -32) : $baseLink;
 		$urlsegment = new SiteTreeURLSegmentField("URLSegment", $this->fieldLabel('URLSegment'));
 		$urlsegment->setURLPrefix($url);
+		$urlsegment->setAttribute('data-related-field', 'Title');
 		$helpText = (self::nested_urls() && count($this->Children())) ? $this->fieldLabel('LinkChangeNote') : '';
 		if(!URLSegmentFilter::$default_allow_multibyte) {
 			$helpText .= $helpText ? '<br />' : '';

--- a/css/screen.css
+++ b/css/screen.css
@@ -21,13 +21,17 @@
 .cms-content-tools #cms-content-treeview .cms-tree a:hover > .text > .badge, .cms-content-tools #cms-content-treeview .cms-tree .jstree-clicked > .text > .badge { display: inline-block; }
 
 /** ------------------------------------------------------------------ URLSegment field ----------------------------------------------------------------- */
-.field.urlsegment.loading { background: url(../images/loading.gif) no-repeat 162px 8px; }
+.field.urlsegment .preview, .field.urlsegment .edit, .field.urlsegment .update, .field.urlsegment .cancel, .field.urlsegment .help { display: none; }
 .field.urlsegment .prefix, .field.urlsegment .preview { padding-top: 8px; display: inline-block; }
 .field.urlsegment .prefix { color: #777; }
-.field.urlsegment .cancel, .field.urlsegment .update, .field.urlsegment .edit { margin-left: 7px; }
-.field.urlsegment .help { margin-left: 0; }
+.field.urlsegment .edit { margin-left: 5px; }
+.field.urlsegment .cancel { margin-left: 0; text-decoration: none; }
+.field.urlsegment .cancel:hover { text-decoration: underline; }
+.field.urlsegment .help { margin: 10px 0 0 0; }
+.field.urlsegment.loading { background: url(../images/loading.gif) no-repeat 162px 8px; }
+.field.urlsegment.urlsegment-transformed .text.urlsegment { min-width: 140px; width: auto !important; max-width: auto !important; }
 
-#Form_EditForm #Title .update { margin-left: 7px; }
+.field.text .update { margin-left: 5px; }
 
 .cms .AssetAdmin .cms-content-fields { overflow: hidden; }
 .cms .AssetAdmin .cms-content-fields .cms-edit-form.AssetAdmin { overflow-y: auto; }

--- a/javascript/CMSMain.EditForm.js
+++ b/javascript/CMSMain.EditForm.js
@@ -17,40 +17,26 @@
 
 		/**
 		 * Class: .cms-edit-form input[name=Title]
-		 * 
+		 *
 		 * Input validation on the Title field
 		 */
 		$('.cms-edit-form input[name=Title]').entwine({
 			// Constructor: onmatch
 			onmatch : function() {
-				var self = this;
-
+				var self = this,
+					form = self.parents('form'),
+					live_link = $('input[name=LiveLink]', form);
+				
 				self.data('OrigVal', self.val());
 				
-				var form = self.parents('form');
-				var url_segment = $('.field.urlsegment', form).find(':text');
-				var live_link = $('input[name=LiveLink]', form);
+				this.bind('change', function(e) {
+					var origTitle = self.data('OrigVal');
+					var title = self.val();
+					self.data('OrigVal', title);
+					self.updateRelatedFields(title, origTitle);
+					self.updateBreadcrumbLabel(title);
+				});
 				
-				self._addActions();
-
-				if(url_segment.length > 0) {
-					this.bind('change', function(e) {
-						var origTitle = self.data('OrigVal');
-						var title = self.val();
-						self.data('OrigVal', title);
-
-						// Criteria for defining a "new" page
-						if ((url_segment.val().indexOf('new') == 0) && live_link.val() == '') {
-							self.updateURLSegment(title);
-						} else {
-							$('.update', self.parent()).show();
-						}
-
-						self.updateRelatedFields(title, origTitle);
-						self.updateBreadcrumbLabel(title);
-					});
-				}
-
 				this._super();
 			},
 			onunmatch: function() {
@@ -59,7 +45,7 @@
 			
 			/**
 			 * Function: updateRelatedFields
-			 * 
+			 *
 			 * Update the related fields if appropriate
 			 * (String) title The new title
 			 * (Stirng) origTitle The original title
@@ -77,57 +63,17 @@
 			},
 			
 			/**
-			 * Function: updateURLSegment
-			 * 
-			 * Update the URLSegment
-			 * (String) title
-			 */
-			updateURLSegment: function(title) {
-				var url_segment_field = $('.field.urlsegment', this.parents('form'));
-				var updateURLFromTitle = $('.update', this.parent());
-				url_segment_field.update(title);
-				if (updateURLFromTitle.is(':visible')) {
-					updateURLFromTitle.hide();
-				}
-			},
-			
-			/**
 			 * Function: updateBreadcrumbLabel
-			 * 
+			 *
 			 * Update the breadcrumb
 			 * (String) title
 			 */
 			updateBreadcrumbLabel: function(title) {
 				var pageID = $('.cms-edit-form input[name=ID]').val();
 				var panelCrumb = $('span.cms-panel-link.crumb');
-				if (title && title != "") {
+				if (title && title !== "") {
 					panelCrumb.text(title);
 				}
-			},
-			
-			/**
-			 * Function: _addActions
-			 *  
-			 * Utility to add update from title action
-			 * 
-			 */
-			_addActions: function() {
-				var self = this;
-				var	updateURLFromTitle;
-				
-				// update button
-				updateURLFromTitle = $('<button />', {
-					'class': 'update ss-ui-button-small',
-					'text': 'Update URL',
-					'click': function(e) {
-						e.preventDefault();
-						self.updateURLSegment(self.val());
-					}
-				});
-				
-				// insert elements
-				updateURLFromTitle.insertAfter(self);
-				updateURLFromTitle.hide();
 			}
 		});
 

--- a/javascript/SiteTreeURLSegmentField.js
+++ b/javascript/SiteTreeURLSegmentField.js
@@ -1,215 +1,274 @@
 (function($) {
 	$.entwine('ss', function($) {
+
 		/**
 		 * Class: .field.urlsegment
-		 * 
+		 *
 		 * Input validation on the URLSegment field
 		 */
 		$('.field.urlsegment:not(.readonly)').entwine({
-	
+
+			/**
+			 * URLSegment Input Field
+			 */
+			InputField: null,
+
+			/**
+			 * URLSegment Preview Element
+			 */
+			Preview: null,
+
+			/**
+			 * URL Prefix Element
+			 */
+			Prefix: null,
+
+			/**
+			 * Edit Button Element
+			 */
+			EditButton: null,
+
+			/**
+			 * Update Button Element
+			 */
+			UpdateButton: null,
+
+			/**
+			 * Cancel Button Element
+			 */
+			CancelButton: null,
+
+			/**
+			 * Help Text Element
+			 */
+			Help: null,
+
+			/**
+			 * Ex. Title Field
+			 */
+			RelatedField: null,
+
 			/**
 			 * Constructor: onmatch
 			 */
 			onmatch : function() {
+				var self = this,
+					relatedFieldByName,
+					relatedField;
+
 				// Only initialize the field if it contains an editable field.
 				// This ensures we don't get bogus previews on readonly fields.
-				if(this.find(':text').length) {
-					this._addActions(); // add elements and actions for editing
-					this.edit(); // toggle
-					this._autoInputWidth(); // set width of input field
+				if(!this.find(':text').length) {
+					this._super();
+					return;
 				}
-				
+
+				// set elements
+				this.setInputField(this.find(':text'));
+				this.setPreview(this.find('.preview'));
+				this.setPrefix(this.find('.prefix'));
+				this.setEditButton(this.find('.edit'));
+				this.setUpdateButton(this.find('.update'));
+				this.setCancelButton(this.find('.cancel'));
+				this.setHelp(this.find('.help'));
+
+				// edit button
+				this.on('click', '.edit', function(e) {
+					e.preventDefault();
+					self.edit();
+					self.find(':text').focus();
+				});
+
+				// update button
+				this.on('click', '.update', function(e) {
+					e.preventDefault();
+					self.update();
+				});
+
+				// cancel button
+				this.on('click', '.cancel', function(e) {
+					e.preventDefault();
+					self.cancel();
+				});
+
+				// default state
+				this.reset();
+
+				// field has been transformed
+				this.addClass('urlsegment-transformed');
+
+				// check for a related field
+				relatedFieldByName = this.getInputField().data('related-field');
+				if (relatedFieldByName) {
+					relatedField = this.parents('form').find('input[name=' + relatedFieldByName + ']');
+					if (relatedField.length) {
+						this.setRelatedField(relatedField);
+						this._addUpdateFromBehavior();
+					}
+				}
+
 				this._super();
 			},
 			onunmatch: function() {
 				this._super();
 			},
-			
+
+			/**
+			 * Function: reset
+			 */
+			reset: function() {
+				var field = this.getInputField();
+
+				field.hide();
+				this.getUpdateButton().hide();
+				this.getCancelButton().hide();
+				this.getPreview().show().text(field.val());
+				this.getEditButton().show();
+				this.getHelp().slideUp();
+				this._autoInputWidth();
+			},
+
 			/**
 			 * Function: edit
-			 *  
-			 * Toggles the edit state of the field
-			 * 
-			 * Return URLSegemnt val()
-			 * 
-			 * Parameters:
-			 *  (Bool) auto (optional, triggers a second toggle)
 			 */
-			edit: function(auto) {
-				
-				var field = this.find(':text'),
-					holder = this.find('.preview'),
-					edit = this.find('.edit'),
-					update = this.find('.update'),
-					cancel = this.find('.cancel'),
-					help = this.find('.help');
-				
-				// transfer current value to holder
-				holder.text(field.val());
-				
-				// toggle elements
-				if (field.is(':visible')) {
-					update.hide();
-					cancel.hide();
-					field.hide();
-					holder.show();
-					edit.show();
-					help.hide();
-				} else {
-					edit.hide();
-					holder.hide();
+			edit: function() {
+				var field = this.getInputField();
+
+				// transfer current value to preview
+				// we can restore from here later
+				// if action is canceled
+				this.getPreview().text(field.val());
+
+				if (!field.is(':visible')) {
 					field.show();
-					update.show();
-					cancel.show();
-					help.show();
+					this.getUpdateButton().show();
+					this.getCancelButton().show();
+					this.getPreview().hide();
+					this.getEditButton().hide();
+					this.getHelp().slideDown();
+				} else {
+					this.reset();
 				}
-				
-				// field updated from another fields value
-				// reset to original state
-				if (auto) this.edit();
-				
-				return field.val();
 			},
-			
+
 			/**
 			 * Function: update
-			 *  
+			 *
 			 * Commits the change of the URLSegment to the field
 			 * Optional: pass in (String)
 			 * to update the URLSegment
 			 */
 			update: function() {
-				
+
 				var self = this,
-					field = this.find(':text'),
-					holder = this.find('.preview'),
+					field = this.getInputField(),
+					holder = this.getPreview(),
 					currentVal = holder.text(),
 					updateVal,
 					title = arguments[0];
-				
+
 				if (title && title !== "") {
 					updateVal = title;
 				} else {
 					updateVal = field.val();
 				}
-				
+
 				if (currentVal != updateVal) {
-					self.addClass('loading');
-					self.suggest(updateVal, function(data) {
+					this.addClass('loading');
+					this.suggest(updateVal, function(data) {
 						var newVal = decodeURIComponent(data.value);
 						field.val(newVal);
-						self.edit(title);
+						self.reset();
 						self.removeClass('loading');
 					});
 				} else {
-					self.edit();
+					this.reset();
 				}
 			},
-			
+
 			/**
 			 * Function: cancel
-			 *  
-			 * Cancels any changes to the field
 			 *
-			 * Return URLSegemnt val()
+			 * Cancels any changes to the field
 			 *
 			 */
 			cancel: function() {
-				var field = this.find(':text'),
-					holder = this.find('.preview');
+				var field = this.getInputField(),
+					holder = this.getPreview();
+
 					field.val(holder.text());
-					this.edit();
-					
-				return field.val();
+					this.reset();
 			},
-	
+
 			/**
 			 * Function: suggest
-			 *  
+			 *
 			 * Return a value matching the criteria.
-			 * 
+			 *
 			 * Parameters:
 			 *  (String) val
 			 *  (Function) callback
 			 */
 			suggest: function(val, callback) {
-				var field = this.find(':text'), urlParts = $.path.parseUrl(this.closest('form').attr('action')),
+				var field = this.getInputField(),
+					urlParts = $.path.parseUrl(this.closest('form').attr('action')),
 					url = urlParts.hrefNoSearch + '/field/' + field.attr('name') + '/suggest/?value=' + encodeURIComponent(val);
-				if(urlParts.search) url += '&' + urlParts.search.replace(/^\?/, '');
 
-				$.get(
-					url,
-					function(data) {callback.apply(this, arguments);}
-				);
-				
+				if (urlParts.search) url += '&' + urlParts.search.replace(/^\?/, '');
+
+				$.get(url, function(data) {
+					callback.apply(this, arguments);
+				});
 			},
-			
+
 			/**
-			 * Function: _addActions
-			 *  
-			 * Utility to add edit buttons and actions
-			 * 
+			 * Function: _addUpdateFromBehavior
+			 *
+			 * Adds "update from" behaviour to related field
 			 */
-			_addActions: function() {
+			_addUpdateFromBehavior: function() {
 				var self = this,
-					field = this.find(':text'),
-					preview,
-					editAction,
-					updateAction,
-					cancelAction;
-					
-				// element to display non-editable text
-				preview = $('<span />', {
-					'class': 'preview'
-				});
-				
-				// edit button
-				editAction = $('<button />', {
-					'class': 'ss-ui-button ss-ui-button-small edit',
-					'text': ss.i18n._t('URLSEGMENT.Edit', 'Edit'),
-					'click': function(e) {
-						e.preventDefault();
-						self.edit();
-						self.find(':text').focus();
-					}
-				});
-				
-				// update button
-				updateAction = $('<button />', {
+					urlsegment = this.getInputField(),
+					updateURLSegment,
+					related = this.getRelatedField(),
+					livelink = $('input[name=LiveLink]', this.parents('form'));
+
+				updateURLSegment = $('<button />', {
 					'class': 'update ss-ui-button-small',
-					'text': ss.i18n._t('URLSEGMENT.OK', 'OK'),
+					'text': ss.i18n._t('URLSEGMENT.UpdateURLSegment', 'Update URL'),
 					'click': function(e) {
 						e.preventDefault();
-						self.update();
+						self.update(related.val());
+						$(this).fadeOut();
 					}
 				});
-				
-				// cancel button
-				cancelAction = $('<button />', {
-					'class': 'cancel ss-ui-action-minor ss-ui-button-small',
-					'href': '#',
-					'text':  ss.i18n._t('URLSEGMENT.Cancel', 'Cancel'),
-					'click': function(e) {
-						e.preventDefault();
-						self.cancel();
-					}
-				});
-				
+
 				// insert elements
-				preview.insertAfter('.prefix');
-				editAction.insertAfter(field);
-				cancelAction.insertAfter(field);
-				updateAction.insertAfter(field);
+				updateURLSegment.insertAfter(related);
+				updateURLSegment.hide();
+
+				// watch for changes on related field
+				related.bind('change', function(e) {
+					var field = $(this);
+
+					// Criteria for defining a "new" page
+					if ((urlsegment.val().indexOf('new') === 0) && livelink.val() === '') {
+						self.update(related.val());
+					} else {
+						$('.update', field.parent()).fadeIn();
+					}
+				});
+
 			},
-			
+
 			/**
 			 * Function: _autoInputWidth
 			 *
-			 * Sets the width of input so it lines up with the other fields
+			 * Adjust width of text input
 			 */
 			_autoInputWidth: function() {
-				var field = this.find(':text');
-				field.width((field.width() + 15) - this.find('.prefix').width());
+				var field = this.getInputField();
+				field.attr('size', field.val().length + 4);
 			}
 		});
 	});

--- a/javascript/lang/en_US.js
+++ b/javascript/lang/en_US.js
@@ -32,8 +32,6 @@ if(typeof(ss) == 'undefined' || typeof(ss.i18n) == 'undefined') {
 		'Tree.EditPage': 'Edit',
 		'CMSMain.ConfirmRestoreFromLive': "Do you really want to copy the published content to the draft site?",
 		'CMSMain.RollbackToVersion': "Do you really want to roll back to version #%s of this page?",
-		'URLSEGMENT.Edit': 'Edit',
-		'URLSEGMENT.OK': 'OK',
-		'URLSEGMENT.Cancel': 'Cancel'
+		'URLSEGMENT.UpdateURLSegment': "Update URL"
 	});
 }

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -371,6 +371,9 @@ en:
     many_many_LinkTracking: 'Link Tracking'
   SiteTreeURLSegmentField:
     HelpChars: ' Special characters are automatically converted or removed.'
+    Edit: 'Edit'
+    OK: 'OK'
+    Cancel: 'Cancel'
   StaticExporter:
     BASEURL: 'Base URL'
     EXPORTTO: 'Export to that folder'

--- a/scss/_CMSMain.scss
+++ b/scss/_CMSMain.scss
@@ -94,8 +94,12 @@
  * ----------------------------------------------------------------- */
 .field.urlsegment {
 
-	&.loading {
-		background: url(../images/loading.gif) no-repeat 162px 8px;
+	.preview,
+	.edit,
+	.update,
+	.cancel,
+	.help {
+		display: none;
 	}
 
 	.prefix,
@@ -108,15 +112,40 @@
 		color: #777;
 	}
 
-	.cancel, .update, .edit {
-		margin-left: 7px;
+	.edit {
+		margin-left: 5px;
+	}
+
+	.cancel {
+		margin-left: 0;
+		text-decoration: none;
+		&:hover {
+			text-decoration: underline;
+		}
 	}
 
 	.help {
-		margin-left: 0;
+		margin: 10px 0 0 0;
 	}
+
+	&.loading {
+		background: url(../images/loading.gif) no-repeat 162px 8px;
+	}
+
+	&.urlsegment-transformed {
+		.text.urlsegment {
+			min-width: 140px;
+			width: auto !important;
+			max-width: auto !important;
+		}
+	}
+
 }
 
-#Form_EditForm #Title .update {
-	margin-left: 7px;
+.field.text {
+
+	.update {
+		margin-left: 5px;
+	}
+
 }

--- a/templates/forms/SiteTreeURLSegmentField.ss
+++ b/templates/forms/SiteTreeURLSegmentField.ss
@@ -1,4 +1,8 @@
-<span class="prefix">$URLPrefix</span><input $AttributesHTML />
+<span class="prefix">$URLPrefix</span>
+<span class="preview"></span><input $AttributesHTML />
+<button class="edit ss-ui-button ss-ui-button-small"><%t SiteTreeURLSegmentField.Edit 'Edit' %></button>
+<button class="update ss-ui-button ss-ui-button-small"><%t SiteTreeURLSegmentField.OK 'Okay' %></button>
+<button class="cancel ss-ui-button ss-ui-button-small ss-ui-action-minor"><%t SiteTreeURLSegmentField.Cancel 'Cancel' %></button>
 <% if HelpText %>
-<p class="help">$HelpText</p>
+<p class="help message">$HelpText</p>
 <% end_if %>


### PR DESCRIPTION
Fixes #8032 and allows for setting of related field to add "update from title" behavior to. Declaring of related field now uses: FormField->setAttribute('data-related-field', 'Title');. "update from title" logic moved into SiteTreeURLSegmentField.js. Action buttons moved into field template.
