### PR TITLE
Back, Delete and Save Buttons in Admin Panels not appearing on first cli...

### DIFF
--- a/javascript/ModelAdmin.js
+++ b/javascript/ModelAdmin.js
@@ -364,7 +364,7 @@ $(document).ready(function() {
 				if(!this.future || !this.future.length) {
 				    $('#Form_EditForm_action_goForward, #Form_ResultsForm_action_goForward').hide();
 			    }
-				if(!this.history || this.history.length <= 1) {
+				if(!this.history || this.history.length < 1) {
 				    $('#Form_EditForm_action_goBack, #Form_ResultsForm_action_goBack').hide();
 				
 					// we don't need save and delete button on result form


### PR DESCRIPTION
...ck

The 'Back', 'Delete' and 'Save' buttons on the Admin panel don't appear if you go straight into a DataObject item,

You needed to click 'Search' first, this added an extra item to the history array, have changed the condition for the number of items in this array before the buttons appear, now only 1 item needs to be in the Array
