### PR TITLE
FIX 673 Prevent double execution of onmatch on cms-add-form FIX Properly...

### DIFF
--- a/javascript/CMSMain.AddForm.js
+++ b/javascript/CMSMain.AddForm.js
@@ -15,18 +15,12 @@
 		});
 		
 		$(".cms-add-form").entwine({
-			onmatch: function() {
-				if (this.hasClass('initialised')) return;
+			onadd: function() {
 				var self = this;
 				this.find('#ParentID .TreeDropdownField').bind('change', function() {
 					self.updateTypeList();
 				});
 				this.updateTypeList();
-				this._super();
-				this.addClass('initialised');
-			},
-			onunmatch: function() {
-				this._super();
 			},
 			
 			/**


### PR DESCRIPTION
... selct the right item when choosing pagetype during new page creation

I'm not too proud to have to set a flag after the onmatch is performed, but onmatch is called a second time after the first click on one of the radio of the pagetype, and there's no known fix for that (see https://groups.google.com/forum/?fromgroups=#!topic/jquery-entwine/Y0mDxM_kHbQ)
