### PR TITLE
Fix “I can insert an image from the CMS file store”.

### DIFF
--- a/tests/behat/features/insert-an-image.feature
+++ b/tests/behat/features/insert-an-image.feature
@@ -55,12 +55,11 @@ Feature: Insert an image into a page
     # Required to avoid "unsaved changed" browser dialog
     Then I press the "Save draft" button
 
-  @todo 
   Scenario: I can insert an image from the CMS file store
     Given I press the "Insert Media" button
     And I press the "From the CMS" button
-    And I select "folder1" in the "Find in Folder" dropdown
-    And I select "file1.jpg"
+    And I fill in the "ParentID" dropdown with "folder1"
+    And I click on "file1.jpg" in the "Files" table
     When I press the "Insert" button
     Then the "Content" HTML field should contain "file1.jpg"
     # Required to avoid "unsaved changed" browser dialog


### PR DESCRIPTION
This requires the framework PR silverstripe/silverstripe-framework#2754 before the test will pass without failure.
