### PR TITLE
NEW Adding CMS sitetree filter to see the current 'live' site

### DIFF
--- a/code/controllers/CMSSiteTreeFilter.php
+++ b/code/controllers/CMSSiteTreeFilter.php
@@ -203,6 +203,47 @@ abstract class CMSSiteTreeFilter extends Object {
 }
 
 /**
+ * This filter will display the SiteTree as a site visitor might see the site, i.e only the
+ * pages that is currently published.
+ *
+ * Note that this does not check canView permissions that might hide pages from certain visitors
+ */
+class CMSSIteTreeFilter_PublishedPages extends CMSSiteTreeFilter {
+
+	/**
+	 * @return string
+	 */
+	static public function title() {
+		return _t('CMSSIteTreeFilter_PublishedPages.Title', "Published pages");
+	}
+
+	/**
+	 * @var string
+	 */
+	protected $childrenMethod = "AllHistoricalChildren";
+
+	/**
+	 * @var string
+	 */
+	protected $numChildrenMethod = 'numHistoricalChildren';
+
+	/**
+	 * Filters out all pages who's status who's status that doesn't exist on live
+	 *
+	 * @see {@link SiteTree::getStatusFlags()}
+	 * @return array
+	 */
+	public function pagesIncluded() {
+		$pages = Versioned::get_including_deleted('SiteTree');
+		$pages = $this->applyDefaultFilters($pages);
+		$pages = $pages->filterByCallback(function($page) {
+			return $page->ExistsOnLive;
+		});
+		return $this->mapIDs($pages);
+	}
+}
+
+/**
  * Works a bit different than the other filters:
  * Shows all pages *including* those deleted from stage and live.
  * It does not filter out pages still existing in the different stages.

--- a/tests/behat/features/search-for-a-page.feature
+++ b/tests/behat/features/search-for-a-page.feature
@@ -96,3 +96,18 @@ Feature: Search for a page
 		And I press the "Apply Filter" button
 		Then I should see "Live Page" in the tree
 		And I should not see "About Us" in the tree
+
+	Scenario: I can include only live pages in my search
+		Given a "page" "Live Page"
+		And the "page" "Live Page" is published
+		And a "page" "Draft Page"
+		And a "page" "Draft Page" is unpublished
+		And a "page" "Deleted Page"
+		And the "page" "Deleted Page" is unpublished
+		And the "page" "Deleted Page" is deleted
+
+		When I select "Published pages" from "Pages"
+		And I press the "Apply Filter" button
+		Then I should not see "Draft Page" in the tree
+		And I should not see "Deleted Page" in the tree
+		But I should see "Live Page" in the tree


### PR DESCRIPTION
This adds a new filter that will show a content editor what the current published site-tree
looks like for a visitor. This helps when there is a lot of drafted content that get included
in the default filter 'All Pages'
