### PR TITLE
[FIX] Custom page icons

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -449,7 +449,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	 * 
 	 * @return String CSS 
 	 */
-	public function generatePageIconsCss() {
+	public static function generatePageIconsCss() {
 		$css = ''; 
 		
 		$classes = ClassInfo::subclassesFor('SiteTree'); 


### PR DESCRIPTION
SilverStripe has a feature to set custom icons for page types for an
instance:
public static $icon =
'background-image:url(zz-basic/backend/images/treeicons/page-file.png);'
;

When you open /admin/pages/ url it works ok, but if you will go to
settings, then refresh the page and click to pages icons won't be shown
cuz custom css generated to display custom icons won't be included by
ajax response.

CMSMain has a function generatePageIconsCss() it's dynamic function I
suggest to make it static. Anyway it calls ClassInfo staticly, but in
this way we can also add
Requirements::customCSS(CMSMain::generatePageIconsCss()); to
LeftAndMain or to LeftAndMain extenders

For an instance here's my way to do that:
class LeftAndMainNormalizer extends LeftAndMainExtension {
    public function init(){
        parent::init();
        Requirements::customCSS(CMSMain::generatePageIconsCss());
    }
}
