### PR TITLE
BUG: Narrowing site tree search to one date shows no pages

### DIFF
--- a/code/controllers/CMSSiteTreeFilter.php
+++ b/code/controllers/CMSSiteTreeFilter.php
@@ -153,12 +153,12 @@ abstract class CMSSiteTreeFilter extends Object {
 
 				case 'LastEditedFrom':
 					$fromDate = new DateField(null, null, $val);
-					$query = $query->filter("LastEdited:GreaterThanOrEqual", $fromDate->dataValue());
+					$query = $query->filter("LastEdited:GreaterThanOrEqual", $fromDate->dataValue().' 00:00:00');
 					break;
 
 				case 'LastEditedTo':
 					$toDate = new DateField(null, null, $val);
-					$query = $query->filter("LastEdited:LessThanOrEqual", $toDate->dataValue());
+					$query = $query->filter("LastEdited:LessThanOrEqual", $toDate->dataValue().' 23:59:59');
 					break;
 
 				case 'ClassName':

--- a/tests/controller/CMSSiteTreeFilterTest.php
+++ b/tests/controller/CMSSiteTreeFilterTest.php
@@ -114,7 +114,19 @@ class CMSSiteTreeFilterTest extends SapphireTest {
 		$f = new CMSSiteTreeFilter_StatusDraftPages();
 		$draftPage->delete();
 		$this->assertEmpty($f->isPageIncluded($draftPage));		
-	}			
+	}
+
+	public function testDateFromToLastSameDate() {
+		$draftPage = $this->objFromFixture('Page', 'page4');
+		// Grab the date
+		$date = substr($draftPage->LastEdited, 0, 10);
+		// Filter with that date
+		$filter = New CMSSiteTreeFilter_Search(array(
+			'LastEditedFrom' => $date,
+			'LastEditedTo' => $date
+		));
+		$this->assertTrue($filter->isPageIncluded($draftPage), 'Using the same date for from and to should show find that page');
+	}
 	
 	public function testStatusRemovedFromDraftFilter() {
 		$removedDraftPage = $this->objFromFixture('Page', 'page6');


### PR DESCRIPTION
It turns out that the search doesn't work if you put the same date into both start and end date. Adding
time to the query seems to fix this issue.
