### PR TITLE
Fixing test failures introduced by Translatable and SiteTreeSubsites

### DIFF
--- a/tests/model/VirtualPageTest.php
+++ b/tests/model/VirtualPageTest.php
@@ -9,6 +9,10 @@ class VirtualPageTest extends SapphireTest {
 		'VirtualPageTest_VirtualPageSub',
 	);
 
+	protected $illegalExtensions = array(
+		'SiteTree' => array('SiteTreeSubsites', 'Translatable')
+	);
+
 	protected $requiredExtensions = array(
 		'SiteTree' => array('VirtualPageTest_PageExtension')
 	);


### PR DESCRIPTION
Same fix as e93abc6, except it applies to VirtualPageTest.

See pull request #924 for more information on how it applies to other test classes.
