### PR TITLE
FIX: Broken file link tracking (fixes #996)

### DIFF
--- a/code/model/SiteTreeLinkTracking.php
+++ b/code/model/SiteTreeLinkTracking.php
@@ -38,24 +38,22 @@ class SiteTreeLinkTracking extends DataExtension {
 			$href = Director::makeRelative($link->getAttribute('href'));
 
 			if($href) {
-				if(preg_match('/\[sitetree_link,id=([0-9]+)\]/i', $href, $matches)) {
-					$ID = $matches[1];
+				if(preg_match('/\[(sitetree|file)_link[,\s]id=([0-9]+)\]/i', $href, $matches)) {
+					$type = $matches[1];
+					$id = $matches[2];
 
-					// clear out any broken link classes
-					if($class = $link->getAttribute('class')) {
-						$link->setAttribute('class',
-							preg_replace('/(^ss-broken|ss-broken$| ss-broken )/', null, $class));
-					}
-
-					$linkedPages[] = $ID;
-					if(!DataObject::get_by_id('SiteTree', $ID))  $record->HasBrokenLink = true;
-
-				} else if(substr($href, 0, strlen(ASSETS_DIR) + 1) == ASSETS_DIR.'/') {
-					$candidateFile = File::find(Convert::raw2sql(urldecode($href)));
-					if($candidateFile) {
-						$linkedFiles[] = $candidateFile->ID;
-					} else {
-						$record->HasBrokenFile = true;
+					if($type === 'sitetree') {
+						if(SiteTree::get()->byID($id)) {
+							$linkedPages[] = $id;
+						} else {
+							$record->HasBrokenLink = true;
+						}
+					} else if($type === 'file') {
+						if(File::get()->byID($id)) {
+							$linkedFiles[] = $id;
+						} else {
+							$record->HasBrokenFile = true;
+						}
 					}
 				} else if($href == '' || $href[0] == '/') {
 					$record->HasBrokenLink = true;

--- a/tests/model/SiteTreeBrokenLinksTest.php
+++ b/tests/model/SiteTreeBrokenLinksTest.php
@@ -46,18 +46,6 @@ class SiteTreeBrokenLinksTest extends SapphireTest {
 		$this->assertTrue($rp->HasBrokenLink, 'Broken redirector page IS marked as such');
 	}
 
-	public function testBrokenAssetLinks() {
-		$obj = $this->objFromFixture('Page','content');
-		
-		$obj->Content = '<a href="assets/nofilehere.pdf">this is a broken link to a pdf file</a>';
-		$obj->syncLinkTracking();
-		$this->assertTrue($obj->HasBrokenFile, 'Page has a broken file');
-		
-		$obj->Content = '<a href="assets/privacypolicy.pdf">this is not a broken file link</a>';
-		$obj->syncLinkTracking();
-		$this->assertFalse($obj->HasBrokenFile, 'Page does NOT have a broken file');
-	}
-
 	public function testDeletingFileMarksBackedPagesAsBroken() {
 		// Test entry
 		$file = new File();
@@ -65,7 +53,10 @@ class SiteTreeBrokenLinksTest extends SapphireTest {
 		$file->write();
 
 		$obj = $this->objFromFixture('Page','content');
-		$obj->Content = '<a href="assets/test-file.pdf">link to a pdf file</a>';
+		$obj->Content = sprintf(
+			'<p><a href="[file_link,id=%d]">Working Link</a></p>',
+			$file->ID
+		);
 		$obj->write();
 		$this->assertTrue($obj->doPublish());
 		// Confirm that it isn't marked as broken to begin with


### PR DESCRIPTION
List of changes:
- Switched `SiteTree` linking to use `SiteTree::get()->byID($id)` instead of `DataObject::get_by_id()`
- Removed the attempted ‘ss-broken’ class removal - this never worked: the class attribute was changed but this modified field data was never added to the record.
- Fixed link tracking for files to be parsed from shortcodes instead of scanning for the presence of `ASSETS_DIR` in the href
- Allowed spaces in the link shortcodes for legacy CMS support

If it’d be preferred, I can re-add the old file link tracking (that searches the href for `ASSETS_DIR`) in case any legacy CMS content is relying on that.
