### PR TITLE
API Add a missing hook so we can override the SiteTree preview link.

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -446,7 +446,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return string
 	 */
 	public function PreviewLink($action = null) {
-		return $this->AbsoluteLink($action);
+		if($this->hasMethod('alternatePreviewLink')) {
+			return $this->alternatePreviewLink($action);
+		} else {
+			return $this->AbsoluteLink($action);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
Maybe still acceptable under 3.1? I could argue it's a bug ;) I need it for some Subsite fixes.
