### PR TITLE
BUG: Context menu too long (Fixes #811)

### DIFF
--- a/javascript/CMSMain.Tree.js
+++ b/javascript/CMSMain.Tree.js
@@ -2,6 +2,40 @@
 
 	$.entwine('ss.tree', function($){
 		$('.cms-tree').entwine({
+			onadd: function(){
+				var self = this;
+				$(document).on('context_show.vakata', function(){
+					self.adjustContextClass(this);
+				});
+
+				this._super();
+			},
+			/*
+			 * Add and remove classes from context menus to allow for
+			 * adjusting the display
+			 */
+			adjustContextClass: function(){
+				var menus = $('#vakata-contextmenu').find("ul ul");
+
+				menus.each(function(i){
+					var col = "1", 
+						count = $(menus[i]).find('li').length;
+
+					//Assign columns to menus over 10 items long
+					if(count > 20){
+						col = "3"; 
+					}else if(count > 10){
+						col = "2"; 
+					}
+
+					$(menus[i]).addClass('col-' + col).removeClass('right');
+
+					//Remove "right" class that jstree adds on mouseenter
+					$(menus[i]).find('li').on("mouseenter", function (e) { 
+						$(this).parent('ul').removeClass("right");
+					});
+				});
+			},
 			getTreeConfig: function() {
 				var self = this, config = this._super(), hints = this.getHints();
 				config.plugins.push('contextmenu');
@@ -101,7 +135,7 @@
 										);
 									}
 								}
-							]									
+							]
 						};
 
 						return menuitems;


### PR DESCRIPTION
Added javascript to add and remove classes on context sub menus, to allow for multi column layout.

Linked to: https://github.com/silverstripe/silverstripe-framework/pull/2303

Tested on IE8, IE9, Chrome, and Firefox.

After:

![after](https://f.cloud.github.com/assets/984753/921736/175e4f3e-ff05-11e2-8c15-3896e1c6419d.png)
