### PR TITLE
Make Settings Link in CMSSettingsController clickable

### DIFF
--- a/code/controllers/CMSSettingsController.php
+++ b/code/controllers/CMSSettingsController.php
@@ -94,7 +94,7 @@ class CMSSettingsController extends LeftAndMain {
 		return new ArrayList(array(
 			new ArrayData(array(
 				'Title' => _t("{$this->class}.MENUTITLE", $defaultTitle),
-				'Link' => false
+				'Link' => ($unlinked) ? false : $this->Link()
 			))
 		));
 	}


### PR DESCRIPTION
When SiteConfig has a GridField, you can't click on the Link to go back
