### PR TITLE
FIX: ErrorPage generating empty responses for 403/401 requests

### DIFF
--- a/tests/model/ErrorPageTest.php
+++ b/tests/model/ErrorPageTest.php
@@ -60,5 +60,14 @@ class ErrorPageTest extends FunctionalTest {
 		/* Don't show the error page in the search */
 		$this->assertEquals($page->ShowInSearch, 0, 'Don\'t show the error page in search');
 	}
-	
+
+	public function testBehaviourOf403() {
+		$page = $this->objFromFixture('ErrorPage', '403');
+		$page->publish('Stage', 'Live');
+		
+		$response = $this->get($page->Link());
+		
+		$this->assertEquals($response->getStatusCode(), '403');
+		$this->assertNotNull($response->getBody(), 'We have body text from the error page');
+	}
 }

--- a/tests/model/ErrorPageTest.yml
+++ b/tests/model/ErrorPageTest.yml
@@ -4,3 +4,8 @@ ErrorPage:
       URLSegment: page-not-found
       Content: My error page body
       ErrorCode: 404
+   403:
+      Title: Permission Failure
+      URLSegment: permission-denied
+      Content: You do not have permission to view this page
+      ErrorCode: 403


### PR DESCRIPTION
Previously by setting the response status code inside the action, this prevented response bodies from being included due to 403/401 being matched by SS_HTTPResponse::isFinished() (which stops popular

I assume SS_HTTPResponse::isFinished() is valid for the permission error use case (and I would be hesitant to change it) so this simply moves the declaration of the response status code till after the parent has populated the body of the response.
