### PR TITLE
Update doRollback messages to work well with the new reverts.

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -1092,15 +1092,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		if($version) {
 			$record->doRollbackTo($version);
 			$message = _t(
-				'CMSMain.ROLLEDBACKVERSION',
-				"Rolled back to version #%d.  New version number is #%d",
-				array('version' => $data['Version'], 'versionnew' => $record->Version)
+				'CMSMain.ROLLEDBACKVERSIONv2',
+				"Rolled back to version #%d.",
+				array('version' => $data['Version'])
 			);
 		} else {
 			$record->doRollbackTo('Live');
 			$message = _t(
-				'CMSMain.ROLLEDBACKPUB',"Rolled back to published version. New version number is #{version}",
-				array('version' => $record->Version)
+				'CMSMain.ROLLEDBACKPUBv2',"Rolled back to published version."
 			);
 		}
 

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -101,8 +101,8 @@ en:
     RESTORE: Restore
     RESTORED: 'Restored ''{title}'' successfully'
     ROLLBACK: 'Roll back to this version'
-    ROLLEDBACKPUB: 'Rolled back to published version. New version number is #{version}'
-    ROLLEDBACKVERSION: 'Rolled back to version #%d.  New version number is #%d'
+    ROLLEDBACKPUBv2: 'Rolled back to published version.'
+    ROLLEDBACKVERSIONv2: 'Rolled back to version #%d.'
     SAVE: Save
     SAVEDRAFT: 'Save Draft'
     TabContent: Content


### PR DESCRIPTION
Currently reverts are not creating the new versions anymore - they are
simply copying the Version over. Remove incorrect message about new
version creation and remove the "cancel draft changes" message that's
not correct.
