### PR TITLE
Using new CMSForm class to allow for validation errors in CMS

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -395,7 +395,7 @@ JS
 	
 	public function AddForm() {
 		$folder = singleton('Folder');
-		$form = new Form(
+		$form = CMSForm::create( 
 			$this,
 			'AddForm',
 			new FieldList(
@@ -407,7 +407,8 @@ JS
 					->addExtraClass('ss-ui-action-constructive')->setAttribute('data-icon', 'accept')
 					->setTitle(_t('AssetAdmin.ActionAdd', 'Add folder'))
 			)
-		);
+		)->setHTMLID('Form_AddForm');
+		$form->setResponseNegotiator($this->getResponseNegotiator());
 		$form->setTemplate($this->getTemplatesWithSuffix('_EditForm'));
 		// TODO Can't merge $FormAttributes in template at the moment
 		$form->addExtraClass('add-form cms-add-form cms-edit-form cms-panel-padded center ' . $this->BaseCSSClasses());

--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -76,7 +76,7 @@ class CMSFileAddController extends LeftAndMain {
 		asort($exts);
 		$uploadField->Extensions = implode(', ', $exts);
 
-		$form = new Form(
+		$form = CMSForm::create( 
 			$this,
 			'getEditForm',
 			new FieldList(
@@ -84,7 +84,8 @@ class CMSFileAddController extends LeftAndMain {
 				new HiddenField('ID')
 			),
 			new FieldList()
-		);
+		)->setHTMLID('Form_getEditForm');
+		$form->setResponseNegotiator($this->getResponseNegotiator());
 		$form->addExtraClass('center cms-edit-form ' . $this->BaseCSSClasses());
 		// Don't use AssetAdmin_EditForm, as it assumes a different panel structure
 		$form->setTemplate($this->getTemplatesWithSuffix('_EditForm'));

--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -663,7 +663,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				$validator = new RequiredFields();
 			}
 			
-			$form = new Form($this, "EditForm", $fields, $actions, $validator);
+			$form = CMSForm::create( 
+				$this, "EditForm", $fields, $actions, $validator
+			)->setHTMLID('Form_EditForm');
+			$form->setResponseNegotiator($this->getResponseNegotiator());
 			$form->loadDataFrom($record);
 			$form->disableDefaultAction();
 			$form->addExtraClass('cms-edit-form');
@@ -686,9 +689,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			$this->extend('updateEditForm', $form);
 			return $form;
 		} else if($id) {
-			return new Form($this, "EditForm", new FieldList(
+			$form = CMSForm::create( $this, "EditForm", new FieldList(
 				new LabelField('PageDoesntExistLabel',_t('CMSMain.PAGENOTEXISTS',"This page doesn't exist"))), new FieldList()
-			);
+			)->setHTMLID('Form_EditForm');
+			$form->setResponseNegotiator($this->getResponseNegotiator());
+			return $form;
 		}
 	}
 
@@ -788,13 +793,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			}
 		));
 		
-		$listview = new Form(
+		$listview = CMSForm::create( 
 			$this,
 			'ListViewForm',
 			new FieldList($gridField),
 			new FieldList()
-		);
+		)->setHTMLID('Form_ListViewForm');
 		$listview->setAttribute('data-pjax-fragment', 'ListViewForm');
+		$listview->setResponseNegotiator($this->getResponseNegotiator());
 
 		$this->extend('updateListView', $listview);
 		

--- a/code/controllers/CMSPageAddController.php
+++ b/code/controllers/CMSPageAddController.php
@@ -106,7 +106,10 @@ class CMSPageAddController extends CMSPageEditController {
 		
 		$this->extend('updatePageOptions', $fields);
 		
-		$form = new Form($this, "AddForm", $fields, $actions);
+		$form = CMSForm::create( 
+			$this, "AddForm", $fields, $actions
+		)->setHTMLID('Form_AddForm');
+		$form->setResponseNegotiator($this->getResponseNegotiator());
 		$form->addExtraClass('cms-add-form stacked cms-content center cms-edit-form ' . $this->BaseCSSClasses());
 		$form->setTemplate($this->getTemplatesWithSuffix('_EditForm'));
 

--- a/code/controllers/CMSPageHistoryController.php
+++ b/code/controllers/CMSPageHistoryController.php
@@ -251,13 +251,13 @@ class CMSPageHistoryController extends CMSMain {
 		// Use <button> to allow full jQuery UI styling
 		foreach($actions->dataFields() as $action) $action->setUseButtonTag(true);
 
-		$form = new Form(
+		$form = CMSForm::create( 
 			$this,
 			'VersionsForm',
 			$fields,
 			$actions
-		);
-		
+		)->setHTMLID('Form_VersionsForm');
+		$form->setResponseNegotiator($this->getResponseNegotiator());
 		$form->loadDataFrom($this->request->requestVars());
 		$hiddenID->setValue($id);
 		$form->unsetValidator();

--- a/code/controllers/CMSSettingsController.php
+++ b/code/controllers/CMSSettingsController.php
@@ -37,7 +37,10 @@ class CMSSettingsController extends LeftAndMain {
 		$navField->setAllowHTML(true);
 
 		$actions = $siteConfig->getCMSActions();
-		$form = new Form($this, 'EditForm', $fields, $actions);
+		$form = CMSForm::create( 
+			$this, 'EditForm', $fields, $actions
+		)->setHTMLID('Form_EditForm');
+		$form->setResponseNegotiator($this->getResponseNegotiator());
 		$form->addExtraClass('root-form');
 		$form->addExtraClass('cms-edit-form cms-panel-padded center');
 		// don't add data-pjax-fragment=CurrentForm, its added in the content template instead

--- a/code/controllers/ReportAdmin.php
+++ b/code/controllers/ReportAdmin.php
@@ -171,7 +171,10 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider {
 		}
 
 		$actions = new FieldList();
-		$form = new Form($this, "EditForm", $fields, $actions);
+		$form = CMSForm::create( 
+			$this, "EditForm", $fields, $actions
+		)->setHTMLID('Form_EditForm');
+		$form->setResponseNegotiator($this->getResponseNegotiator());
 		$form->addExtraClass('cms-edit-form cms-panel-padded center ' . $this->BaseCSSClasses());
 		$form->loadDataFrom($this->request->getVars());
 


### PR DESCRIPTION
This class allows deferring handling of responses to the parent
controller's response negotiator implementation.

Related framework PR: https://github.com/silverstripe/silverstripe-framework/pull/2084

See https://github.com/silverstripe/silverstripe-framework/pull/1814 for discussion.
