### PR TITLE
Fixing test not auto-following admin/pages/SearchForm

### DIFF
--- a/tests/search/CMSMainSearchFormTest.php
+++ b/tests/search/CMSMainSearchFormTest.php
@@ -3,8 +3,6 @@ class CMSMainSearchFormTest extends FunctionalTest {
 	
 	protected static $fixture_file = '../controller/CMSMainTest.yml';
 	
-	protected $autoFollowRedirection = false;
-	
 	public function testTitleFilter() {
 		$this->session()->inst_set('loggedInAs', $this->idFromFixture('Member', 'admin'));
 


### PR DESCRIPTION
With additional modules like Translatable, this test fails because
a 301 is issued to redirect the admin/pages/SearchForm request to the
correct URL containining a locale in the query string.
