### PR TITLE
Page history panel: show appropriate message when viewing latest version

### DIFF
--- a/code/controllers/CMSPageHistoryController.php
+++ b/code/controllers/CMSPageHistoryController.php
@@ -142,13 +142,16 @@ class CMSPageHistoryController extends CMSMain {
 			);
 			
 			$revert->setReadonly(true);
-		}
-		else {
-			$message = _t(
-				'CMSPageHistoryController.VIEWINGVERSION',
-				"Currently viewing version {version}.", 
-				array('version' => $versionID)
-			);
+		} else {
+			if($record->isLatestVersion()) {
+				$message = _t('CMSPageHistoryController.VIEWINGLATEST', 'Currently viewing the latest version.');
+			} else {
+				$message = _t(
+					'CMSPageHistoryController.VIEWINGVERSION',
+					"Currently viewing version {version}.",
+					array('version' => $versionID)
+				);
+			}
 		}
 		
 		$fields->addFieldToTab('Root.Main', 

--- a/tests/controller/CMSPageHistoryControllerTest.php
+++ b/tests/controller/CMSPageHistoryControllerTest.php
@@ -52,7 +52,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest {
 		$this->assertEquals($this->versionPublishCheck2, $form->Fields()->dataFieldByName('Version')->Value());
 
 		$this->assertContains(
-			sprintf("Currently viewing version %s.", $this->versionPublishCheck2),
+			'Currently viewing the latest version',
 			$form->Fields()->fieldByName('Root.Main.CurrentlyViewingMessage')->getContent()
 		);
 		


### PR DESCRIPTION
Show a more useful "Currently viewing latest version" instead of "Currently viewing version x" when viewing the latest version for a page.
