### PR TITLE
BUG Fix issue with page search ignoring filters

### DIFF
--- a/tests/behat/features/search-for-a-page.feature
+++ b/tests/behat/features/search-for-a-page.feature
@@ -40,12 +40,59 @@ Feature: Search for a page
 		Then I should not see "Recent Page" in the tree
 		But I should see "Old Page" in the tree
 
-
 	Scenario: I can include deleted pages in my search
 		Given a "page" "Deleted Page"
+		And the "page" "Deleted Page" is unpublished
 		And the "page" "Deleted Page" is deleted
 		When I press the "Apply Filter" button
 		Then I should not see "Deleted Page" in the tree
 		When I select "All pages, including deleted" from "Pages"
 		And I press the "Apply Filter" button
 		Then I should see "Deleted Page" in the tree
+
+	Scenario: I can include only deleted pages in my search
+		Given a "page" "Deleted Page"
+		And the "page" "Deleted Page" is unpublished
+		And the "page" "Deleted Page" is deleted
+		When I press the "Apply Filter" button
+		Then I should not see "Deleted Page" in the tree
+		When I select "Deleted pages" from "Pages"
+		And I press the "Apply Filter" button
+		Then I should see "Deleted Page" in the tree
+		And I should not see "About Us" in the tree
+
+	Scenario: I can include draft pages in my search
+		Given a "page" "Draft Page"
+		And the "page" "Draft Page" is not published
+		When I press the "Apply Filter" button
+		Then I should see "Draft Page" in the tree
+		When I select "Draft unpublished pages" from "Pages"
+		And I press the "Apply Filter" button
+		Then I should see "Draft Page" in the tree
+		And I should not see "About Us" in the tree
+
+	Scenario: I can include changed pages in my search
+		When I click on "About Us" in the tree
+		Then I should see an edit page form
+
+		When I fill in the "Content" HTML field with "my new content"
+		And I press the "Save draft" button
+		Then I should see "Saved" in the "button#Form_EditForm_action_save" element
+
+		When I go to "/admin/pages"
+		And I expand the "Filter" CMS Panel
+		When I select "Changed pages" from "Pages"
+		And I press the "Apply Filter" button
+		Then I should see "About Us" in the tree
+		And I should not see "Home" in the tree
+
+	Scenario: I can include live pages in my search
+		Given a "page" "Live Page"
+		And the "page" "Live Page" is published
+		And the "page" "Live Page" is deleted
+		When I press the "Apply Filter" button
+		Then I should not see "Live Page" in the tree
+		When I select "Live but removed from draft" from "Pages"
+		And I press the "Apply Filter" button
+		Then I should see "Live Page" in the tree
+		And I should not see "About Us" in the tree

--- a/tests/controller/CMSSiteTreeFilterTest.yml
+++ b/tests/controller/CMSSiteTreeFilterTest.yml
@@ -5,6 +5,18 @@ Page:
       Title: Page 2
    page3:
       Title: Page 3
+   page4:
+      Title: Page 4
+   page5:
+      Title: Page 5
+      Content: 'Default text'
+   page6:
+      Title: Page 6
+   page7:
+      Title: Page 7  
+   page7a:
+      Parent: =>Page.page7       
+      Title: Page 7a
    page2a:
       Parent: =>Page.page2
       Title: Page 2a


### PR DESCRIPTION
Reworked solution to https://github.com/silverstripe/silverstripe-cms/pull/969

@phptek do you mind to please review this?

I've changed the search filter titles to:
- All pages
- All pages, including deleted
- Changed pages
- Deleted pages
- Draft unpublished pages
- Live but removed from draft
