### PR TITLE
Change SiteTreeHints to check for canEdit

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -386,12 +386,12 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$json = '';
 		$classes = SiteTree::page_type_classes();
 
-	 	$cacheCanCreate = array();
-	 	foreach($classes as $class) $cacheCanCreate[$class] = singleton($class)->canCreate();
+	 	$cacheCanEdit = array();
+	 	foreach($classes as $class) $cacheCanEdit[$class] = singleton($class)->canEdit();
 
 	 	// Generate basic cache key. Too complex to encompass all variations
 	 	$cache = SS_Cache::factory('CMSMain_SiteTreeHints');
-	 	$cacheKey = md5(implode('_', array(Member::currentUserID(), implode(',', $cacheCanCreate), implode(',', $classes))));
+	 	$cacheKey = md5(implode('_', array(Member::currentUserID(), implode(',', $cacheCanEdit), implode(',', $classes))));
 	 	if($this->request->getVar('flush')) $cache->clean(Zend_Cache::CLEANING_MODE_ALL);
 	 	$json = $cache->load($cacheKey);
 	 	if(!$json) {
@@ -420,7 +420,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				
 				if(
 					($obj instanceof HiddenClass)
-					|| (!array_key_exists($class, $cacheCanCreate) || !$cacheCanCreate[$class])
+					|| (!array_key_exists($class, $cacheCanEdit) || !$cacheCanEdit[$class])
 					|| ($needsPerm && !$this->can($needsPerm))
 				) {
 					$globalDisallowed[] = $class;

--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -387,7 +387,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$classes = SiteTree::page_type_classes();
 
 	 	$cacheCanEdit = array();
-	 	foreach($classes as $class) $cacheCanEdit[$class] = singleton($class)->canEdit();
+	 	foreach($classes as $class) {
+			if ($classInstance = $class::get()->First()) {
+				$cacheCanEdit[$class] = $classInstance->canEdit();
+			}
+		}
 
 	 	// Generate basic cache key. Too complex to encompass all variations
 	 	$cache = SS_Cache::factory('CMSMain_SiteTreeHints');


### PR DESCRIPTION
Allowing ability to have
public function canCreate($member = null) {
    return MyPage::get()->count() < 1;
}
and still be able to re-order this page in the sitetree.

I have tested moving pages in site tree, with and without the canCreate and canEdit rules, can_be_root and allowed_children statics.

This Fixes #657
