### PR TITLE
BUG Metadata heading removed from RediretorPage

### DIFF
--- a/code/model/RedirectorPage.php
+++ b/code/model/RedirectorPage.php
@@ -120,9 +120,7 @@ class RedirectorPage extends Page {
 		$fields->removeByName('Content', true);
 		
 		// Remove all metadata fields, does not apply for redirector pages
-		$fields->removeByName('MetaTagsHeader');
-		$fields->removeByName('MetaDescription');
-		$fields->removeByName('ExtraMeta');
+		$fields->removeByName('Metadata');
 		
 		$fields->addFieldsToTab('Root.Main',
 			array(


### PR DESCRIPTION
Currently the empty metadata accordion stays on the RedirectorPage. This is now removed.
