### PR TITLE
FIX 8316 Prevents browser default behaviour when changing the pagetypes ...

### DIFF
--- a/javascript/CMSMain.AddForm.js
+++ b/javascript/CMSMain.AddForm.js
@@ -70,7 +70,8 @@
 		});
 		
 		$(".cms-add-form #PageType li").entwine({
-			onclick: function() {
+			onclick: function(e) {
+				e.preventDefault();
 				this.setSelected(true);
 			},
 			setSelected: function(bool) {


### PR DESCRIPTION
...if creating a new page
As we explicitly set the 'checked' attribute manually, it is required to prevent browser's default behaviour, or the first item in the radio buttons list gets selected, instead of the clicked one.
