### PR TITLE
BUGFIX: HTML markup in ExtraMeta field being stripped out.

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1489,7 +1489,8 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		foreach($htmlFields as $field) {
 			$formField = new HTMLEditorField($field);
 			$formField->setValue($this->$field);
-			$formField->saveInto($this);
+			$formField->linkTracking();
+			$formField->imageTracking();
 		}
 		$this->extend('augmentSyncLinkTracking');
 	}


### PR DESCRIPTION
Refs silverstripe/silverstripe-cms#804.

Relies on https://github.com/silverstripe/silverstripe-framework/pull/2268. Link and image tracking should probably be moved out of HTMLEditorField and into silverstripe-cms at some point. Also, I am not currently set up with complete support for unit tests so this has undergone some manual testing but not unit testing.
