### PR TITLE
BUGFIX Use onadd instead of onmatch on cms-add-form when creating new pa...

### DIFF
--- a/javascript/CMSMain.AddForm.js
+++ b/javascript/CMSMain.AddForm.js
@@ -15,16 +15,12 @@
 		});
 		
 		$(".cms-add-form").entwine({
-			onmatch: function() {
+			onadd: function() {
 				var self = this;
 				this.find('#ParentID .TreeDropdownField').bind('change', function() {
 					self.updateTypeList();
 				});
 				this.updateTypeList();
-				this._super();
-			},
-			onunmatch: function() {
-				this._super();
 			},
 			
 			/**


### PR DESCRIPTION
...ge #673
This is a better fix than what I pushed in #674. Using onadd instead of onmatch as recommended by @hafriedlander
