### PR TITLE
VirtualPages: Allow whitelisting methods and relations

### DIFF
--- a/code/model/VirtualPage.php
+++ b/code/model/VirtualPage.php
@@ -417,9 +417,8 @@ class VirtualPage extends Page {
 	public function __call($method, $args) {
 		if(parent::hasMethod($method)) {
 			return parent::__call($method, $args);
-		} else {
-			return call_user_func_array(array($this->copyContentFrom(), $method), $args);
 		}
+		return call_user_func_array(array($this->copyContentFrom(), $method), $args);
 	}
 
 	public function hasField($field) {
@@ -452,6 +451,8 @@ class VirtualPage_Controller extends Page_Controller {
 	private static $allowed_actions = array(
 		'loadcontentall' => 'ADMIN',
 	);
+
+	private static $virtual_methods;
 	
 	/**
 	 * Reloads the content if the version is different ;-)
@@ -477,6 +478,7 @@ class VirtualPage_Controller extends Page_Controller {
 	 * We can't load the content without an ID or record to copy it from.
 	 */
 	public function init(){
+		self::$virtual_methods = Config::inst()->get('VirtualPage','virtual_methods');
 		if(isset($this->record) && $this->record->ID){
 			if($this->record->VersionID != $this->failover->CopyContentFrom()->Version){
 				$this->reloadContent();
@@ -521,7 +523,11 @@ class VirtualPage_Controller extends Page_Controller {
 	 * @param string $args 
 	 */
 	public function __call($method, $args) {
+
 		try {
+			if(self::$virtual_methods && in_array($method, self::$virtual_methods)){
+				throw new Exception("",2175);
+			}
 			return parent::__call($method, $args);
 		} catch (Exception $e) {
 			// Hack... detect exception type. We really should use exception subclasses.
@@ -535,6 +541,5 @@ class VirtualPage_Controller extends Page_Controller {
 			return call_user_func_array(array($controller, $method), $args);
 		}
 	}
+
 }
-
-


### PR DESCRIPTION
... that should be called on the referenced page, and not the VirtualPage’s methods/relations.

This is particularly useful for getting images to display that relate to the referenced page.

The whitelist is a just a config of relations or function names, as they are defined in Page/Page_Controller.

eg:

```yaml
---
Name: app
After: "*"
---
VirtualPage:
  virtual_methods:
    - Image1
    - Image2
    - HeroImage
```