### PR TITLE
NEW SiteTree->updateCmsListViewForm() to modify the displayed list

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -734,7 +734,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	
 	public function ListViewForm() {
 		$params = $this->request->requestVar('q');
-		$list = $this->getList($params, $parentID = $this->request->requestVar('ParentID'));
+		$parentID = $this->request->requestVar('ParentID');
+		$list = $this->getList($params, $parentID);
+		$parent = $parentID ? $this->getRecord($parentID) : singleton($this->stat('tree_class'));
+		
 		$gridFieldConfig = GridFieldConfig::create()->addComponents(			
 			new GridFieldSortableHeader(),
 			new GridFieldDataColumns(),
@@ -796,6 +799,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$listview->setAttribute('data-pjax-fragment', 'ListViewForm');
 
 		$this->extend('updateListView', $listview);
+
+		if($parent->hasMethod('updateCmsListViewForm')) {
+			$parent->updateCmsListViewForm($listview);
+		}
 		
 		$listview->disableSecurityToken();
 		return $listview;

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2206,6 +2206,17 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		return $actions;
 	}
+
+	/**
+	 * Update the form provided by {@link CMSMain->ListViewForm()},
+	 * e.g. to customize the data source of its children,
+	 * or alter the GridField capabilities.
+	 * 
+	 * @param Form $form
+	 */
+	public function updateCmsListViewForm(Form &$form) {
+		// no-op
+	}
 	
 	/**
 	 * Publish this page.


### PR DESCRIPTION
I'm aware this adds a bit more clutter to an already cluttered SiteTree, but in the end its consistent with `getCMSFields()`. We could change it into more of a listener pattern, but this implies either new class structures or anonymous functions defined on every invocation.
It would also remove the abilities for inheritance, e.g. to decide on a specific implementation if the parent functionality should be invoked.

The naming is following the new coding conventions with proper camel casing. I think its the lesser of two evils (vs. keeping it consistent with uppercased CMS elsewhere, and creating more deprecations later on).

Docs for the feature are in https://github.com/silverstripe/sapphire/pull/1291
