### PR TITLE
FIX Correct page title shown when restoring a page, instead of html of t...

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -1259,7 +1259,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			rawurlencode(_t(
 				'CMSMain.RESTORED',
 				"Restored '{title}' successfully", 
-				array('title' => $restoredPage->TreeTitle)
+				array('title' => $restoredPage->Title)
 			))
 		);
 		


### PR DESCRIPTION
...ree node. That is a fix for the regression mentioned in https://github.com/silverstripe/silverstripe-framework/pull/1996

Reproduction step:
- Delete a draft
- Restore the draft, observe the success message is "Restored <some HTML/> successfully", as opposed to "Restored 'My page' successfully". 

This patch addresses this issue
