### PR TITLE
FIX: GridField button styling in reports

### DIFF
--- a/code/reports/Report.php
+++ b/code/reports/Report.php
@@ -264,8 +264,9 @@ class SS_Report extends ViewableData {
 			new GridFieldSortableHeader(),
 			new GridFieldDataColumns(),
 			new GridFieldPaginator(),
-			new GridFieldPrintButton(),
-			new GridFieldExportButton()
+			new GridFieldButtonRow('after'),
+			new GridFieldPrintButton('buttons-after-left'),
+			new GridFieldExportButton('buttons-after-left')
 		);
 		$gridField = new GridField('Report',false, $items, $gridFieldConfig);
 		$columns = $gridField->getConfig()->getComponentByType('GridFieldDataColumns');


### PR DESCRIPTION
Ensure that `GridFieldPrintButton` and `GridFieldExportButton` are added to a `GridFieldButtonRow` before being added to the `GridField`. This follows the conventions from silverstripe/silverstripe-framework#2136.
