### PR TITLE
Refactor old page redirector into an extension

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -22,6 +22,8 @@ class ContentController extends Controller {
 
 	protected $dataRecord;
 
+	private static $extensions = array('OldPageRedirector');
+
 	private static $allowed_actions = array(
 		'successfullyinstalled',
 		'deleteinstallfiles', // secured through custom code
@@ -168,31 +170,6 @@ class ContentController extends Controller {
 				'URLSegment' => rawurlencode($action)
 			))->first();
 			if(class_exists('Translatable')) Translatable::enable_locale_filter();
-			
-			// if we can't find a page with this URLSegment try to find one that used to have 
-			// that URLSegment but changed. See ModelAsController->getNestedController() for similiar logic.
-			if(!$child){
-				$child = ModelAsController::find_old_page($action,$this->ID);
-				if($child){
-					$response = new SS_HTTPResponse();
-					$params = $request->getVars();
-					if(isset($params['url'])) unset($params['url']);
-					$response->redirect(
-						Controller::join_links(
-							$child->Link(
-								Controller::join_links(
-									$request->param('ID'), // 'ID' is the new 'URLSegment', everything shifts up one position
-									$request->param('OtherID')
-								)
-							),
-							// Needs to be in separate join links to avoid urlencoding
-							($params) ? '?' . http_build_query($params) : null
-						),
-						301
-					);
-					return $response;
-				}
-			}
 		}
 		
 		// we found a page with this URLSegment.

--- a/code/controllers/OldPageRedirector.php
+++ b/code/controllers/OldPageRedirector.php
@@ -1,0 +1,91 @@
+<?php
+
+class OldPageRedirector extends Extension {
+
+	/**
+	 * On every URL that generates a 404, we'll capture it here and see if we can
+	 * find an old URL that it should be redirecting to.
+	 *
+	 * @param SS_HTTPResponse $request The request object
+	 */
+	public function onBeforeHTTPError404($request) {
+		// Build up the request parameters
+		$params = array_filter(array_values($request->allParams()), function($v) { return ($v !== NULL); });
+
+		$getvars = $request->getVars();
+		unset($getvars['url']);
+
+		$page = self::find_old_page($params);
+
+		if ($page) {
+			$res = new SS_HTTPResponse();
+			$res->redirect(
+				Controller::join_links(
+					$page,
+					($getvars) ? '?' . http_build_query($getvars) : null
+				), 301);
+			throw new SS_HTTPResponse_Exception($res);
+		}
+	}
+
+	/**
+	 * Attempt to find an old/renamed page from some given the URL as an array
+	 *
+	 * @param array $params The array of URL, e.g. /foo/bar as array('foo', 'bar')
+	 * @param SiteTree $parent The current parent in the recursive flow
+	 * @param boolean $redirect Whether we've found an old page worthy of a redirect
+	 *
+	 * @return string|boolean False, or the new URL
+	 */
+	static public function find_old_page($params, $parent = null, $redirect = false) {
+		$URL = Convert::raw2sql(array_shift($params));
+		if (empty($URL)) { return false; }
+		if ($parent) {
+			$page = SiteTree::get()->filter(array('ParentID' => $parent->ID, 'URLSegment' => $URL))->First();
+		} else {
+			$page = SiteTree::get()->filter(array('URLSegment' => $URL))->First();
+		}
+
+		if (!$page) {
+			// If we haven't found a candidate, lets resort to finding an old page with this URL segment
+			// TODO: Rewrite using ORM syntax
+			$query = new SQLQuery (
+				'"RecordID"',
+				'"SiteTree_versions"',
+				"\"URLSegment\" = '$URL' AND \"WasPublished\" = 1" . ($parent ? ' AND "ParentID" = ' . $parent->ID : ''),
+				'"LastEdited" DESC',
+				null,
+				null,
+				1
+			);
+			$record = $query->execute()->first();
+			if ($record) {
+				$page = SiteTree::get()->byID($record['RecordID']);
+				$redirect = true;
+			}
+		}
+
+		if ($page && $page->canView()) {
+			if (count($params)) {
+				// We have to go deeper!
+				$ret = self::find_old_page($params, $page, $redirect);
+				if ($ret) {
+					// A valid child page was found! We can return it
+					return $ret;
+				} else {
+					// No valid page found.
+					if ($redirect) {
+						// If we had some redirect to be done, lets do it. imagine /foo/action -> /bar/action, we still want this redirect to happen if action isn't a page
+						return $page->Link() . implode('/', $params);
+					}
+				}
+			} else {
+				// We've found the final, end all, page.
+				return $page->Link();
+			}
+		}
+
+		return false;
+	}
+}
+


### PR DESCRIPTION
Would very much like to have this in 3.1, it's not an API break for anything I'm aware of.

Happy to add tests etc or change how it's done, this was just a first attempt at moving it out.

For reference, the use case for this is where you want to be able to put in your own redirect handler that will get called before finding the old pages. Currently, it's impossible. This will allow unloading the OldPageRedirector extension and loading yours in first.
