### PR TITLE
Page edit access with CMS_ACCESS_LeftAndMain (fixes #908)

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -852,7 +852,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		if(!$fromLive
 			&& !Session::get('unsecuredDraftSite')
-			&& !Permission::checkMember($member, array('CMS_ACCESS_CMSMain', 'VIEW_DRAFT_CONTENT'))) {
+			&& !Permission::checkMember($member, array('CMS_ACCESS_LeftAndMain', 'CMS_ACCESS_CMSMain', 'VIEW_DRAFT_CONTENT'))) {
 			// If we weren't definitely loaded from live, and we can't view non-live content, we need to
 			// check to make sure this version is the live version and so can be viewed
 			if (Versioned::get_versionnumber_by_stage($this->class, 'Live', $this->ID) != $this->Version) return false;
@@ -1107,7 +1107,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @param Boolean $useCached
 	 * @return Array An map of {@link SiteTree} ID keys, to boolean values
 	 */
-	static public function batch_permission_check($ids, $memberID, $typeField, $groupJoinTable, $siteConfigMethod, $globalPermission = 'CMS_ACCESS_CMSMain', $useCached = true) {
+	static public function batch_permission_check($ids, $memberID, $typeField, $groupJoinTable, $siteConfigMethod, $globalPermission = null, $useCached = true) {
+		if($globalPermission === NULL) $globalPermission = array('CMS_ACCESS_LeftAndMain', 'CMS_ACCESS_CMSMain');
+
 		// Sanitise the IDs
 		$ids = array_filter($ids, 'is_numeric');
 		
@@ -1226,7 +1228,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * page can be edited.
 	 */
 	static public function can_edit_multiple($ids, $memberID, $useCached = true) {
-		return self::batch_permission_check($ids, $memberID, 'CanEditType', 'SiteTree_EditorGroups', 'canEdit', 'CMS_ACCESS_CMSMain', $useCached);
+		return self::batch_permission_check($ids, $memberID, 'CanEditType', 'SiteTree_EditorGroups', 'canEdit', null, $useCached);
 	}
 
 	/**

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -454,6 +454,16 @@ class SiteTreeTest extends SapphireTest {
 		// Can't edit a child of that page that has its permissions overridden
 		$this->assertFalse($product4->canEdit($editor));
 	}
+
+	public function testCanEditWithAccessToAllSections() {
+		$page = new Page();
+		$page->write();
+		$allSectionMember = $this->objFromFixture('Member', 'allsections');
+		$securityAdminMember = $this->objFromFixture('Member', 'securityadmin');
+
+		$this->assertTrue($page->canEdit($allSectionMember));
+		$this->assertFalse($page->canEdit($securityAdminMember));
+	}
 	
 	public function testEditPermissionsOnDraftVsLive() {
 		// Create an inherit-permission page

--- a/tests/model/SiteTreeTest.yml
+++ b/tests/model/SiteTreeTest.yml
@@ -3,7 +3,11 @@ Group:
       Title: Editors
    admins:
       Title: Administrators
-      
+   allsections:
+      Title: All Section Editors
+   securityadmins:
+      Title: Security Admins
+
 Permission:
    admins:
       Code: ADMIN
@@ -11,7 +15,13 @@ Permission:
    editors:
       Code: CMS_ACCESS_CMSMain
       Group: =>Group.editors
-      
+   allsections:
+      Code: CMS_ACCESS_LeftAndMain
+      Group: =>Group.allsections
+   securityadmins:
+      Code: CMS_ACCESS_SecurityAdmin
+      Group: =>Group.securityadmins
+
 Member:
    editor:
       FirstName: Test
@@ -21,6 +31,10 @@ Member:
       FirstName: Test
       Surname: Administrator
       Groups: =>Group.admins
+   allsections:
+      Groups: =>Group.allsections
+   securityadmin:
+      Groups: =>Group.securityadmins
 
 Page:
     home:


### PR DESCRIPTION
"Access to all sections" implies edit access in the CMS
