### PR TITLE
FIX: allow creating SS_Reports with sourceQuery, instead of only sourceRecords

### DIFF
--- a/code/reports/Report.php
+++ b/code/reports/Report.php
@@ -120,7 +120,7 @@ class SS_Report extends ViewableData {
 		if($this->hasMethod('sourceRecords')) {
 			return $this->sourceRecords($params, null, null);
 		} else {
-			$query = $this->sourceQuery();
+			$query = $this->sourceQuery($params);
 			$results = new ArrayList();
 			foreach($query->execute() as $data) {
 				$class = $this->dataClass();
@@ -266,7 +266,7 @@ class SS_Report extends ViewableData {
 	public function getReportField() {
 		// TODO Remove coupling with global state
 		$params = isset($_REQUEST['filters']) ? $_REQUEST['filters'] : array();
-		$items = $this->sourceRecords($params, null, null);
+		$items = $this->records($params);
 
 		$gridFieldConfig = GridFieldConfig::create()->addComponents(
 			new GridFieldToolbarHeader(),

--- a/tests/reports/ReportTest.php
+++ b/tests/reports/ReportTest.php
@@ -52,6 +52,20 @@ class ReportTest extends SapphireTest {
 			$reportNames,
 			'ReportTest_FakeTest_Abstract is NOT in reports list as it is abstract');
 	}
+
+	public function testReportField() {
+		$report = new ReportTest_FakeTest(); //uses sourceRecords
+		$records = $report->records(array());
+		$this->assertInstanceOf('SS_List', $records);
+		$field = $report->getReportField();
+		$this->assertInstanceOf('GridField', $field);
+		
+		$report = new ReportTest_FakeTest2(); //uses sourceQuery
+		$records = $report->records(array());
+		$this->assertInstanceOf('SS_List', $records);
+		$field = $report->getReportField();
+		$this->assertInstanceOf('GridField', $field);
+	}
 }
 
 class ReportTest_FakeTest extends SS_Report implements TestOnly {
@@ -86,8 +100,8 @@ class ReportTest_FakeTest2 extends SS_Report implements TestOnly {
 			)
 		);
 	}
-	public function sourceRecords($params, $sort, $limit) {
-		return new ArrayList();
+	public function sourceQuery($params) {
+		return new SQLQuery("*","SiteTree");
 	}
 
 	public function sort() {


### PR DESCRIPTION
The code suggests that you can implement either `sourceQuery` or `sourceRecords`:
Report.php line 112: "Please override sourceQuery()/sourceRecords()"

This PR fixes things so that you can in fact do that. Does not break backwards compatibility.