### PR TITLE
NEW Locate page template without needing to define a controller

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -369,7 +369,38 @@ HTML;
 		}
 		
 		return i18n::convert_rfc1766($locale);
+	}	
+
+
+	/**
+	 * Return an SSViewer object to render the template for the current page.
+	 *
+	 * @param $action string
+	 *
+	 * @return SSViewer
+	 */
+	public function getViewer($action) {
+		// Manually set templates should be dealt with by Controller::getViewer()
+		if(isset($this->templates[$action]) && $this->templates[$action]
+			|| (isset($this->templates['index']) && $this->templates['index'])
+			|| $this->template
+		) {
+			return parent::getViewer($action);
+		}
+
+		// Prepare action for template search
+		if($action == "index") $action = "";
+		else $action = '_' . $action;
+
+		// Find templates by dataRecord
+		$templates = SSViewer::get_templates_by_class(get_class($this->dataRecord), $action, "SiteTree");
+
+		// Next, we need to add templates for all controllers
+		$templates += SSViewer::get_templates_by_class(get_class($this), $action, "Controller");
+
+		return new SSViewer($templates);
 	}
+
 
 	/**
 	 * This action is called by the installation system

--- a/tests/controller/ContentControllerTest.php
+++ b/tests/controller/ContentControllerTest.php
@@ -121,6 +121,44 @@ class ContentControllerTest extends FunctionalTest {
 			$this->get($page->RelativeLink())->getBody(),
 			'"sitetree_link" shortcodes get parsed properly'
 		);
+	}	
+
+
+	/**
+	 * Tests that {@link ContentController::getViewer()} chooses the correct templates.
+	 *
+	 * @covers ContentController::getViewer()
+	**/
+	public function testGetViewer() {
+
+		// // Test a page without a controller (ContentControllerTest_PageWithoutController.ss)
+		$page = new ContentControllerTestPageWithoutController();
+		$page->URLSegment = "test";
+		$page->write();
+		$page->publish("Stage", "Live");
+
+		$response = $this->get($page->RelativeLink());
+		$this->assertEquals("ContentControllerTestPageWithoutController", $response->getBody());
+
+
+		// // This should fall over to user Page.ss
+		$page = new ContentControllerTestPage();
+		$page->URLSegment = "test";
+		$page->write();
+		$page->publish("Stage", "Live");
+
+		$response = $this->get($page->RelativeLink());
+		$this->assertEquals("Foo", $response->getBody());
+
+
+		// Test that the action template is rendered.
+		$page = new ContentControllerTestPage();
+		$page->URLSegment = "page-without-controller";
+		$page->write();
+		$page->publish("Stage", "Live");
+
+		$response = $this->get($page->RelativeLink("test"));
+		$this->assertEquals("ContentControllerTestPage_test", $response->getBody());
 	}
 
 }
@@ -141,4 +179,14 @@ class ContentControllerTest_Page_Controller extends Page_Controller {
 		return $this->index();
 	}
 
+}
+
+// For testing templates
+class ContentControllerTestPageWithoutController extends Page { }
+
+class ContentControllerTestPage extends Page { }
+class ContentControllerTestPage_Controller extends Page_Controller {
+	private static $allowed_actions = array(
+		"test",
+	);
 }

--- a/tests/templates/ContentControllerTestPageWithoutController.ss
+++ b/tests/templates/ContentControllerTestPageWithoutController.ss
@@ -1,0 +1,1 @@
+ContentControllerTestPageWithoutController

--- a/tests/templates/ContentControllerTestPage_test.ss
+++ b/tests/templates/ContentControllerTestPage_test.ss
@@ -1,0 +1,1 @@
+ContentControllerTestPage_test


### PR DESCRIPTION
See #900 and #881 for background.

I've raised this PR against master as the method for selecting templates has changed, albeit only slightly. I would imagine only edge-cases would be affected by the change.
