### PR TITLE
Behat tests for image upload from computer, editing images, etc

### DIFF
--- a/tests/behat/features/insert-an-image.feature
+++ b/tests/behat/features/insert-an-image.feature
@@ -6,10 +6,8 @@ Feature: Insert an image into a page
 
   Background:
     Given a "page" "About Us"
-    #And a "file" "assets/folder1/file1.jpg"
-    #And a "file" "assets/folder1/file3.jpg"
-    #And a "file" "assets/folder1/folder1.1/file2.jpg"
-    #And a "folder" "assets/folder2"
+    And a "file" "assets/folder1/file1.jpg"
+    And a "file" "assets/folder1/file2.jpg"
     And I am logged in with "ADMIN" permissions
     And I go to "/admin/pages"
     And I click on "About Us" in the tree
@@ -28,17 +26,36 @@ Feature: Insert an image into a page
     # Required to avoid "unsaved changed" browser dialog
     Then I press the "Save draft" button
 
-  @todo
+  @assets
   Scenario: I can insert an image uploaded from my own computer
     Given I press the "Insert Media" button
     And I press the "From your computer" button
-    # TODO Figure out how to provide the file
     And I attach the file "testfile.jpg" to "AssetUploadField" with HTML5
-    Then the upload field should have successfully uploaded "testfile.jpg"
+    # TODO Delay previous step until upload succeeded
+    And I wait for 2 seconds
+    Then there should be a file "assets/Uploads/testfile.jpg"
     When I press the "Insert" button
     Then the "Content" HTML field should contain "testfile.jpg"
+    # Required to avoid "unsaved changed" browser dialog
+    Then I press the "Save draft" button
 
-  @todo
+  @assets
+  Scenario: I can overwrite an existing image with one uploaded from my own computer
+    Given a "file" "assets/Uploads/file1.jpg"
+    When I press the "Insert Media" button
+    And I press the "From your computer" button
+    And I attach the file "file1.jpg" to "AssetUploadField" with HTML5
+    # TODO Delay previous step until upload succeeded
+    And I wait for 2 seconds
+    Then I should see "Overwrite"
+    When I press the "Overwrite" button
+    Then there should be a file "assets/Uploads/file1.jpg"
+    When I press the "Insert" button
+    Then the "Content" HTML field should contain "file1.jpg"
+    # Required to avoid "unsaved changed" browser dialog
+    Then I press the "Save draft" button
+
+  @todo 
   Scenario: I can insert an image from the CMS file store
     Given I press the "Insert Media" button
     And I press the "From the CMS" button
@@ -46,6 +63,8 @@ Feature: Insert an image into a page
     And I select "file1.jpg"
     When I press the "Insert" button
     Then the "Content" HTML field should contain "file1.jpg"
+    # Required to avoid "unsaved changed" browser dialog
+    Then I press the "Save draft" button
 
   @todo
   Scenario: I can insert multiple images at once
@@ -53,10 +72,12 @@ Feature: Insert an image into a page
     And I press the "From the CMS" button
     And I select "folder1" in the "Find in Folder" dropdown
     And I select "file1.jpg"
-    And I select "file3.jpg"
+    And I select "file2.jpg"
     When I press the "Insert" button
     Then the "Content" HTML field should contain "file1.jpg"
-    And the "Content" HTML field should contain "file1.jpg"
+    And the "Content" HTML field should contain "file2.jpg"
+    # Required to avoid "unsaved changed" browser dialog
+    Then I press the "Save draft" button
 
   @todo
   Scenario: I can edit properties of an image before inserting it
@@ -69,6 +90,8 @@ Feature: Insert an image into a page
     And I press the "Insert" button
     Then the "Content" HTML field should contain "file1.jpg"
     And the "Content" HTML field should contain "My alt"
+    # Required to avoid "unsaved changed" browser dialog
+    Then I press the "Save draft" button
 
   @todo
   Scenario: I can edit dimensions of an image before inserting it
@@ -81,6 +104,8 @@ Feature: Insert an image into a page
     When I fill in "Height" with "20"
     And I press the "Insert" button
     Then the "Content" HTML field should contain "<img src=assets/folder1/file1.jpg width=10 height=20>"
+    # Required to avoid "unsaved changed" browser dialog
+    Then I press the "Save draft" button
 
   @todo
   Scenario: I can edit dimensions of an existing image
@@ -93,3 +118,5 @@ Feature: Insert an image into a page
     When I fill in "Height" with "20"
     And I press the "Insert" button
     Then the "Content" HTML field should contain "<img src=assets/folder1/file1.jpg width=10 height=20>"
+    # Required to avoid "unsaved changed" browser dialog
+    Then I press the "Save draft" button


### PR DESCRIPTION
See `insert-an-image.feature` for a start on this (only "insert from web" is tested so far). Depends on https://github.com/silverstripe/silverstripe-framework/pull/2603 for tests to pass.

Fixes https://github.com/silverstripe/silverstripe-cms/issues/628

``` cucumber
@todo
  Scenario: I can insert an image uploaded from my own computer
    Given I press the "Insert Media" button
    And I press the "From your computer" button
    # TODO Figure out how to provide the file
    And I attach the file "testfile.jpg" to "AssetUploadField" with HTML5
    Then the upload field should have successfully uploaded "testfile.jpg"
    When I press the "Insert" button
    Then the "Content" HTML field should contain "testfile.jpg"

  @todo
  Scenario: I can insert an image from the CMS file store
    Given I press the "Insert Media" button
    And I press the "From the CMS" button
    And I select "folder1" in the "Find in Folder" dropdown
    And I select "file1.jpg"
    When I press the "Insert" button
    Then the "Content" HTML field should contain "file1.jpg"

  @todo
  Scenario: I can insert multiple images at once
    Given I press the "Insert Media" button
    And I press the "From the CMS" button
    And I select "folder1" in the "Find in Folder" dropdown
    And I select "file1.jpg"
    And I select "file3.jpg"
    When I press the "Insert" button
    Then the "Content" HTML field should contain "file1.jpg"
    And the "Content" HTML field should contain "file1.jpg"

  @todo
  Scenario: I can edit properties of an image before inserting it
    Given I press the "Insert Media" button
    And I press the "From the CMS" button
    And I select "folder1" in the "Find in Folder" dropdown
    And I select "file1.jpg"
    And I follow "Edit"
    When I fill in "Alternative text (alt)" with "My alt"
    And I press the "Insert" button
    Then the "Content" HTML field should contain "file1.jpg"
    And the "Content" HTML field should contain "My alt"

  @todo
  Scenario: I can edit dimensions of an image before inserting it
    Given I press the "Insert Media" button
    And I press the "From the CMS" button
    And I select "folder1" in the "Find in Folder" dropdown
    And I select "file1.jpg"
    And I follow "Edit"
    When I fill in "Width" with "10"
    When I fill in "Height" with "20"
    And I press the "Insert" button
    Then the "Content" HTML field should contain "<img src=assets/folder1/file1.jpg width=10 height=20>"

  @todo
  Scenario: I can edit dimensions of an existing image
    Given the "page" "About us" contains "<img src=assets/folder1/file1.jpg>"
    And I reload the current page
    When I highlight "<img src=assets/folder1/file1.jpg>" in the "Content" HTML field
    And I press the "Insert Media" button
    Then I should see "file1.jpg"
    When I fill in "Width" with "10"
    When I fill in "Height" with "20"
    And I press the "Insert" button
    Then the "Content" HTML field should contain "<img src=assets/folder1/file1.jpg width=10 height=20>"
```
