### PR TITLE
ENHANCEMENT: ensure that error page ends up at the bottom of the sitetree

### DIFF
--- a/code/model/ErrorPage.php
+++ b/code/model/ErrorPage.php
@@ -172,12 +172,23 @@ class ErrorPage extends Page {
 	}
 	
 	/**
+	 * We make sure that the Error Pages always sit 
+	 * at the bottom of the SiteTree / GridField List.
+	 * We have taken one million as a minimum sort number
+	 * for Error Pages.  
+	 */
+	public function onBeforeWrite() {
+		$minimumSortNumber = 1000000;
+		parent::onBeforeWrite();
+		if($this->Sort < $minimumSortNumber) {
+			$this->Sort = $this->Sort + $minimumSortNumber;
+		}
+	}
+	
+	/**
 	 * When an error page is published, create a static HTML page with its
 	 * content, so the page can be shown even when SilverStripe is not
 	 * functioning correctly before publishing this page normally.
-	 * @param string|int $fromStage Place to copy from. Can be either a stage name or a version number.
-	 * @param string $toStage Place to copy to. Must be a stage name.
-	 * @param boolean $createNewVersion Set this to true to create a new version number.  By default, the existing version number will be copied over.
 	 */
 	public function doPublish() {
 		parent::doPublish();


### PR DESCRIPTION
removed some erroneous @params in comments and added onBeforeWrite, which increases the sort number of any ErrorPage to one million.  We do this so that ErrorPages will always show at the bottom of the sitetree (and not in amongst other pages). We could look at them being either at the top or the bottom, but bottom seems most appropriate.
