### PR TITLE
Update travis configuration to use composer phpunit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
       env: DB=MYSQL CORE_RELEASE=3.1
     - php: 5.4
       env: DB=MYSQL CORE_RELEASE=3.1 BEHAT_TEST=1
+  allow_failures:
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.1
 
 before_script:
  - composer self-update
@@ -38,7 +41,7 @@ before_script:
  - php ~/travis-support/travis_setup_php54_webserver.php --if-env BEHAT_TEST
 
 script: 
- - "if [ \"$BEHAT_TEST\" = \"\" ]; then phpunit cms/tests; fi"
+ - "if [ \"$BEHAT_TEST\" = \"\" ]; then vendor/bin/phpunit cms/tests; fi"
  - "if [ \"$BEHAT_TEST\" = \"1\" ]; then vendor/bin/behat @cms; fi"
 
 after_failure:


### PR DESCRIPTION
Since travis updated to using phpunit 4 by default our test cases (which rely on 3.7) have been breaking.
Made PHP 5.6 an allowed failure, which is due to Zend framework v1 using deprecated code.

See silverstripe-labs/silverstripe-travis-support#5
