### PR TITLE
API Custom admin URL

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -12,10 +12,3 @@ Director:
     'RemoveOrphanedPagesTask//$Action/$ID/$OtherID': 'RemoveOrphanedPagesTask'
     'SiteTreeMaintenanceTask//$Action/$ID/$OtherID': 'SiteTreeMaintenanceTask'
     'SiteTreeMaintenanceTask//$Action/$ID/$OtherID': 'SiteTreeMaintenanceTask'
----
-Name: legacycmsroutes
-After: '#adminroutes'
----
-Director:
-  rules:
-    'admin/cms': '->admin/pages'

--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -169,7 +169,7 @@ JS
 			new GridFieldEditButton(),
 			new GridFieldDeleteAction(),
 			new GridFieldDetailForm(),
-			GridFieldLevelup::create($folder->ID)->setLinkSpec('admin/assets/show/%d')
+			GridFieldLevelup::create($folder->ID)->setLinkSpec(AdminRootController::admin_url().'assets/show/%d')
 		);
 
 		$gridField = GridField::create('File', $title, $this->getList(), $gridFieldConfig);

--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -148,7 +148,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	 */
 	public function Link($action = null) {
 		$link = Controller::join_links(
-			$this->stat('url_base', true),
+			AdminRootController::admin_url(),
 			$this->stat('url_segment', true), // in case we want to change the segment
 			'/', // trailing slash needed if $action is null!
 			"$action"

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1492,7 +1492,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			if(!SiteTree::get_by_link(Config::inst()->get('RootURLController', 'default_homepage_link'))) {
 				$homepage = new Page();
 				$homepage->Title = _t('SiteTree.DEFAULTHOMETITLE', 'Home');
-				$homepage->Content = _t('SiteTree.DEFAULTHOMECONTENT', '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>. You can now access the <a href="http://doc.silverstripe.org">developer documentation</a>, or begin <a href="http://doc.silverstripe.org/doku.php?id=tutorials">the tutorials.</a></p>');
+				$homepage->Content = _t('SiteTree.DEFAULTHOMECONTENT', '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="'.AdminRootController::admin_url().'">the CMS</a>. You can now access the <a href="http://doc.silverstripe.org">developer documentation</a>, or begin <a href="http://doc.silverstripe.org/doku.php?id=tutorials">the tutorials.</a></p>');
 				$homepage->URLSegment = Config::inst()->get('RootURLController', 'default_homepage_link');
 				$homepage->Sort = 1;
 				$homepage->write();
@@ -1914,9 +1914,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 					$parentPage = $linkedPage->Parent;
 					if($parentPage) {
 						if($parentPage->ID) {
-							$parentPageLinks[] = "<a class=\"cmsEditlink\" href=\"admin/pages/edit/show/$linkedPage->ID\">{$parentPage->Title}</a>";
+							$parentPageLinks[] = "<a class=\"cmsEditlink\" href=\"".AdminRootController::admin_url()."pages/edit/show/$linkedPage->ID\">{$parentPage->Title}</a>";
 						} else {
-							$parentPageLinks[] = "<a class=\"cmsEditlink\" href=\"admin/pages/edit/show/$linkedPage->ID\">" .
+							$parentPageLinks[] = "<a class=\"cmsEditlink\" href=\"".AdminRootController::admin_url()."pages/edit/show/$linkedPage->ID\">" .
 								_t('SiteTree.TOPLEVEL', 'Site Content (Top Level)') .
 								"</a>";
 						}
@@ -1968,7 +1968,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				->setFieldFormatting(array(
 					'Title' => function($value, &$item) {
 						return sprintf(
-							'<a href="admin/pages/edit/show/%d">%s</a>',
+							'<a href=\"'.AdminRootController::admin_url().'pages/edit/show/%d\">%s</a>',
 							(int)$item->ID,
 							Convert::raw2xml($item->Title)
 						);

--- a/code/model/VirtualPage.php
+++ b/code/model/VirtualPage.php
@@ -191,7 +191,7 @@ class VirtualPage extends Page {
 		
 		// Create links back to the original object in the CMS
 		if($this->CopyContentFrom()->exists()) {
-			$link = "<a class=\"cmsEditlink\" href=\"admin/pages/edit/show/$this->CopyContentFromID\">" 
+			$link = "<a class=\"cmsEditlink\" href=\"".AdminRootController::admin_url()."pages/edit/show/$this->CopyContentFromID\">" 
 				. _t('VirtualPage.EditLink', 'edit')
 				. "</a>";
 			$msgs[] = _t(

--- a/javascript/AssetAdmin.js
+++ b/javascript/AssetAdmin.js
@@ -11,7 +11,7 @@
 		$(document).ready(function() {
 			$('#Form_BatchActionsForm').entwine('.ss.tree').register(
 				// TODO Hardcoding of base URL
-				'admin/assets/batchactions/delete', 
+				ss.config.adminURL+'assets/batchactions/delete', 
 				function(ids) {
 					var confirmed = confirm(
 						ss.i18n.sprintf(
@@ -112,7 +112,7 @@
 						  var url = $(currNode).find('a').attr('href');
 							$('.cms-content').loadPanel(url);
 						}
-						$('.cms-tree')[0].setCustomURL('admin/assets/getsubtree');
+						$('.cms-tree')[0].setCustomURL(ss.config.adminURL+'assets/getsubtree');
 						$('.cms-tree')[0].reload({onSuccess: function() {
 							// TODO Reset current tree node
 						}});

--- a/tasks/RemoveOrphanedPagesTask.php
+++ b/tasks/RemoveOrphanedPagesTask.php
@@ -97,7 +97,7 @@ in the other stage:<br />
 				array("\"$orphanBaseClass\".\"ID\"" => $orphan->ID)
 			);
 			$label = sprintf(
-				'<a href="admin/pages/edit/show/%d">%s</a> <small>(#%d, Last Modified Date: %s, Last Modifier: %s, %s)</small>',
+				'<a href="'.AdminRootController::admin_url().'pages/edit/show/%d">%s</a> <small>(#%d, Last Modified Date: %s, Last Modifier: %s, %s)</small>',
 				$orphan->ID,
 				$orphan->Title,
 				$orphan->ID,

--- a/templates/Includes/Install_deleteinstallfiles.ss
+++ b/templates/Includes/Install_deleteinstallfiles.ss
@@ -13,7 +13,7 @@
 		<%t ContentController.InstallFilesDeleted "Installation files have been successfully deleted." %>
 	</p>
 	<p style="margin: 1em 0">
-		<%t ContentController.StartEditing 'You can start editing your content by opening <a href="{link}">the CMS</a>.' link="admin/" %>
+		<%t ContentController.StartEditing 'You can start editing your content by opening <a href="{link}">the CMS</a>.' link=$AdminURL %>
 		<br />
 		&nbsp; &nbsp; <%t ContentController.Email "Email" %>: $Username<br />
 		&nbsp; &nbsp; <%t ContentController.Password "Password" %>: $Password<br />

--- a/templates/Includes/Install_successfullyinstalled.ss
+++ b/templates/Includes/Install_successfullyinstalled.ss
@@ -10,7 +10,7 @@
 	<strong>&nbsp; &nbsp; <%t ContentController.Password "Password" %>: $Password</strong></p>
 
 <p>
-	<%t ContentController.StartEditing 'You can start editing your content by opening <a href="{link}">the CMS</a>.' link="admin/" %>
+	<%t ContentController.StartEditing 'You can start editing your content by opening <a href="{link}">the CMS</a>.' link=$AdminURL %>
 </p>
 
 <div style="background:#fcf8f2; border-radius:4px; border: 1px solid #ffc28b; padding:5px; margin:5px;">


### PR DESCRIPTION
CMS version of the main Framework pull request that allow for custom admin URL via yml config.

This basically tries to remove all occurrences of hard-coded admin URL. Also removed the `#legacycmsroutes` since those are deprecated since version 2.3 I think, hope that's OK.

Work in progress for now so we can discuss the implementation. Will be squashed and made ready once all OK.

Main PR here https://github.com/silverstripe/silverstripe-framework/pull/3274
