### PR TITLE
Temporary FIX: Tree View Add New Button Parent ID Broken

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -205,7 +205,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	public function LinkPageAdd($extraArguments = null) {
 		$link = singleton("CMSPageAddController")->Link();
 		$this->extend('updateLinkPageAdd', $link);
-		if($extraArguments) $link = Controller::join_links ($link, $extraArguments);
+		if($extraArguments) $link = $link . $extraArguments;
 		return $link;
 	}
 	


### PR DESCRIPTION
In relation to: https://github.com/silverstripe/silverstripe-cms/issues/855

The %s in https://github.com/silverstripe/silverstripe-cms/blob/f937b95eaf2b74ee75b46ad56a44e9126a927690/templates/Includes/CMSPagesController_ContentToolActions.ss

is encoded by https://github.com/silverstripe/silverstripe-framework/blob/a8c1dd7f535bce772a06c9717b09f2ba882300db/control/Controller.php (Line 576)
