### PR TITLE
BUG Fix encoding of SearchForm::getSearchQuery

### DIFF
--- a/code/search/ContentControllerSearchExtension.php
+++ b/code/search/ContentControllerSearchExtension.php
@@ -42,7 +42,7 @@ class ContentControllerSearchExtension extends Extension {
 	public function results($data, $form, $request) {
 		$data = array(
 			'Results' => $form->getResults(),
-			'Query' => $form->getSearchQuery(),
+			'Query' => DBField::create_field('Text', $form->getSearchQuery()),
 			'Title' => _t('SearchForm.SearchResults', 'Search Results')
 		);
 		return $this->owner->customise($data)->renderWith(array('Page_results', 'Page'));

--- a/code/search/SearchForm.php
+++ b/code/search/SearchForm.php
@@ -27,6 +27,10 @@ class SearchForm extends Form {
 		"SiteTree", "File"
 	);
 	
+	private static $casting = array(
+		'SearchQuery' => 'Text'
+	);
+	
 	/**
 	 * 
 	 * @param Controller $controller
@@ -186,7 +190,7 @@ class SearchForm extends Form {
 		if(!isset($data)) $data = $_REQUEST;
 		
 		// The form could be rendered without the search being done, so check for that.
-		if (isset($data['Search'])) return Convert::raw2xml($data['Search']);
+		if (isset($data['Search'])) return $data['Search'];
 	}
 	
 	/**


### PR DESCRIPTION
This made it awkward for user code to extract the query value for use in other applications; This would otherwise have to be xml decoded again.
Casting has been promoted to the templating level via `DBField::create_field` and a `SearchForm.casting` config setting.

Rebase of https://github.com/silverstripe/silverstripe-cms/pull/1005 against master
[ref: CWPBUG-153]
