### PR TITLE
BUG: fixing previews for old pages in side by side editing ticket 8089

### DIFF
--- a/templates/CMSPageHistoryController_versions.ss
+++ b/templates/CMSPageHistoryController_versions.ss
@@ -13,7 +13,7 @@
 		<tr id="page-$RecordID-version-$Version" class="$EvenOdd $PublishedClass<% if not WasPublished %><% if not Active %> ui-helper-hidden<% end_if %><% end_if %><% if Active %> active<% end_if %>" data-published="<% if WasPublished %>true<% else %>false<% end_if %>">
 			<td class="ui-helper-hidden"><input type="checkbox" name="Versions[]" id="cms-version-{$Version}" value="$Version"<% if Active %> checked="checked"<% end_if %> /></td>
 			<% with LastEdited %>
-				<td class="last-edited first-column" title="$Ago - $Nice">$Nice</td>
+				<td class="last-edited first-column" value="$Value" title="$Ago - $Nice">$Nice</td>
 			<% end_with %>
 			<td><% if Author %>$Author.FirstName $Author.Surname.Initial<% else %><% _t('CMSPageHistoryController_versions.ss.UNKNOWN','Unknown') %><% end_if %></td>
 			<td class="last-column"><% if Published %><% if Publisher %>$Publisher.FirstName $Publisher.Surname.Initial<% else %><% _t('CMSPageHistoryController_versions.ss.UNKNOWN','Unknown') %><% end_if %><% else %><% _t('CMSPageHistoryController_versions.ss.NOTPUBLISHED','Not published') %><% end_if %></td>			


### PR DESCRIPTION
Fix for preview old pages in history with side by side editing added the edited date to the td which is used to store a param for loading the iframe.
A pull request will also be raised for framework.
