### PR TITLE
Ensure that all child pages are deleted (regardless of their ShowInMenu ...

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1562,7 +1562,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		parent::onBeforeDelete();
 		
 		// If deleting this page, delete all its children.
-		if(SiteTree::config()->enforce_strict_hierarchy && $children = $this->Children()) {
+		if(SiteTree::config()->enforce_strict_hierarchy && $children = $this->AllChildren()) {
 			foreach($children as $child) {
 				$child->delete();
 			}

--- a/tests/model/SiteTreeTest.yml
+++ b/tests/model/SiteTreeTest.yml
@@ -56,6 +56,7 @@ Page:
     Title: Staff
     URLSegment: my-staff
     Parent: =>Page.about
+    ShowInMenus: 0
   products:
     Title: Products
     CanEditType: OnlyTheseUsers


### PR DESCRIPTION
...status) when a page is deleted and enforce_strict_hierarchy is enabled

Solution for: https://github.com/silverstripe/silverstripe-cms/issues/1026
