### PR TITLE
BUG Fixing regression from silverstripe/sapphire/67d1327

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2621,7 +2621,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			if(is_string($data)) $data = array('text' => $data);
 			$treeTitle .= sprintf(
 				"<span class=\"badge %s\"%s>%s</span>",
-				Convert::raw2xml($class),
+				'status-' . Convert::raw2xml($class),
 				(isset($data['title'])) ? sprintf(' title="%s"', Convert::raw2xml($data['title'])) : '',
 				Convert::raw2xml($data['text'])
 			);


### PR DESCRIPTION
Status flag classes didn't pick up styling because the flag was changed to prefix "status-" in https://github.com/silverstripe/silverstripe-framework/commit/67d1327b90187b25877af05fbb5046176153ef92

This fixes it to prefix all the flag classes with "status-" so the styling is picked up correctly.
