### PR TITLE
Fixing test failures because of Translatable and SiteTreeSubsites

### DIFF
--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -8,7 +8,7 @@ class SiteTreeTest extends SapphireTest {
 	protected static $fixture_file = 'SiteTreeTest.yml';
 
 	protected $illegalExtensions = array(
-		'SiteTree' => array('SiteTreeSubsites')
+		'SiteTree' => array('SiteTreeSubsites', 'Translatable')
 	);
 	
 	protected $extraDataObjects = array(

--- a/tests/search/SearchFormTest.php
+++ b/tests/search/SearchFormTest.php
@@ -11,7 +11,11 @@
 class ZZZSearchFormTest extends FunctionalTest {
 	
 	protected static $fixture_file = 'SearchFormTest.yml';
-	
+
+	protected $illegalExtensions = array(
+		'SiteTree' => array('SiteTreeSubsites', 'Translatable')
+	);
+
 	protected $mockController;
 	
 	public function waitUntilIndexingFinished() {


### PR DESCRIPTION
Fixes problems with SiteTreeTest and SearchFormTest failing when Translatable::set_default_locale() is defined as something other than en_US.
