### PR TITLE
FIX 'Add new' page button missing ParentID

### DIFF
--- a/javascript/CMSMain.AddForm.js
+++ b/javascript/CMSMain.AddForm.js
@@ -99,8 +99,9 @@
 				}
 					
 				var data = {selector: this.data('targetPanel'),pjax: this.data('pjax')}, url;
-				if(parentID) {
-					url = $.path.addSearchParams(ss.i18n.sprintf(this.data('urlAddpage'), parentId), this.data('extraParams'));
+				if(parentId) {
+					extraParams = this.data('extraParams') ? this.data('extraParams') : '';
+					url = $.path.addSearchParams(ss.i18n.sprintf(this.data('urlAddpage'), parentId), extraParams);
 				} else {
 					url = this.attr('href');
 				}


### PR DESCRIPTION
Slight typo causing this. Also slightly amended how extra URL parameters are tagged on to prevent `&undefined` being appended to URL.
