### PR TITLE
Fixed js bug on Files and Images tree

### DIFF
--- a/javascript/CMSMain_left.js
+++ b/javascript/CMSMain_left.js
@@ -31,8 +31,8 @@ addpageclass.prototype = {
 		
 			var selectedNode = $('sitetree').firstSelected();
 			if(selectedNode) this.showApplicableChildrenPageTypes(selectedNode.hints);
+			$('sitetree').observeMethod('SelectionChanged', this.treeSelectionChanged.bind(this));
 		}
-		$('sitetree').observeMethod('SelectionChanged', this.treeSelectionChanged.bind(this));
 	},
 	
 	onclick : function() {


### PR DESCRIPTION
Call observeMethod only if ($(_HANDLER_FORMS.addpage).elements.PageType) exist to prevent javascript error on File & Images page.

See https://github.com/silverstripe/silverstripe-cms/commit/f4b7fe05fa62c116e10336fa6309491386632c61
