### PR TITLE
NEW "Show children as list" tree context action

### DIFF
--- a/javascript/CMSMain.Tree.js
+++ b/javascript/CMSMain.Tree.js
@@ -12,12 +12,27 @@
 							'edit': {
 								'label': ss.i18n._t('Tree.EditPage'),
 								'action': function(obj) {
-										$('.cms-container').entwine('.ss').loadPanel(ss.i18n.sprintf(
+									$('.cms-container').entwine('.ss').loadPanel(ss.i18n.sprintf(
 										self.data('urlEditpage'), obj.data('id')
 									));
 								}
 							}
 						};
+
+						// Add "show as list"
+						if(!node.hasClass('nochildren')) {
+							menuitems['showaslist'] = {
+								'label': ss.i18n._t('Tree.ShowAsList'),
+								'action': function(obj) {
+									$('.cms-container').entwine('.ss').loadPanel(
+										self.data('urlListview') + '&ParentID=' + obj.data('id'),
+										null,
+										// Default to list view tab
+										{tabState: {'pages-controller-cms-content': {'tabSelector': '.content-listview'}}}
+									);
+								}
+							};
+						}
 						
 						// Build a list for allowed children as submenu entries
 						var pagetype = node.data('pagetype'),

--- a/javascript/lang/en_US.js
+++ b/javascript/lang/en_US.js
@@ -33,6 +33,7 @@ if(typeof(ss) == 'undefined' || typeof(ss.i18n) == 'undefined') {
 		'Tree.EditPage': 'Edit',
 		'Tree.ThisPageOnly': 'This page only',
 		'Tree.ThisPageAndSubpages': 'This page and subpages',
+		'Tree.ShowAsList': 'Show children as list',
 		'CMSMain.ConfirmRestoreFromLive': "Do you really want to copy the published content to the draft site?",
 		'CMSMain.RollbackToVersion': "Do you really want to roll back to version #%s of this page?",
 		'URLSEGMENT.Edit': 'Edit',

--- a/templates/Includes/CMSMain_TreeView.ss
+++ b/templates/Includes/CMSMain_TreeView.ss
@@ -19,7 +19,7 @@ $ExtraTreeTools
 	</div>
 	<% end_if %>
 
-	<div class="cms-tree" data-url-tree="$Link(getsubtree)" data-url-savetreenode="$Link(savetreenode)" data-url-updatetreenodes="$Link(updatetreenodes)" data-url-addpage="{$LinkPageAdd('AddForm/?action_doAdd=1')}&amp;ParentID=%s&amp;PageType=%s&amp;SecurityID=$SecurityID" data-url-editpage="$LinkPageEdit('%s')" data-url-duplicate="{$Link('duplicate/%s')}?SecurityID=$SecurityID" data-url-duplicatewithchildren="{$Link('duplicatewithchildren/%s')}?SecurityID=$SecurityID" data-hints="$SiteTreeHints.XML">
+	<div class="cms-tree" data-url-tree="$Link(getsubtree)" data-url-savetreenode="$Link(savetreenode)" data-url-updatetreenodes="$Link(updatetreenodes)" data-url-addpage="{$LinkPageAdd('AddForm/?action_doAdd=1')}&amp;ParentID=%s&amp;PageType=%s&amp;SecurityID=$SecurityID" data-url-editpage="$LinkPageEdit('%s')" data-url-duplicate="{$Link('duplicate/%s')}?SecurityID=$SecurityID" data-url-duplicatewithchildren="{$Link('duplicatewithchildren/%s')}?SecurityID=$SecurityID" data-url-listview="{$Link('?view=list')}" data-hints="$SiteTreeHints.XML">
 		$SiteTreeAsUL
 	</div>
 </div>

--- a/templates/Includes/CMSPagesController_Content.ss
+++ b/templates/Includes/CMSPagesController_Content.ss
@@ -7,10 +7,10 @@
 	
 		<div class="cms-content-header-tabs">
 			<ul class="cms-tabset-nav-primary">
-				<li class="content-treeview<% if ViewState == tree %> ui-tabs-active<% end_if %> cms-tabset-icon tree">
+				<li class="content-treeview<% if ViewState == tree %> ui-tabs-active ss-tabs-force-active<% end_if %> cms-tabset-icon tree">
 					<a href="#cms-content-treeview" class="cms-panel-link" data-href="$LinkTreeView"><% _t('CMSPagesController.TreeView', 'Tree View') %></a>
 				</li>
-				<li class="content-listview<% if ViewState == list %> ui-tabs-active<% end_if %> cms-tabset-icon list">
+				<li class="content-listview<% if ViewState == list %> ui-tabs-active ss-tabs-force-active<% end_if %> cms-tabset-icon list">
 					<a href="#cms-content-listview" class="cms-panel-link" data-href="$LinkListView"><% _t('CMSPagesController.ListView', 'List View') %></a>
 				</li>
 				<!--


### PR DESCRIPTION
Allows for easier navigation between tree and list,
particularly if a node has many children nodes
(since it doesn't require expanding that node).

Uses a new 'ss-tabs-force-active' class on the tabset
to enforce the correct view state. This also fixes an issue
where you couldn't link to a list view directly via URL.

Depends on https://github.com/silverstripe/sapphire/pull/1288 being merged in.

![](https://api.monosnap.com/image/download?id=Hj1q1DFQhCidfwhlyNISSRLzw)
