### PR TITLE
BUGFIX: Content authors with SiteTree#canView() but not SiteTree#canEdit...

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2657,7 +2657,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if(!$this->canAddChildren())
 			$classes .= " nochildren";
 
-		if(!$this->canEdit() && !$this->canAddChildren()) 
+		if(!$this->canView() && !$this->canEdit() && !$this->canAddChildren())
 			$classes .= " disabled";
 
 		if(!$this->ShowInMenus) 


### PR DESCRIPTION
```
BUGFIX: Content authors without SiteTree#canEdit() but that did have SiteTree#canView(), were unable to click on SiteTree items in the CMS.
- The 'disabled' attribute in <li> will now only render if the author _really_ can't do _anything_
```
