### PR TITLE
Fix test sometimes using cached relationship object.

### DIFF
--- a/tests/model/VirtualPageTest.php
+++ b/tests/model/VirtualPageTest.php
@@ -499,6 +499,8 @@ class VirtualPageTest extends SapphireTest {
 
 		$virtual = DataObject::get_by_id('VirtualPage', $virtual->ID, false);
 		$virtual->CopyContentFromID = $notRootPage->ID;
+		$virtual->flushCache();
+
 		$isDetected = false;
 		try {
 			$virtual->write();


### PR DESCRIPTION
In some circumstances, the CopyContentFrom page will be cached, so when
it is accessed the incorrect value was returned, meaning the test
would fail.
