### PR TITLE
ENHANCEMENT: Hide SilverStripeNavigator_CMSLink when in a LeftAndMain extension not just CMSMain extensions

### DIFF
--- a/code/controllers/SilverStripeNavigator.php
+++ b/code/controllers/SilverStripeNavigator.php
@@ -196,12 +196,12 @@ class SilverStripeNavigatorItem_CMSLink extends SilverStripeNavigatorItem {
 	}
 	
 	public function isActive() {
-		return (Controller::curr() instanceof CMSMain);
+		return (Controller::curr() instanceof LeftAndMain);
 	}
 	
 	public function canView($member = null) {
 		// Don't show in CMS
-		return !(Controller::curr() instanceof CMSMain);
+		return !(Controller::curr() instanceof LeftAndMain);
 	}
 
 }


### PR DESCRIPTION
This pull request changes SilverStripeNavigator_CMSLink to be hidden when in the admin not just CMSMain extensions, this hides the CMS link when previewing DataObjects in a custom LeftAndMain extension or ModelAdmin.
