### PR TITLE
Set IE Document Mode to the last version

### DIFF
--- a/templates/AssetAdmin_uploadiframe.ss
+++ b/templates/AssetAdmin_uploadiframe.ss
@@ -4,7 +4,7 @@
 		<% base_tag %>
 		<meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 		<title><% _t('TITLE', 'Image Uploading Iframe') %></title>
-		<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
+		<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 		<style type="text/css">
 			body {
 				padding: 0;

--- a/templates/BlankPage.ss
+++ b/templates/BlankPage.ss
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" >
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 <title>$Title</title>
 <% base_tag %>
 </head>

--- a/templates/Dialog.ss
+++ b/templates/Dialog.ss
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" >
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 <% base_tag %>
 <title>$Title</title>
 </head>

--- a/templates/LeftAndMain.ss
+++ b/templates/LeftAndMain.ss
@@ -3,7 +3,7 @@
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
 <meta http-equiv="Content-language" content="$i18nLocale" />
-<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 <% base_tag %>
 <title>$ApplicationName | $SectionTitle</title>
 </head>

--- a/templates/LeftAndMain_printable.ss
+++ b/templates/LeftAndMain_printable.ss
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" >
 <head>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7" />
+<meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 <% base_tag %>
 <title>SilverStripe CMS - $Title</title>
 </head>


### PR DESCRIPTION
Internet Explorer 11 set the documents to emulate version 7, causing avoidable errors setting Document Mode to the Edge.
