### PR TITLE
BUG: fixed "regression"  adding a new class to SiteTree elem (edit-disabled) 

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2651,17 +2651,27 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	public function CMSTreeClasses() {
 		$classes = sprintf('class-%s', $this->class);
-		if($this->HasBrokenFile || $this->HasBrokenLink)
+		if($this->HasBrokenFile || $this->HasBrokenLink) {
 			$classes .= " BrokenLink";
+		}
 
-		if(!$this->canAddChildren())
+		if(!$this->canAddChildren()) {
 			$classes .= " nochildren";
+		}
 
-		if(!$this->canView() && !$this->canEdit() && !$this->canAddChildren())
-			$classes .= " disabled";
+		if(!$this->canEdit() && !$this->canAddChildren()) {
+			if (!$this->canView()) {
+				$classes .= " disabled";
+			} else {
+				$classes .= " edit-disabled";
+			}
+		}
+		elseif (!$this->canEdit() && !$this->canAddChildren())
+			
 
-		if(!$this->ShowInMenus) 
+		if(!$this->ShowInMenus) {
 			$classes .= " notinmenu";
+		}
 			
 		//TODO: Add integration
 		/*


### PR DESCRIPTION
regression inserted with 9281ebc64764a58f86f685f9765e1d8b60995e5a

related to https://github.com/silverstripe/silverstripe-framework/pull/2039
