### PR TITLE
API Filter by date created for files

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -98,17 +98,19 @@ JS
 		// Don't filter list when a detail view is requested,
 		// to avoid edge cases where the filtered list wouldn't contain the requested
 		// record due to faulty session state (current folder not always encoded in URL, see #7408).
-		if(!$folder->ID && $this->request->requestVar('ID') === null && ($this->request->param('ID') == 'field')) {
+		if(!$folder->ID
+			&& $this->request->requestVar('ID') === null
+			&& ($this->request->param('ID') == 'field')
+		) {
 			return $list;
 		}
 
 		// Re-add previously removed "Name" filter as combined filter
 		// TODO Replace with composite SearchFilter once that API exists
-		if(isset($params['Name'])) {
-			$list = $list->where(sprintf(
-				'"Name" LIKE \'%%%s%%\' OR "Title" LIKE \'%%%s%%\'',
-				Convert::raw2sql($params['Name']),
-				Convert::raw2sql($params['Name'])
+		if(!empty($params['Name'])) {
+			$list = $list->filterAny(array(
+				'Name:PartialMatch' => $params['Name'],
+				'Title:PartialMatch' => $params['Name']
 			));
 		}
 
@@ -117,23 +119,26 @@ JS
 
 		// If a search is conducted, check for the "current folder" limitation.
 		// Otherwise limit by the current folder as denoted by the URL.
-		if(!$params || @$params['CurrentFolderOnly']) {
+		if(empty($params) || !empty($params['CurrentFolderOnly'])) {
 			$list = $list->filter('ParentID', $folder->ID);
 		}
 
 		// Category filter
-		if(isset($params['AppCategory'])) {
-			if(isset(File::config()->app_categories[$params['AppCategory']])) {
-				$exts = File::config()->app_categories[$params['AppCategory']];
-			} else {
-				$exts = array();
-			}
-			$categorySQLs = array();
-			foreach($exts as $ext) $categorySQLs[] = '"File"."Name" LIKE \'%.' . $ext . '\'';
-			// TODO Use DataList->filterAny() once OR connectives are implemented properly
-			if (count($categorySQLs) > 0) {
-				$list = $list->where('(' . implode(' OR ', $categorySQLs) . ')');
-			}
+		if(!empty($params['AppCategory'])
+			&& !empty(File::config()->app_categories[$params['AppCategory']])
+		) {
+			$exts = File::config()->app_categories[$params['AppCategory']];
+			$list = $list->filter('Name:PartialMatch', $exts);
+		}
+		
+		// Date filter
+		if(!empty($params['CreatedFrom'])) {
+			$fromDate = new DateField(null, null, $params['CreatedFrom']);
+			$list = $list->filter("Created:GreaterThanOrEqual", $fromDate->dataValue());
+		}
+		if(!empty($params['CreatedTo'])) {
+			$toDate = new DateField(null, null, $params['CreatedTo']);
+			$list = $list->filter("Created:LessThanOrEqual", $toDate->dataValue());
 		}
 
 		return $list;
@@ -342,6 +347,21 @@ JS
 		foreach($context->getFilters() as $filter) $filter->setFullName(sprintf('q[%s]', $filter->getFullName()));
 
 		// Customize fields
+		$context->addField(
+			new HeaderField('q[Date]', _t('CMSSearch.FILTERDATEHEADING', 'Date'), 4)
+		);
+		$context->addField(
+			DateField::create(
+				'q[CreatedFrom]', 
+				_t('CMSSearch.FILTERDATEFROM', 'From')
+			)->setConfig('showcalendar', true)
+		);
+		$context->addField(
+			DateField::create(
+				'q[CreatedTo]',
+				_t('CMSSearch.FILTERDATETO', 'To')
+			)->setConfig('showcalendar', true)
+		);
 		$appCategories = array(
 			'image' => _t('AssetAdmin.AppCategoryImage', 'Image'),
 			'audio' => _t('AssetAdmin.AppCategoryAudio', 'Audio'),
@@ -382,7 +402,7 @@ JS
 		$fields = $context->getSearchFields();
 		$actions = new FieldList(
 			FormAction::create('doSearch',  _t('CMSMain_left_ss.APPLY_FILTER', 'Apply Filter'))
-			->addExtraClass('ss-ui-action-constructive'),
+				->addExtraClass('ss-ui-action-constructive'),
 			Object::create('ResetFormAction', 'clear', _t('CMSMain_left_ss.RESET', 'Reset'))
 		);
 		

--- a/tests/behat/features/manage-files.feature
+++ b/tests/behat/features/manage-files.feature
@@ -5,8 +5,8 @@ Feature: Manage files
   So that I can insert them into my content efficiently
 
   Background:
-    Given a "image" "assets/folder1/file1.jpg"
-    And a "image" "assets/folder1/folder1.1/file2.jpg"
+    Given a "image" "assets/folder1/file1.jpg" was created "2012-01-01 12:00:00"
+    And a "image" "assets/folder1/folder1.1/file2.jpg" was created "2010-01-01 12:00:00"
     And a "folder" "assets/folder2"
     And I am logged in with "ADMIN" permissions
     And I go to "/admin/assets"
@@ -75,3 +75,11 @@ Feature: Manage files
     And I press the "Apply Filter" button
     Then the "Files" table should contain "file1"
     And the "Files" table should not contain "document"
+
+  Scenario: I can filter out files that don't match the date range
+    Given I expand the "Filter" CMS Panel
+    And I fill in "From" with "2003-01-01"
+    And I fill in "To" with "2011-01-01"
+    And I press the "Apply Filter" button
+    And the "Files" table should contain "file2"
+    And the "Files" table should not contain "file1"


### PR DESCRIPTION
This PR incorporates a date filter for assets, similar to the filter used by the sitetree filter.

Since the column shown in the grid in AssetAdmin is the `Created` column, this is the same column the filter acts on. The SiteTree filter however acts on the `LastModified` column.

The behat test cases rely on an extension to behat to allow the modified date of staging files to be specified. _Do not merge before silverstripe-labs/silverstripe-behat-extension#32_

ref: CWPBUG-144
