### PR TITLE
FIX: Prevent AssetAdmin duplicate confirmation for file deletion (fixes silverstripe/silverstripe-framework#2639)

### DIFF
--- a/javascript/AssetAdmin.js
+++ b/javascript/AssetAdmin.js
@@ -48,7 +48,7 @@
 			}
 		});
 
-		$('.AssetAdmin.cms-edit-form .action.gridfield-button-delete').entwine({
+		$('.AssetAdmin.cms-edit-form .ss-gridfield .col-buttons .action.gridfield-button-delete, .AssetAdmin.cms-edit-form .Actions button.action.action-delete').entwine({
 			onclick: function(e) {
 				var msg;
 				if(this.closest('.ss-gridfield-item').data('class') == 'Folder') {


### PR DESCRIPTION
We just needed higher specificity than the selector here: https://github.com/silverstripe/silverstripe-framework/blob/3.1/javascript/GridField.js#L139.

Frustratingly, using higher specificity for one of the two selectors doesn’t work - both need to be more specific. So despite the fact that the `.AssetAdmin.cms-edit-form .Actions button.action.action-delete` selector is never reached, we still need it in there. Perhaps @hafriedlander can advise if there’s a way around this?

The delete button in the ‘EditForm’ view for a file comes close to matching the second selector, but the `.cms-edit-form` is lacking the `.AssetAdmin` class.
