### PR TITLE
Re-indexed disallowed array because of json_encode issue

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -422,7 +422,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				// then add the ones which are globally disallowed.
 				$disallowed = array_diff($classes, (array)$allowed);
 				$disallowed = array_unique(array_merge($disallowed, $globalDisallowed));
-				if($disallowed) $def[$class]['disallowedChildren'] = $disallowed;
+				// Re-index the array for JSON non sequential key issue
+				if($disallowed) $def[$class]['disallowedChildren'] = array_values($disallowed);
 
 				$defaultChild = $obj->defaultChild();
 				if($defaultChild != 'Page' && $defaultChild != null) {


### PR DESCRIPTION
Re-indexed disallowed array because of json_encode issue with non-sequential array

See example #3 here: http://www.php.net/manual/en/function.json-encode.php

If we are dealing with a non-sequential array json_encode transform it into an object, so CMSMain.Tree.js can't handle it, resulting in $allowed_children and $can_create (and maybe others) not honored in contextual menu.
