### PR TITLE
BUG Fix sorting on main ReportAdmin grid

### DIFF
--- a/code/controllers/ReportAdmin.php
+++ b/code/controllers/ReportAdmin.php
@@ -37,7 +37,9 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider {
 		parent::init();
 
 		//set the report we are currently viewing from the URL
-		$this->reportClass = (isset($this->urlParams['ReportClass'])) ? $this->urlParams['ReportClass'] : null;
+		$this->reportClass = (isset($this->urlParams['ReportClass']) && $this->urlParams['ReportClass'] !== 'index')
+			? $this->urlParams['ReportClass']
+			: null;
 		$allReports = SS_Report::get_reports();
 		$this->reportObject = (isset($allReports[$this->reportClass])) ? $allReports[$this->reportClass] : null;
 
@@ -132,8 +134,11 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider {
 	 * @return String
 	 */
 	public function Link($action = null) {
-		$link = parent::Link($action);
-		if ($this->reportObject) $link = $this->reportObject->getLink($action);
+		if ($this->reportObject) {
+			$link = $this->reportObject->getLink($action);
+		} else {
+			$link = self::join_links(parent::Link('index'), $action);
+		}
 		return $link;
 	}
 

--- a/code/reports/Report.php
+++ b/code/reports/Report.php
@@ -83,6 +83,15 @@ class SS_Report extends ViewableData {
 	}
 	
 	/**
+	 * Allows access to title as a property
+	 * 
+	 * @return string
+	 */
+	public function getTitle() {
+		return $this->title();
+	}
+	
+	/**
 	 * Return the description of this report.
 	 * 
 	 * You have two ways of specifying the description:


### PR DESCRIPTION
Currently trying to sort the reportadmin grid results in a JS error. This is due to the controller routing not properly supporting multiple routes. This fix mocks an 'index' sub-action to expose the main form via ajax.

ref: CWPBUG-133

Depends on https://github.com/silverstripe/silverstripe-framework/pull/3139 and https://github.com/silverstripe/silverstripe-framework/pull/3138
