### PR TITLE
BUG Fix deleted pages redirecting the CMS

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -120,12 +120,6 @@ class ContentController extends Controller {
 			)
 		) {
 			if(!$this->dataRecord->canViewStage(Versioned::current_archived_date() ? 'Stage' : Versioned::current_stage())) {
-				$link = $this->Link();
-				$message = _t(
-					"ContentController.DRAFT_SITE_ACCESS_RESTRICTION", 
-					'You must log in with your CMS password in order to view the draft or archived content. ' .
-					'<a href="%s">Click here to go back to the published site.</a>'
-				);
 				Session::clear('currentStage');
 				Session::clear('archiveDate');
 				

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1397,7 +1397,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$tags .= $this->ExtraMeta . "\n";
 		} 
 		
-		if(Permission::check('CMS_ACCESS_CMSMain') && in_array('CMSPreviewable', class_implements($this)) && !$this instanceof ErrorPage) {
+		if(Permission::check('CMS_ACCESS_CMSMain')
+			&& in_array('CMSPreviewable', class_implements($this))
+			&& !$this instanceof ErrorPage
+			&& $this->ID > 0
+		) {
 			$tags .= "<meta name=\"x-page-id\" content=\"{$this->ID}\" />\n";
 			$tags .= "<meta name=\"x-cms-edit-link\" content=\"" . $this->CMSEditLink() . "\" />\n";
 		}

--- a/tests/behat/features/insert-a-link.feature
+++ b/tests/behat/features/insert-a-link.feature
@@ -50,8 +50,7 @@ So that I can link to a external website or a page on my site
     And I select "awesome" in the "Content" HTML field
     When I press the "Insert Link" button
     When I select the "Anchor on this page" radio button
-    # Need to hard-code the id attribute of the <select> here, as there are two form fields to pick from
-    And I select "myanchor" from "Form_EditorToolbarLinkForm_AnchorSelector"
+    And I fill in "myanchor" for "Anchor"
     And I press the "Insert link" button
     Then the "Content" HTML field should contain "<a href="#myanchor">awesome</a>"
     # Required to avoid "unsaved changes" browser dialog

--- a/tests/behat/features/manage-files.feature
+++ b/tests/behat/features/manage-files.feature
@@ -71,7 +71,7 @@ Feature: Manage files
   Scenario: I can filter the files list view using filetype
     Given a "file" "assets/document.pdf"
     And I expand the "Filter" CMS Panel
-    And I select "Image" from "File type"
+    And I select "Image" from "File type" with javascript
     And I press the "Apply Filter" button
     Then the "Files" table should contain "file1"
     And the "Files" table should not contain "document"

--- a/tests/behat/features/manage-page-permissions.feature
+++ b/tests/behat/features/manage-page-permissions.feature
@@ -30,7 +30,7 @@ Scenario: I can limit global view permissions to logged-in users
 
 Scenario: I can limit global view permissions to certain groups
 	Given I select "Only these people (choose from list)" from "Who can view pages on this site?" input group
-	And I select "AUTHOR group" from "Viewer Groups"
+	And I select "AUTHOR group" from "Viewer Groups" with javascript
 	And I press the "Save" button
 	When I am not logged in
 	And I go to the homepage
@@ -51,7 +51,7 @@ Scenario: I can limit global edit permissions to logged-in users
 
 Scenario: I can limit global edit permissions to certain groups
 	Given I select "Only these people (choose from list)" from "Who can edit pages on this site?" input group
-	And I select "ADMIN group" from "Viewer Groups"
+	And I select "ADMIN group" from "Editor Groups" with javascript
 	And I press the "Save" button
 	Then pages should not be editable by "AUTHOR"
 	But pages should be editable by "ADMIN"

--- a/tests/behat/features/publish-a-page.feature
+++ b/tests/behat/features/publish-a-page.feature
@@ -61,7 +61,7 @@ So that only high quality changes are seen by our visitors
 		Given I am logged in with "ADMIN" permissions
 		And I go to "/admin/pages"
 		And I should see "Hello" in the tree
-		And I follow "Hello"
+		And I click on "Hello" in the tree
 
 		When I click "More options" in the "#ActionMenus" element
 		And I press the "Unpublish" button
@@ -75,7 +75,7 @@ So that only high quality changes are seen by our visitors
 		Given I am logged in with "ADMIN" permissions
 		And I go to "/admin/pages"
 		And I should see "My Page" in the tree
-		When I follow "My Page"
+		And I click on "My Page" in the tree
 		And I press the "Publish" button
 		And I click "More options" in the "#ActionMenus" element
 		Then I should see "Unpublish" in the "#ActionMenus_MoreOptions" element


### PR DESCRIPTION
Update behat tests for Mink 1.6 compatibility

Fixes issue with viewing of archived (deleted) pages in the cms preview pane which was breaking behat tests

Relies on https://github.com/silverstripe-labs/silverstripe-behat-extension/pull/47 to be merged first
