### PR TITLE
FIX so that OldPageRedirector::find_old_page uses ORM call

### DIFF
--- a/code/controllers/OldPageRedirector.php
+++ b/code/controllers/OldPageRedirector.php
@@ -48,20 +48,17 @@ class OldPageRedirector extends Extension {
 		}
 
 		if (!$page) {
-			// If we haven't found a candidate, lets resort to finding an old page with this URL segment
-			// TODO: Rewrite using ORM syntax
-			$query = new SQLQuery (
-				'"RecordID"',
-				'"SiteTree_versions"',
-				"\"URLSegment\" = '$URL' AND \"WasPublished\" = 1" . ($parent ? ' AND "ParentID" = ' . $parent->ID : ''),
-				'"LastEdited" DESC',
-				null,
-				null,
-				1
-			);
-			$record = $query->execute()->first();
+			// If we haven't found a candidate, resort to finding a previously published page version with this URL segment
+			 $record = DataList::create('SiteTree')
+             ->where("\"URLSegment\" = '$URL'")
+             ->where("\"WasPublished\" = 1")
+             ->where($parent ? ' AND "ParentID" = ' . $parent->ID : '')
+             ->sort('"LastEdited" DESC')
+             ->limit(1)
+             ->setDataQueryParam("Versioned.mode", 'all_versions')->first();
+
 			if ($record) {
-				$page = SiteTree::get()->byID($record['RecordID']);
+				$page = SiteTree::get()->byID($record->RecordID);
 				$redirect = true;
 			}
 		}

--- a/code/controllers/OldPageRedirector.php
+++ b/code/controllers/OldPageRedirector.php
@@ -7,7 +7,6 @@ class OldPageRedirector extends Extension {
 	 * find an old URL that it should be redirecting to.
 	 *
 	 * @param SS_HTTPResponse $request The request object
-	 * @throws SS_HTTPResponse_Exception
 	 */
 	public function onBeforeHTTPError404($request) {
 		// Build up the request parameters
@@ -50,12 +49,13 @@ class OldPageRedirector extends Extension {
 		if (!$page) {
 			// If we haven't found a candidate, resort to finding a previously published page version with this URL segment
 			$oldRecords = DataList::create('SiteTree')
-	             ->where("\"URLSegment\" = '$URL'")
-	             ->where("\"WasPublished\" = 1")
-	             ->sort('"LastEdited" DESC')
-	             ->limit(1)
-	             ->setDataQueryParam("Versioned.mode", 'all_versions');
-            if($parent) $oldRecords->where('"ParentID" = ' . $parent->ID);
+	            	->filter(array(
+	            		'URLSegment' => $URL,
+	            		'WasPublished' => 1))
+	            	->sort('"LastEdited" DESC')
+	            	->setDataQueryParam("Versioned.mode", 'all_versions');
+
+            if($parent) $oldRecords->filter(array('ParentID' => $parent->ID));
 
             $record = $oldRecords->first();
             

--- a/code/controllers/OldPageRedirector.php
+++ b/code/controllers/OldPageRedirector.php
@@ -49,14 +49,16 @@ class OldPageRedirector extends Extension {
 
 		if (!$page) {
 			// If we haven't found a candidate, resort to finding a previously published page version with this URL segment
-			 $record = DataList::create('SiteTree')
-             ->where("\"URLSegment\" = '$URL'")
-             ->where("\"WasPublished\" = 1")
-             ->where($parent ? ' AND "ParentID" = ' . $parent->ID : '')
-             ->sort('"LastEdited" DESC')
-             ->limit(1)
-             ->setDataQueryParam("Versioned.mode", 'all_versions')->first();
+			$oldRecords = DataList::create('SiteTree')
+	             ->where("\"URLSegment\" = '$URL'")
+	             ->where("\"WasPublished\" = 1")
+	             ->sort('"LastEdited" DESC')
+	             ->limit(1)
+	             ->setDataQueryParam("Versioned.mode", 'all_versions');
+            if($parent) $oldRecords->where('"ParentID" = ' . $parent->ID);
 
+            $record = $oldRecords->first();
+            
 			if ($record) {
 				$page = SiteTree::get()->byID($record->RecordID);
 				$redirect = true;


### PR DESCRIPTION
Cleaning out a TODO item in OldPageRedirector so that we now use ORM syntax to find old versions of pages.