### PR TITLE
FIX: Fix failover to index template in ContentController::getViewer()

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -404,6 +404,10 @@ HTML;
 		// Next, we need to add templates for all controllers
 		$templates += SSViewer::get_templates_by_class(get_class($this), $action, "Controller");
 
+		// Fail-over to the same for the "index" action
+		$templates += SSViewer::get_templates_by_class(get_class($this->dataRecord), "", "SiteTree");
+		$templates += SSViewer::get_templates_by_class(get_class($this), "", "Controller");
+
 		return new SSViewer($templates);
 	}
 

--- a/tests/controller/ContentControllerTest.php
+++ b/tests/controller/ContentControllerTest.php
@@ -161,6 +161,11 @@ class ContentControllerTest extends FunctionalTest {
 
 		$response = $this->get($page->RelativeLink("test"));
 		$this->assertEquals("ContentControllerTestPage_test", $response->getBody());
+
+		// Test that an action without a template will default to the index template, which is
+		// to say the default Page.ss template
+		$response = $this->get($page->RelativeLink("testwithouttemplate"));
+		$this->assertEquals("Foo", $response->getBody());
 	}
 
 }
@@ -190,5 +195,10 @@ class ContentControllerTestPage extends Page { }
 class ContentControllerTestPage_Controller extends Page_Controller {
 	private static $allowed_actions = array(
 		"test",
+		"testwithouttemplate"
 	);
+
+	function testwithouttemplate() {
+		return array();
+	}
 }


### PR DESCRIPTION
Historically, if you visit a foo action on Page, and Page_foo.ss doesn't exist, then it fails over
to Page.ss.  The introduction of ContentController::getViewer() broke this, but this patch adds a
test for this case and fixes it.

It was identified by build failures on silverstripe/userforms when tested against the master branch.
