### PR TITLE
BUG CMSFileAddController: get page id for action fileexists

### DIFF
--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -26,6 +26,7 @@ class CMSFileAddController extends LeftAndMain {
 		if($id && is_numeric($id) && $id > 0) {
 			$folder = DataObject::get_by_id('Folder', $id);
 			if($folder && $folder->exists()) {
+				Session::set("{$this->class}.currentPage", $id);
 				return $folder;
 			}
 		}


### PR DESCRIPTION
UploadField->fileexists() fails to check if a file exists in a certain folder (and fallsback to "assets/"), if CMSFileAddController doesn't provide a valid folder (-- and fallsback to "assets/newFolder/").

admin/assets/add/?ID=123:
$this->currentPageID() = 123
$folder->getFilename() = 'assets/Uploads/foo/bar/'

admin/assets/add/EditForm/field/AssetUploadField/fileexists?filename=test.jpg:
$this->currentPageID() = 0
$folder->getFilename() = 'assets/NewFolder/'

silverstripe/silverstripe-framework#2904
