### PR TITLE
BUGFIX Use the default string 'Any' instead of 'All' for class name crit...

### DIFF
--- a/code/CMSSiteTreeFilter.php
+++ b/code/CMSSiteTreeFilter.php
@@ -152,7 +152,7 @@ class CMSSiteTreeFilter_Search extends CMSSiteTreeFilter {
 		}
 		
 		// Match against exact ClassName
-		if (isset($data['ClassName']) && $data['ClassName'] != 'All') {
+		if (isset($data['ClassName']) && $data['ClassName'] != 'Any') {
 			$klass = Convert::raw2sql($data['ClassName']);
 			$where[] = "\"ClassName\" = '$klass'";
 		}


### PR DESCRIPTION
...eria in search form on CMSMain

At the moment, the only way to get results from the search form is to click "Clear" before adding any criteria, or the search form returns zero results. This is due to the difference between CMSMain#SiteTreeFilterPageTypeField which uses 'Any' as the default value for any classname, while CMSSiteTreeFilter#pagesIncluded expects 'All'. Regression introduced in 9e5af18b5c9c1b43
