### PR TITLE
Add generic notice class to filter panels

### DIFF
--- a/templates/Includes/CMSMain_ListView.ss
+++ b/templates/Includes/CMSMain_ListView.ss
@@ -8,7 +8,7 @@
 
 <div class="cms-panel-content center">
 	<% if TreeIsFiltered %>
-	<div class="cms-tree-filtered">
+	<div class="cms-tree-filtered cms-notice">
 		<strong><% _t('CMSMain.ListFiltered', 'Filtered list.') %></strong>
 		<a href="$LinkPages" class="cms-panel-link">
 			<% _t('CMSMain.TreeFilteredClear', 'Clear filter') %>

--- a/templates/Includes/CMSMain_TreeView.ss
+++ b/templates/Includes/CMSMain_TreeView.ss
@@ -11,7 +11,7 @@ $ExtraTreeTools
 
 <div class="center">
 	<% if TreeIsFiltered %>
-	<div class="cms-tree-filtered">
+	<div class="cms-tree-filtered cms-notice">
 		<strong><% _t('CMSMain.TreeFiltered', 'Filtered tree.') %></strong>
 		<a href="$LinkPages" class="cms-panel-link">
 			<% _t('CMSMain.TreeFilteredClear', 'Clear filter') %>


### PR DESCRIPTION
- Added cms-notice class to filter panels for easier reuse of styles

(See this pull request for styling implementation: https://github.com/silverstripe/silverstripe-framework/pull/2058)
