### PR TITLE
Return 410 for successfullyinstalled after install files are gone

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -372,6 +372,10 @@ HTML;
 	 * This action is called by the installation system
 	 */
 	public function successfullyinstalled() {
+		// Return 410 Gone if this site is not actually a fresh installation
+		if (!file_exists(BASE_PATH . '/install.php')) {
+			$this->httpError(410);
+		}
 		// The manifest should be built by now, so it's safe to publish the 404 page
 		$fourohfour = Versioned::get_one_by_stage('ErrorPage', 'Stage', '"ErrorCode" = 404');
 		if($fourohfour) {


### PR DESCRIPTION
It was possible to append '/successfullyinstalled' to any SilverStripe
URL (with the cms module present), and the code would run, including
republishing the 404 page.

Now, if the install.php file is gone, this controller method throws the
410 (Gone) status code. The 410 status is chosen rather than 404 to
mitigate the likelihood that crawlers such as the Googlebot will follow
stray links to this URI.
