### PR TITLE
Pulls/redirector proto relative

### DIFF
--- a/code/model/RedirectorPage.php
+++ b/code/model/RedirectorPage.php
@@ -107,7 +107,11 @@ class RedirectorPage extends Page {
 		parent::onBeforeWrite();
 
 		// Prefix the URL with "http://" if no prefix is found
-		if($this->ExternalURL && (strpos($this->ExternalURL, '://') === false)) {
+		if(
+			$this->ExternalURL 
+			&& !parse_url($this->ExternalURL, PHP_URL_SCHEME) 
+			&& !preg_match('#^//#', $this->ExternalURL)
+		) {
 			$this->ExternalURL = 'http://' . $this->ExternalURL;
 		}
 	}

--- a/tests/model/RedirectorPageTest.php
+++ b/tests/model/RedirectorPageTest.php
@@ -50,4 +50,18 @@ class RedirectorPageTest extends FunctionalTest {
 		$page->write();
 		$this->assertEquals($page->ExternalURL, 'http://google.com', 'onBeforeWrite will not double prefix if written again!');
 	}
+
+	public function testAllowsProtocolRelative() {
+		$noProtocol = new RedirectorPage(array('ExternalURL' => 'mydomain.com'));
+		$noProtocol->write();
+		$this->assertEquals('http://mydomain.com', $noProtocol->ExternalURL);
+
+		$protocolAbsolute = new RedirectorPage(array('ExternalURL' => 'http://mydomain.com'));
+		$protocolAbsolute->write();
+		$this->assertEquals('http://mydomain.com', $protocolAbsolute->ExternalURL);
+
+		$protocolRelative = new RedirectorPage(array('ExternalURL' => '//mydomain.com'));
+		$protocolRelative->write();
+		$this->assertEquals('//mydomain.com', $protocolRelative->ExternalURL);
+	}
 }


### PR DESCRIPTION
Allows for consistent redirection via http:// or https://. Use case is an external site which "shares" the login state by including an iframe from the SilverStripe site as a header. Since I've set `Session.cookie_secure=true`, the http:// and https:// versions don't share a cookie, so we have to ensure the correct protocol is retained.
