### PR TITLE
FIX ensure controller stack is updated when execution halted by an exception

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -193,8 +193,18 @@ class ContentController extends Controller {
 			}
 			
 			Director::set_current_page($this->data());
-			$response = parent::handleRequest($request, $model);
-			Director::set_current_page(null);
+
+			try {
+				$response = parent::handleRequest($request, $model);
+
+				Director::set_current_page(null);
+			} catch(SS_HTTPResponse_Exception $e) {
+				$this->popCurrent();
+				
+				Director::set_current_page(null);
+
+				throw $e;
+			}
 		}
 		
 		return $response;


### PR DESCRIPTION
From https://github.com/silverstripe/silverstripe-framework/issues/2467

popCurrent would be incorrectly not pop a controller from the controller stack if an exception was throw from inside the handleRequest() method.

This change captures the exception, ensures the controller is popped from the stack and passes the exception along.
