### PR TITLE
FIX Escape the sitetree_link shortcode return value

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -400,11 +400,13 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		) {
 			 return; // There were no suitable matches at all.
 		}
+
+		$link = Convert::raw2att($page->Link());
 		
 		if($content) {
-			return sprintf('<a href="%s">%s</a>', $page->Link(), $parser->parse($content));
+			return sprintf('<a href="%s">%s</a>', $link, $parser->parse($content));
 		} else {
-			return $page->Link();
+			return $link;
 		}
 	}
 	

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -554,6 +554,7 @@ class SiteTreeTest extends SapphireTest {
 	public function testLinkShortcodeHandler() {
 		$aboutPage = $this->objFromFixture('Page', 'about');
 		$errorPage = $this->objFromFixture('ErrorPage', '404');
+		$redirectPage = $this->objFromFixture('RedirectorPage', 'external');
 		
 		$parser = new ShortcodeParser();
 		$parser->register('sitetree_link', array('SiteTree', 'link_shortcode_handler'));
@@ -580,6 +581,13 @@ class SiteTreeTest extends SapphireTest {
 		
 		$this->assertEquals($aboutShortcodeExpected, $parser->parse($aboutShortcode), 'Test link to 404 page if no suitable matches.');
 		$this->assertEquals($aboutEnclosedExpected, $parser->parse($aboutEnclosed));
+
+		$redirectShortcode = sprintf('[sitetree_link,id=%d]', $redirectPage->ID);
+		$redirectEnclosed  = sprintf('[sitetree_link,id=%d]Example Content[/sitetree_link]', $redirectPage->ID);
+		$redirectExpected = 'http://www.google.com?a&amp;b';
+
+		$this->assertEquals($redirectExpected, $parser->parse($redirectShortcode));
+		$this->assertEquals(sprintf('<a href="%s">Example Content</a>', $redirectExpected), $parser->parse($redirectEnclosed));
 		
 		$this->assertEquals('', $parser->parse('[sitetree_link]'), 'Test that invalid ID attributes are not parsed.');
 		$this->assertEquals('', $parser->parse('[sitetree_link,id="text"]'));

--- a/tests/model/SiteTreeTest.yml
+++ b/tests/model/SiteTreeTest.yml
@@ -80,3 +80,11 @@ ErrorPage:
     404:
         Title: Page not Found
         ErrorCode: 404
+
+RedirectorPage:
+   external:
+      Title: External
+      URLSegment: external
+      RedirectionType: External
+      ExternalURL: "http://www.google.com?a&b"
+


### PR DESCRIPTION
This matters when there's a redirector page to an external link with an ampersand in it.
