### PR TITLE
API Handle uncaught ValidationException on CMS controller execution

### DIFF
--- a/code/LeftAndMain.php
+++ b/code/LeftAndMain.php
@@ -314,6 +314,15 @@ class LeftAndMain extends Controller {
 		SSViewer::set_theme(null);
 	}
 
+	public function handleRequest(SS_HTTPRequest $request) {
+		try {
+			return parent::handleRequest($request);
+		} catch(ValidationException $e) {
+			// Nicer presentation of model-level validation errors
+			return $this->httpError(403, $e->getResult()->message());
+		}
+	}
+
 	
 	/**
 	 * If this is set to true, the "switchView" context in the


### PR DESCRIPTION
This removes the need for a lot of boilerplate code
around DataObject->write() logic, and avoids generic 500 errors
on user-level failures. This should really be a per-project choice,
but at the moment request handling doesn't allow to configure
custom exception handling.

Rewrite from https://github.com/silverstripe/sapphire/pull/1255
