### PR TITLE
API Added getBreadcrumbItems to SiteTree

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -718,12 +718,31 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * (with ShowInMenus=0).
 	 *
 	 * @param int $maxDepth The maximum depth to traverse.
-	 * @param boolean $unlinked Do not make page names links
+	 * @param boolean $unlinked Whether to link page titles.
 	 * @param boolean|string $stopAtPageType ClassName of a page to stop the upwards traversal.
 	 * @param boolean $showHidden Include pages marked with the attribute ShowInMenus = 0
 	 * @return HTMLText The breadcrumb trail.
 	 */
 	public function Breadcrumbs($maxDepth = 20, $unlinked = false, $stopAtPageType = false, $showHidden = false) {
+		$pages = $this->getBreadcrumbItems($maxDepth, $stopAtPageType, $showHidden);
+		$template = new SSViewer('BreadcrumbsTemplate');
+		return $template->process($this->customise(new ArrayData(array(
+			"Pages" => $pages,
+			"Unlinked" => $unlinked
+		))));
+	}
+
+
+	/**
+	 * Returns a list of breadcrumbs for the current page.
+	 *
+	 * @param int $maxDepth The maximum depth to traverse.
+	 * @param boolean|string $stopAtPageType ClassName of a page to stop the upwards traversal.
+	 * @param boolean $showHidden Include pages marked with the attribute ShowInMenus = 0
+	 *
+	 * @return ArrayList
+	*/
+	public function getBreadcrumbItems($maxDepth = 20, $stopAtPageType = false, $showHidden = false) {
 		$page = $this;
 		$pages = array();
 		
@@ -738,13 +757,10 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			
 			$page = $page->Parent;
 		}
-		
-		$template = new SSViewer('BreadcrumbsTemplate');
-		
-		return $template->process($this->customise(new ArrayData(array(
-			'Pages' => new ArrayList(array_reverse($pages))
-		))));
+
+		return new ArrayList(array_reverse($pages));
 	}
+
 
 	/**
 	 * Make this page a child of another page.

--- a/templates/BreadcrumbsTemplate.ss
+++ b/templates/BreadcrumbsTemplate.ss
@@ -1,5 +1,4 @@
+<%-- Loop is all on one line to prevent whitespace bug in older versions of IE --%>
 <% if $Pages %>
-	<% loop $Pages %>
-		<% if $Last %>$MenuTitle.XML<% else %><a href="$Link" class="breadcrumb-$Pos">$MenuTitle.XML</a> &raquo;<% end_if %>
-	<% end_loop %>
+	<% loop $Pages %><% if $Last %>$MenuTitle.XML<% else %><% if not Up.Unlinked %><a href="$Link" class="breadcrumb-$Pos"><% end_if %>$MenuTitle.XML<% if not Up.Unlinked %></a><% end_if %> &raquo; <% end_if %><% end_loop %>
 <% end_if %>

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -943,6 +943,25 @@ class SiteTreeTest extends SapphireTest {
 		// reset original value
 		Config::inst()->update('SiteTree', 'meta_generator', $generator);
 	}
+
+
+	public function testGetBreadcrumbItems() {
+		$page = $this->objFromFixture("Page", "breadcrumbs");
+		$this->assertEquals($page->getBreadcrumbItems()->count(), 1, "Only display current page.");
+
+		// Test breadcrumb order
+		$page = $this->objFromFixture("Page", "breadcrumbs5");
+		$breadcrumbs = $page->getBreadcrumbItems();
+		$this->assertEquals($breadcrumbs->count(), 5, "Display all breadcrumbs");
+		$this->assertEquals($breadcrumbs->first()->Title, "Breadcrumbs", "Breadcrumbs should be the first item.");
+		$this->assertEquals($breadcrumbs->last()->Title, "Breadcrumbs 5", "Breadcrumbs 5 should be last item.");
+
+		// Test breadcrumb max depth
+		$breadcrumbs = $page->getBreadcrumbItems(2);
+		$this->assertEquals($breadcrumbs->count(), 2, "Max depth should limit the breadcrumbs to 2 items.");
+		$this->assertEquals($breadcrumbs->first()->Title, "Breadcrumbs 4", "First item should be Breadrcumbs 4.");
+		$this->assertEquals($breadcrumbs->last()->Title, "Breadcrumbs 5", "Breadcrumbs 5 should be last.");
+	}
 	
 	/**
 	 * Tests SiteTree::MetaTags

--- a/tests/model/SiteTreeTest.yml
+++ b/tests/model/SiteTreeTest.yml
@@ -89,6 +89,20 @@ Page:
     Title: 'HTML & XML'
     MetaDescription: 'The <br /> and <br> tags'
     ExtraMeta: '<link rel="canonical" href="http://www.mysite.com/html-and-xml" />'
+  breadcrumbs:
+    Title: 'Breadcrumbs'
+  breadcrumbs2:
+    Title: 'Breadcrumbs 2'
+    Parent: =>Page.breadcrumbs
+  breadcrumbs3:
+    Title: 'Breadcrumbs 3'
+    Parent: =>Page.breadcrumbs2
+  breadcrumbs4:
+    Title: 'Breadcrumbs 4'
+    Parent: =>Page.breadcrumbs3
+  breadcrumbs5:
+    Title: 'Breadcrumbs 5'
+    Parent: =>Page.breadcrumbs4
 
 SiteTreeTest_Conflicted:
   parent:


### PR DESCRIPTION
I've re-added the $unlinked functionality but changed this to $linked instead. The double negative isn't a very nice read. If you'd prefer I change this back let me know.
