### PR TITLE
Corrected the CMS fields displayed for a Virtual Page.

### DIFF
--- a/code/model/VirtualPage.php
+++ b/code/model/VirtualPage.php
@@ -165,7 +165,7 @@ class VirtualPage extends Page {
 	 * Generate the CMS fields from the fields from the original page.
 	 */
 	public function getCMSFields() {
-		$fields = parent::getCMSFields();
+		$fields = $this->CopyContentFrom()->getCMSFields();
 		
 		// Setup the linking to the original page.
 		$copyContentFromField = new TreeDropdownField(


### PR DESCRIPTION
Currently the Virtual Page will only display fields defined in Page, however this causes issues when you have a Virtual Page pointing to a subclass containing additional fields (that the user may wish to view).
