### PR TITLE
auto-updating URLSegment field now language-independent (#915)

### DIFF
--- a/code/controllers/CMSPageAddController.php
+++ b/code/controllers/CMSPageAddController.php
@@ -172,7 +172,7 @@ class CMSPageAddController extends CMSPageEditController {
 			"FormInfo.Form_EditForm.formError.message", 
 			_t('CMSMain.PageAdded', 'Successfully created page')
 		);
-		Session::set("FormInfo.Form_EditForm.formError.type", 'good');
+		Session::set("FormInfo.Form_EditForm.formError.type", 'good new');
 		
 		return $this->redirect(Controller::join_links(singleton('CMSPageEditController')->Link('show'), $record->ID));
 	}

--- a/javascript/CMSMain.EditForm.js
+++ b/javascript/CMSMain.EditForm.js
@@ -38,8 +38,9 @@
 						var title = self.val();
 						self.data('OrigVal', title);
 
-						// Criteria for defining a "new" page
-						if ((urlSegmentInput.val().indexOf('new') == 0) && liveLinkInput.val() == '') {
+						// Message class now indicates if it's a new page, old solution was language-dependent
+						// Drawback: URL still auto-updates if page is saved/published but not reloaded
+						if ($('.message.new').length) {
 							self.updateURLSegment(title);
 						} else {
 							$('.update', self.parent()).show();


### PR DESCRIPTION
My suggestion: Add a custom css class ('new') to the FormError message issued when creating a new page, then look for this class when title is changed.
Pros: language-independent, framework untouched, little code.
Cons: Does still auto-update the URL after a new page is saved/published but not reloaded.
