### PR TITLE
FIX Limit ExtraMeta to only allow meta and link elements

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -105,7 +105,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		"MenuTitle" => "Varchar(100)",
 		"Content" => "HTMLText",
 		"MetaDescription" => "Text",
-		"ExtraMeta" => "HTMLText",
+		"ExtraMeta" => "HTMLText('meta, link')",
 		"ShowInMenus" => "Boolean",
 		"ShowInSearch" => "Boolean",
 		"Sort" => "Int",


### PR DESCRIPTION
Depends on https://github.com/silverstripe/silverstripe-framework/pull/2853
