### PR TITLE
BUG Report admin don't listen to filters

### DIFF
--- a/javascript/ReportAdmin.js
+++ b/javascript/ReportAdmin.js
@@ -9,7 +9,7 @@
 				var url = $.path.parseUrl(document.location.href).hrefNoSearch, 
 					params = this.find(':input[name^=filters]').serializeArray();
 				params = $.grep(params, function(param) {return (param.value);}); // filter out empty
-				if(params) url = $.path.addSearchParams(url, params);
+				if(params) url = $.path.addSearchParams(url, $.param(params));
 				$('.cms-container').loadPanel(url);
 				return false;
 			}


### PR DESCRIPTION
It seems like filter params that are added to the url are added in a bad way

Currently

```
?0[name]=filters[ContentReviewOwnerID]&0[value]=1
```

Expected:

```
?filters[ContentReviewOwnerID]=1
```
