### PR TITLE
FIX linktracking not working on file shortcode links

### DIFF
--- a/code/model/SiteTreeLinkTracking.php
+++ b/code/model/SiteTreeLinkTracking.php
@@ -49,7 +49,10 @@ class SiteTreeLinkTracking extends DataExtension {
 
 					$linkedPages[] = $ID;
 					if(!DataObject::get_by_id('SiteTree', $ID))  $record->HasBrokenLink = true;
-
+				} else if (preg_match('/\[file_link,id=([0-9]+)\]/i', $href, $matches)) {
+					$ID = $matches[1];
+					$linkedFiles[] = $ID;
+					if(!File::get()->ById($ID)) $record->HasBrokenFile = true;
 				} else if(substr($href, 0, strlen(ASSETS_DIR) + 1) == ASSETS_DIR.'/') {
 					$candidateFile = File::find(Convert::raw2sql(urldecode($href)));
 					if($candidateFile) {


### PR DESCRIPTION
File links were only being tracked on img tags and a tags that had normal file paths for the href value, not shortcodes. 

So files linked via the HTMLEditor -> insert link -> download a file -> select file, would display "Used on: 0 page(s)" when viewing them in the cms. 
