### PR TITLE
FIX: Prevent "Add Page" button being stuck 'focussed'

### DIFF
--- a/javascript/CMSMain.AddForm.js
+++ b/javascript/CMSMain.AddForm.js
@@ -109,6 +109,9 @@
 				$('.cms-container').loadPanel(url, null, data);
 				e.preventDefault();
 
+				// Remove focussed state from button
+				this.blur();
+
 				// $('.cms-page-add-form-dialog').dialog('open');
 				// e.preventDefault();
 			}


### PR DESCRIPTION
Prevent the UI button getting stuck in its ‘focussed’ state, even after switching panels:

![screen shot 2013-12-16 at 14 41 17](https://f.cloud.github.com/assets/1655548/1755202/b268c712-6660-11e3-9feb-85a320dd6e7b.png)

I’m guessing this is because jQuery UI binds different events for anchors than buttons (namely `focus` and `blur` instead of `mousedown` and `mouseup`).
