### PR TITLE
Update travis configuration to use composer phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
  - cd ~/builds/ss
 
 script: 
- - phpunit cms/tests/
+ - vendor/bin/phpunit cms/tests/
 
 branches:
   except:

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
 		"composer/installers": "*",
 		"silverstripe/framework": "3.0.*"
 	},
+	"require-dev": {
+		"phpunit/PHPUnit": "~3.7"
+	},
 	"autoload": {
 		"classmap": ["tests/behat/"]
 	}


### PR DESCRIPTION
Since travis updated to using phpunit 4 by default our test cases (which rely on 3.7) have been breaking.

See https://github.com/silverstripe-labs/silverstripe-travis-support/pull/5
