### PR TITLE
BUGFIX Only apply the logic for adding page type to the Pages section, n...

### DIFF
--- a/javascript/CMSMain_left.js
+++ b/javascript/CMSMain_left.js
@@ -11,7 +11,7 @@ _NEW_PAGES = new Array();
  */
 var addpageclass;
 addpageclass = Class.create();
-addpageclass.applyTo('#addpage');
+addpageclass.applyTo('.CMSMain #addpage');
 addpageclass.prototype = {
 	originalValues: new Array(),
 	initialize: function () {


### PR DESCRIPTION
...ot the assets. The id for the "Create folder" button in assets is very confusingly labelled #addpage. As a result, logic intended for the cms main section was also getting applied. Commit f4b7fe05fa62 introduced a regression, and the assets folder is frozen due to a js error. I have tested that this change is fine, and that the create folder functionality is still working as intended.
