### PR TITLE
Fix Issue #750

### DIFF
--- a/javascript/CMSMain.Tree.js
+++ b/javascript/CMSMain.Tree.js
@@ -29,7 +29,7 @@
 						var menuitems = 
 							{
 								'edit': {
-									'label': ss.i18n._t('Tree.EditPage'),
+									'label': ss.i18n._t('Tree.EditPage', 'Edit page', 100, 'Used in the context menu when right-clicking on a page node in the CMS tree'),
 									'action': function(obj) {
 										$('.cms-container').entwine('.ss').loadPanel(ss.i18n.sprintf(
 											self.data('urlEditpage'), obj.data('id')
@@ -40,7 +40,7 @@
 						// Test if there are any allowed Children and thus the possibility of adding some 
 						if(allowedChildren.hasOwnProperty('allowedchildren-0')) {
 							menuitems['addsubpage'] = {
-									'label': ss.i18n._t('Tree.AddSubPage'),
+									'label': ss.i18n._t('Tree.AddSubPage', 'Add page under this page', 100, 'Used in the context menu when right-clicking on a page node in the CMS tree'),
 									'submenu': allowedChildren
 								};
 						}				


### PR DESCRIPTION
Add default params to _t() calls to ensure if a translation isn't found for the CMSMain tree context menus, it falls back to a useful English string
