### PR TITLE
BUG: Broken links in the 'Dependent pages' tab

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1830,14 +1830,14 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				->setFieldFormatting(array(
 					'Title' => function($value, &$item) {
 						return sprintf(
-							'<a href=\"admin/pages/edit/show/%d\">%s</a>',
+							'<a href="admin/pages/edit/show/%d">%s</a>',
 							(int)$item->ID,
 							Convert::raw2xml($item->Title)
 						);
 					},
 					'AbsoluteLink' => function($value, &$item) {
 						return sprintf(
-							'<a href=\"%s\">%s</a>',
+							'<a href="%s">%s</a>',
 							Convert::raw2xml($value),
 							Convert::raw2xml($value)
 						);


### PR DESCRIPTION
The double quotes in links href is 'escaped' even though the surrounding quotes are single quotes
