### PR TITLE
FIX #651 Broken redirection after creating new folder in assets

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -491,6 +491,7 @@ JS
 				return $folder;
 			}
 		}
+		$this->setCurrentPageID(null);
 		return new Folder();
 	}
 	


### PR DESCRIPTION
If opening the root asset folder and no current page is set, then by resetting the current page id to null appears to fix the issue.
