### PR TITLE
BUG fixing issue where publish wouldn't return content and filename in a...

### DIFF
--- a/code/staticpublisher/FilesystemPublisher.php
+++ b/code/staticpublisher/FilesystemPublisher.php
@@ -231,7 +231,7 @@ class FilesystemPublisher extends StaticPublisher {
 				);
 			}
 			
-			$files[] = array(
+			$files[$origUrl] = array(
 				'Content' => $content,
 				'Folder' => dirname($path).'/',
 				'Filename' => basename($path),


### PR DESCRIPTION
... different array index to the statuscode.

This bug shows up when using the "BuildStaticCacheFromQueue" task in staticpublishqueue module. The task crashes without this fix.
