### PR TITLE
API Added SiteTreeExtension::updateRelativeLink

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -462,22 +462,19 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function RelativeLink($action = null) {
 		if($this->ParentID && self::config()->nested_urls) {
 			$base = $this->Parent()->RelativeLink($this->URLSegment);
+		} elseif(!$action && $this->URLSegment == RootURLController::get_homepage_link()) {
+			// Unset base for root-level homepages.
+			// Note: Homepages with action parameters (or $action === true) 
+			// need to retain their URLSegment.
+			$base = null;
 		} else {
 			$base = $this->URLSegment;
 		}
 		
-		// Unset base for homepage URLSegments in their default language.
-		// Homepages with action parameters or in different languages
-		// need to retain their URLSegment. We can only do this if the homepage
-		// is on the root level.
-		if(!$action && $base == RootURLController::get_homepage_link() && !$this->ParentID) {
-			$base = null;
-			if(class_exists('Translatable') && $this->hasExtension('Translatable') && $this->Locale != Translatable::default_locale()){ 
-				$base = $this->URLSegment; 
-			}
-		}
+		$this->extend('updateRelativeLink', $base, $action);
 		
-		// Legacy support
+		// Legacy support: If $action === true, retain URLSegment for homepages,
+		// but don't append any action
 		if($action === true) $action = null;
 
 		return Controller::join_links($base, '/', $action);

--- a/code/model/SiteTreeExtension.php
+++ b/code/model/SiteTreeExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Plug-ins for additional functionality in your SiteTree classes.
  * 
@@ -7,23 +8,71 @@
  */
 abstract class SiteTreeExtension extends DataExtension {
 
+	/**
+	 * Hook called before the page's {@link SiteTree::doPublish()} action is completed
+	 * 
+	 * @param SiteTree &$original The current Live SiteTree record prior to publish
+	 */
 	public function onBeforePublish(&$original) {
 	}
 
+	/**
+	 * Hook called after the page's {@link SiteTree::doPublish()} action is completed
+	 * 
+	 * @param SiteTree &$original The current Live SiteTree record prior to publish
+	 */
 	public function onAfterPublish(&$original) {
 	}
 	
+	/**
+	 * Hook called before the page's {@link SiteTree::doUnpublish()} action is completed
+	 */
 	public function onBeforeUnpublish() {
 	}
 	
+	
+	/**
+	 * Hook called after the page's {@link SiteTree::doUnpublish()} action is completed
+	 */
 	public function onAfterUnpublish() {
 	}
 	
+	/**
+	 * Hook called to determine if a user may add children to this SiteTree object
+	 * 
+	 * @see SiteTree::canAddChildren()
+	 * 
+	 * @param Member $member The member to check permission against, or the currently
+	 * logged in user
+	 * @return boolean|null Return false to deny rights, or null to yield to default
+	 */
 	public function canAddChildren($member) {
 	}
 	
+	/**
+	 * Hook called to determine if a user may publish this SiteTree object
+	 * 
+	 * @see SiteTree::canPublish()
+	 * 
+	 * @param Member $member The member to check permission against, or the currently
+	 * logged in user
+	 * @return boolean|null Return false to deny rights, or null to yield to default
+	 */
 	public function canPublish($member) {
-		
+	}
+	
+	/**
+	 * Hook called to modify the $base url of this page, with a given $action,
+	 * before {@link SiteTree::RelativeLink()} calls {@link Controller::join_links()}
+	 * on the $base and $action
+	 * 
+	 * @param string &$base The URL of this page relative to siteroot, not including
+	 * the action
+	 * @param string|boolean &$action The action or subpage called on this page.
+	 * (Legacy support) If this is true, then do not reduce the 'home' urlsegment
+	 * to an empty link
+	 */
+	public function updateRelativeLink(&$base, &$action) {
 	}
 
 }


### PR DESCRIPTION
This API update finally gives extensions the ability to interact with SiteTree urls, so modules such as Translatable, and other SEO-based ones, can do so without requiring hard coding or requiring users to override RelativeLink.

I've refactored out the Translatable hook here and moved it to another pull request for the translatable module at https://github.com/silverstripe/silverstripe-translatable/pull/109

I also have two other modules in mind waiting on this functionality. :)
