### PR TITLE
FIX Use SSViewer.theme_enabled in CMS logic

### DIFF
--- a/code/model/ErrorPage.php
+++ b/code/model/ErrorPage.php
@@ -205,10 +205,10 @@ class ErrorPage extends Page {
 		parent::doPublish();
 
 		// Run the page (reset the theme, it might've been disabled by LeftAndMain::init())
-		$oldTheme = Config::inst()->get('SSViewer', 'theme');
-		Config::inst()->update('SSViewer', 'theme', Config::inst()->get('SSViewer', 'custom_theme'));
+		$oldEnabled = Config::inst()->get('SSViewer', 'theme_enabled');
+		Config::inst()->update('SSViewer', 'theme_enabled', true);
 		$response = Director::test(Director::makeRelative($this->Link()));
-		Config::inst()->update('SSViewer', 'theme', $oldTheme);
+		Config::inst()->update('SSViewer', 'theme_enabled', $oldEnabled);
 
 		$errorContent = $response->getBody();
 		

--- a/code/staticpublisher/FilesystemPublisher.php
+++ b/code/staticpublisher/FilesystemPublisher.php
@@ -172,11 +172,13 @@ class FilesystemPublisher extends StaticPublisher {
 		// Set the appropriate theme for this publication batch.
 		// This may have been set explicitly via StaticPublisher::static_publisher_theme,
 		// or we can use the last non-null theme.
+		$origThemeEnabled = Config::inst()->get('SSViewer', 'theme_enabled');
+		Config::inst()->update('SSViewer', 'theme_enabled', true);
 		$customTheme = Config::inst()->get('StaticPublisher', 'static_publisher_theme');
-		if(!$customTheme)
-			Config::inst()->update('SSViewer', 'theme', Config::inst()->get('SSViewer', 'custom_theme'));
-		else
+		if($customTheme) {
+			$origTheme = Config::inst()->get('SSViewer', 'theme');
 			Config::inst()->update('SSViewer', 'theme', $customTheme);
+		}
 			
 		$currentBaseURL = Director::baseURL();
 		$staticBaseUrl = Config::inst()->get('FilesystemPublisher', 'static_base_url');
@@ -312,6 +314,11 @@ class FilesystemPublisher extends StaticPublisher {
 			} else if(isset($file['Copy'])) {
 				copy($file['Copy'], $path);
 			}
+		}
+
+		Config::inst()->update('SSViewer', 'theme_enabled', $origThemeEnabled);
+		if($customTheme) {
+			Config::inst()->update('SSViewer', 'theme', $origTheme);
 		}
 
 		return $result;

--- a/tests/staticpublisher/FilesystemPublisherTest.php
+++ b/tests/staticpublisher/FilesystemPublisherTest.php
@@ -126,23 +126,16 @@ class FilesystemPublisherTest extends SapphireTest {
 	 * StaticPublishing needs to be able to retrieve a non-null theme at the time publishPages() is called.
 	 */
 	public function testStaticPublisherTheme(){
-		
-		//This will be the name of the default theme of this particular project
-		$default_theme= Config::inst()->get('SSViewer', 'theme');
-		
 		$p1 = new Page();
 		$p1->URLSegment = strtolower(__CLASS__).'-page-1';
 		$p1->HomepageForDomain = '';
 		$p1->write();
 		$p1->doPublish();
 		
-		$current_theme=Config::inst()->get('SSViewer', 'custom_theme');
-		$this->assertEquals($current_theme, $default_theme, 'After a standard publication, the theme is correct');
-		
-		//The CMS sometimes sets the theme to null.  Check that the $current_custom_theme is still the default
-		Config::inst()->update('SSViewer', 'theme', null);
-		$current_theme=Config::inst()->get('SSViewer', 'custom_theme');
-		$this->assertEquals($current_theme, $default_theme, 'After a setting the theme to null, the default theme is correct');
+		$this->assertTrue(
+			Config::inst()->get('SSViewer', 'theme_enabled'), 
+			'After a standard publication, the theme is still enabled'
+		);
 	}
 
 	function testPublishPages() {


### PR DESCRIPTION
The previously used SSViewer::current_custom_theme() has been
removed since we can't influence the setting of configuration values.

The 'theme_enabled' toggle is a cleaner solution to the same problem,
since the 'custom_theme' was really just a way to remember the original
theme, while still disabling it. The toggle makes this more explicit,
but also requires users of the 'theme' setting to check for it.

Depends on https://github.com/silverstripe/sapphire/pull/1340
