### PR TITLE
Modfied Step: I wait for 5 Seconds to be more robust

### DIFF
--- a/tests/behat/features/manage-files.feature
+++ b/tests/behat/features/manage-files.feature
@@ -27,7 +27,7 @@ Feature: Manage files
     Given I click on "folder1" in the "Files" table
     And I press the "Upload" button
     And I attach the file "testfile.jpg" to "AssetUploadField" with HTML5
-    And I wait for 5 seconds
+    And I wait until I see "File upload completed!"
     And I press the "Back to folder" button
     Then the "folder1" table should contain "testfile"
 


### PR DESCRIPTION
Originally, the step was I wait for 5 seconds. This has been modified to I wait until I see "File upload completed!" This means it keeps trying to find the text "File Upload Completed" until it timeouts. 

This is PR is reliant on this being merged in: https://github.com/silverstripe-labs/silverstripe-behat-extension/pull/27
