### PR TITLE
Fix changed pages filter to match SiteTree's 'MODIFIED' label

### DIFF
--- a/code/controllers/CMSSiteTreeFilter.php
+++ b/code/controllers/CMSSiteTreeFilter.php
@@ -300,7 +300,7 @@ class CMSSiteTreeFilter_ChangedPages extends CMSSiteTreeFilter {
 		$pages = Versioned::get_by_stage('SiteTree', 'Stage');
 		$pages = $this->applyDefaultFilters($pages)
 			->leftJoin('SiteTree_Live', '"SiteTree_Live"."ID" = "SiteTree"."ID"')
-			->where('"SiteTree"."Version" > "SiteTree_Live"."Version"');
+			->where('"SiteTree"."Version" <> "SiteTree_Live"."Version"');
 		return $pages;
 	}	
 }

--- a/tests/controller/CMSSiteTreeFilterTest.php
+++ b/tests/controller/CMSSiteTreeFilterTest.php
@@ -72,6 +72,17 @@ class CMSSiteTreeFilterTest extends SapphireTest {
 		$f = new CMSSiteTreeFilter_ChangedPages(array('Term' => 'No Matches'));
 		$results = $f->pagesIncluded();
 		$this->assertEquals(0, count($results));
+
+		// If we roll back to an earlier version than what's on the published site, we should still show the changed
+		$changedPage->Title = 'Changed 2';
+		$changedPage->publish('Stage', 'Live');
+		$changedPage->doRollbackTo(1);
+
+		$f = new CMSSiteTreeFilter_ChangedPages(array('Term' => 'Changed'));
+		$results = $f->pagesIncluded();
+
+		$this->assertEquals(1, count($results));
+		$this->assertEquals(array('ID' => $changedPage->ID, 'ParentID' => 0), $results[0]);
 	}
 	
 	public function testDeletedPagesFilter() {


### PR DESCRIPTION
This change matches how SiteTree::getIsModifiedOnStage() is used to determine whether or not to show the 'MODIFIED' label (ensures that we check for versions that are both less than or greater than the live stage version).
