### PR TITLE
BUGFIX Ensure jQuery is defined before initialising the hasScrollbar plu...

### DIFF
--- a/code/AssetAdmin.php
+++ b/code/AssetAdmin.php
@@ -108,11 +108,11 @@ JS
 		Requirements::javascript(SAPPHIRE_DIR . "/thirdparty/behaviour/behaviour.js");
 		Requirements::javascript(SAPPHIRE_DIR . "/javascript/prototype_improvements.js");
 		Requirements::javascript(SAPPHIRE_DIR . "/javascript/layout_helpers.js");
-		Requirements::javascript(CMS_DIR . "/javascript/LeftAndMain.js");
-		Requirements::javascript(CMS_DIR . "/thirdparty/multifile/multifile.js");
-		Requirements::css(CMS_DIR . "/thirdparty/multifile/multifile.css");
 		Requirements::javascript(SAPPHIRE_DIR . "/thirdparty/jquery/jquery.js");
 		Requirements::javascript(SAPPHIRE_DIR . "/javascript/jquery_improvements.js");
+		Requirements::javascript(CMS_DIR . "/javascript/LeftAndMain.js");
+		Requirements::javascript(CMS_DIR . "/thirdparty/multifile/multifile.js");
+		Requirements::css(CMS_DIR . "/thirdparty/multifile/multifile.css");	
 		Requirements::css(CMS_DIR . "/css/typography.css");
 		Requirements::css(CMS_DIR . "/css/layout.css");
 		Requirements::css(CMS_DIR . "/css/cms_left.css");


### PR DESCRIPTION
...gin. This issue has been around for some time, but wasn't a blocker (an error in the console was mentioning that jquery wasn't defined, but the "Files and Images" section was still working). Something happened between commit 414f60ad2f and 34eb6678d8d, as now the section is completely frozen (no edition of folders or images is possible). I have adopted the same check as at the top of that same file, but it might not be the best approach.
