### PR TITLE
Better UI feedback on VirtualPage states (fixes #1594)

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -395,9 +395,9 @@ en:
     CANACCESS: 'You can access the archived site at this link:'
     HAVEASKED: 'You have asked to view the content of our site on'
   VirtualPage:
-    CHOOSE: 'Choose a page to link to'
+    CHOOSE: 'Linked Page'
     DESCRIPTION: 'Displays the content of another page'
-    EDITCONTENT: 'click here to edit the content'
+    EDITCONTENT: 'Edit content on linked page'
     HEADER: 'This is a virtual page'
     PLURALNAME: 'Virtual Pags'
     PageTypNotAllowedOnRoot: 'Original page type "{type}" is not allowed on the root level for this virtual page'


### PR DESCRIPTION
Changes:
- Changed header styling into a message panel. 
- Added a "Please publish the linked page in order to publish the virtual page." message
- Added "Please choose a linked page and save first in order to publish this page" message
- Removed "click here to edit" link, incorporated into message with clearer "edit" link and original page title

UI:
- With published linked page: http://monosnap.com/image/ojMbU0H4nz9Q9Ztj3KJGF72OP
- With unpublished linked page: http://monosnap.com/image/PM4HUPYLHDG1mOzkaLiTeiSWu
- Without linked page: http://monosnap.com/image/yKs4FRf3hO1hHPPxLonWsBYTh

This still leaves some inconsistencies. Most importantly, you need to click "save" before you're allowed to publish the first time you link to page. Since this depends on PHP conditional logic, its not easy to replicate in JS. We can't just add the "publish" button and hide it, since that button relies on the `canPublish()` method on the model, which in turn has an impact on other behaviour which still needs to be enforced. Its not uncommon that you need to save the page in order for UI changes to have an effect in SS, that's an architectural limitation, which at the same time allows us to build very powerful UIs in PHP. Replicating each of these behaviours in JS will end up a mess, so for now we should just indicate when a UI needs to be refreshed to the user.
