### PR TITLE
API SiteTree->validURLSegment() prioritizes extension votes

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1588,20 +1588,20 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			}
 		}
 		
+		$votes = array_filter(
+			(array)$this->extend('augmentValidURLSegment'), 
+			function($v) {return !is_null($v);}
+		);
+		if($votes) {
+			return min($votes);
+		}
+
 		$existingPage = DataObject::get_one(
 			'SiteTree', 
 			"\"URLSegment\" = '$this->URLSegment' $IDFilter $parentFilter"
 		);
-		if ($existingPage) {
-			return false;
-		}
-
-		$votes = $this->extend('augmentValidURLSegment');
-		if($votes) {
-			return min($votes);
-		}
 		
-		return true;
+		return !($existingPage);
 	}
 	
 	/**

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -4,8 +4,9 @@
  * @subpackage tests
  */
 class SiteTreeTest extends SapphireTest {
-	protected static $fixture_file = 'SiteTreeTest.yml';
 	
+	protected static $fixture_file = 'SiteTreeTest.yml';
+
 	protected $illegalExtensions = array(
 		'SiteTree' => array('SiteTreeSubsites')
 	);
@@ -700,6 +701,18 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertTrue($sitetree->validURLSegment(), 'Valid URLSegment values are allowed');
 	}
 
+	public function testURLSegmentPrioritizesExtensionVotes() {
+		$sitetree = new SiteTree();
+		$sitetree->URLSegment = 'unique-segment';
+		$this->assertTrue($sitetree->validURLSegment());
+
+		SiteTree::add_extension('SiteTreeTest_Extension');
+		$sitetree = new SiteTree();
+		$sitetree->URLSegment = 'unique-segment';
+		$this->assertFalse($sitetree->validURLSegment());
+		SiteTree::remove_extension('SiteTreeTest_Extension');
+	}
+
 	public function testURLSegmentMultiByte() {
 		$origAllow = Config::inst()->get('URLSegmentFilter', 'default_allow_multibyte');
 		Config::inst()->update('URLSegmentFilter', 'default_allow_multibyte', true);
@@ -959,4 +972,12 @@ class SiteTreeTest_StageStatusInherit extends SiteTree implements TestOnly {
 		$flags['inherited-class'] = "InheritedTitle";
 		return $flags;
 	}
+}
+
+class SiteTreeTest_Extension extends DataExtension implements TestOnly {
+
+	public function augmentValidURLSegment() {
+		return false;
+	}
+
 }


### PR DESCRIPTION
Tri-state, use NULL to ignore the extension result. See https://github.com/silverstripe/silverstripe-cms/pull/216 for context.
