### PR TITLE
ContentControllerSearchExtensionTest doesn't clean up after itself.

### DIFF
--- a/tests/controller/ContentControllerSearchExtensionTest.php
+++ b/tests/controller/ContentControllerSearchExtensionTest.php
@@ -1,9 +1,7 @@
 <?php
 class ContentControllerSearchExtensionTest extends SapphireTest {
-	
+
 	public function testCustomSearchFormClassesToTest() {
-		FulltextSearchable::enable('File');
-		
 		$page = new Page();
 		$page->URLSegment = 'whatever';
 		$page->Content = 'oh really?';
@@ -14,4 +12,23 @@ class ContentControllerSearchExtensionTest extends SapphireTest {
 		
 		if (get_class($form) == 'SearchForm') $this->assertEquals(array('File'), $form->getClassesToSearch());
 	}
+
+	public function setUpOnce() {
+		parent::setUpOnce();
+
+		FulltextSearchable::enable('File');
+	}
+
+	/**
+	 * FulltextSearchable::enable() leaves behind remains that don't get cleaned up
+	 * properly at the end of the test. This becomes apparent when a later test tries to
+	 * ALTER TABLE File and add fulltext indexes with the InnoDB table type.
+	 */
+	public function tearDownOnce() {
+		parent::tearDownOnce();
+
+		Config::inst()->update('File', 'create_table_options', array('MySQLDatabase' => 'ENGINE=InnoDB'));
+		File::remove_extension('FulltextSearchable');
+	}
+
 }


### PR DESCRIPTION
The problem is FulltextSearchable::enable() does two things:
It enables the extension, as well as sets the MySQL create table option
to MyISAM. Later tests run with the extension enabled, because it doesn't
get removed at the end of the test, but the table type is set back to
InnoDB when the test is reset and schema recreated.

This produces side-effects where later tests in a suite tries to run
ALTER TABLE on File and add fulltext indexes when the table type
is set to InnoDB, causing an error.
