### PR TITLE
Fix typo in ONLYSELECTTWO alert

### DIFF
--- a/javascript/CMSPageHistoryController.js
+++ b/javascript/CMSPageHistoryController.js
@@ -132,7 +132,7 @@
 				else if(compare) {
 					// check if we have already selected more than two.
 					if(selected.length > 1) {
-						return alert(ss.i18n._t('ONLYSELECTTWO', 'Can only compare two versions at at time.'));
+						return alert(ss.i18n._t('ONLYSELECTTWO', 'You can only compare two versions at this time.'));
 					}
 				
 					this._select();


### PR DESCRIPTION
This fixes a typo when clicking on more than two revisions in the history tab.
