### PR TITLE
BUG Request object now has URL changed

### DIFF
--- a/code/controllers/RootURLController.php
+++ b/code/controllers/RootURLController.php
@@ -117,12 +117,10 @@ class RootURLController extends Controller {
 			return $this->response;
 		}
 			
-		$request = new SS_HTTPRequest (
-			$request->httpMethod(), self::get_homepage_link() . '/', $request->getVars(), $request->postVars()
-		);
+		$request->setUrl(self::get_homepage_link() . '/');
 		$request->match('$URLSegment//$Action', true);
-		
 		$controller = new ModelAsController();
+
 		$result     = $controller->handleRequest($request, $model);
 		
 		$this->popCurrent();


### PR DESCRIPTION
Instead of cloning the Request object and losing all the custom
attributes that don't come through the construct (eg: headers) we can
now set the URL alone.
