### PR TITLE
FIX Fixes #965. Allow user date-settings to show on GridField Page admin

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -754,7 +754,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$columns->setDisplayFields($fields);
 		$columns->setFieldCasting(array(
 			'Created' => 'Datetime->Ago',
-			'LastEdited' => 'Datetime->Ago',
+			'LastEdited' => 'Datetime->FormatFromSettings',
 			'getTreeTitle' => 'HTMLText'
 		));
 


### PR DESCRIPTION
- Relies on framework PR #2961.
