### PR TITLE
VirtualPage getCMSFields problems with LiteralFields

### DIFF
--- a/code/model/VirtualPage.php
+++ b/code/model/VirtualPage.php
@@ -166,8 +166,6 @@ class VirtualPage extends Page {
 	 * Generate the CMS fields from the fields from the original page.
 	 */
 	public function getCMSFields() {
-		//$fields = parent::getCMSFields();
-		
                 
                 $self = $this;
 		$this->beforeUpdateCMSFields(function($fields) use ($self) {
@@ -232,7 +230,6 @@ class VirtualPage extends Page {
                             'CopyContentFromID'
                     );
                 });
-		//return $fields;
                 return parent::getCMSFields();
 	}
 


### PR DESCRIPTION
Fixed the Main Virtual Page to allow for not displaying LiteralFields twice when using DataExtension See bugs fixes #2827, #2850. This is using the same techniques as $member->getCMSFields();
