### PR TITLE
Pulls/3.2/fix upload behat

### DIFF
--- a/tests/behat/features/insert-an-image.feature
+++ b/tests/behat/features/insert-an-image.feature
@@ -40,18 +40,18 @@ Feature: Insert an image into a page
     Then I press the "Save draft" button
 
   @assets
-  Scenario: I can overwrite an existing image with one uploaded from my own computer
+  Scenario: I can upload an image from my own computer that matches the name of an existing file
     Given a "image" "assets/Uploads/file1.jpg"
     When I press the "Insert Media" button
     And I press the "From your computer" button
     And I attach the file "file1.jpg" to "AssetUploadField" with HTML5
     # TODO Delay previous step until upload succeeded
     And I wait for 2 seconds
-    Then I should see "Overwrite"
-    When I press the "Overwrite" button
+    # Note change in default behaviour from 3.1, respect default Upload.replaceFile=false
     Then there should be a file "assets/Uploads/file1.jpg"
+    And there should be a file "assets/Uploads/file2.jpg"
     When I press the "Insert" button
-    Then the "Content" HTML field should contain "file1.jpg"
+    Then the "Content" HTML field should contain "file2.jpg"
     # Required to avoid "unsaved changed" browser dialog
     Then I press the "Save draft" button
 


### PR DESCRIPTION
Due to the change in behaviour from https://github.com/silverstripe/silverstripe-framework/commit/5f7ebd3c235d663b5ad5c0fbcd3d393d2e893306 in 3.2, we now respect the value of the `Upload.replaceFile` config, rather than forcing it to true if we notify of replacement. Now we instead only show the notification if this config would trigger an overwrite.

The new default behaviour is to rename the file, as it used to be prior to the addition of the overwrite notification.
