### PR TITLE
Fixing case where customise was failing SiteTreeLinkTracking

### DIFF
--- a/code/model/SiteTreeLinkTracking.php
+++ b/code/model/SiteTreeLinkTracking.php
@@ -151,12 +151,8 @@ class SiteTreeLinkTracking_Highlighter extends Extension {
 	 * to make sure all pages listed in the BrokenLinkChecker highlight these in their content.
 	 */
 	public function onBeforeRender($field) {
-		// Handle situation when the field has been customised, i.e. via $properties on the HtmlEditorField::Field call.
-		$obj = $this->owner->getCustomisedObj() ?: $this->owner;
-		$value = $obj->value;
-
 		// Parse the text as DOM.
-		$htmlValue = Injector::inst()->create('HTMLValue', $value);
+		$htmlValue = Injector::inst()->create('HTMLValue', $this->owner->value);
 		$links = $this->parser->process($htmlValue);
 
 		foreach ($links as $link) {
@@ -172,9 +168,15 @@ class SiteTreeLinkTracking_Highlighter extends Extension {
 			$link['DOMReference']->setAttribute('class', implode(' ', $classes));
 		}
 
-		$obj->customise(array(
+		$this->owner->customise(array(
 			'Value' => htmlentities($htmlValue->getContent(), ENT_COMPAT, 'UTF-8')
 		));
+
+		// Handle situation when the field has been customised, i.e. via $properties on the HtmlEditorField::Field call.
+		$customisedObj = $this->owner->getCustomisedObj();
+		if($customisedObj) {
+			$customisedObj->Value = htmlentities($htmlValue->getContent(), ENT_COMPAT, 'UTF-8');
+		}
 	}
 
 }

--- a/tests/model/SiteTreeLinkTrackingTest.php
+++ b/tests/model/SiteTreeLinkTrackingTest.php
@@ -34,10 +34,10 @@ class SiteTreeLinkTrackingTest extends SapphireTest {
 		$this->assertFalse($this->isBroken("<a href=\"[file_link,id=$file->ID]\">link</a>"));
 	}
 
-	function highlight($content) {
+	function highlight($content, $parameters = array()) {
 		$field = new SiteTreeLinkTrackingTest_Field('Test');
 		$field->setValue($content);
-		$newContent = html_entity_decode($field->Field(), ENT_COMPAT, 'UTF-8');
+		$newContent = html_entity_decode($field->Field($parameters), ENT_COMPAT, 'UTF-8');
 		return $newContent;
 	}
 
@@ -59,6 +59,33 @@ class SiteTreeLinkTrackingTest extends SapphireTest {
 		$this->assertEquals(substr_count($content, 'ss-broken'), 0, 'All ss-broken classes are removed from good link');
 		$this->assertEquals(substr_count($content, 'existing-class'), 1, 'Existing class is not removed.');
 	}
+
+	function testHighlighterCustomisedObj() {
+		$content = $this->highlight(
+			'<a href="[sitetree_link,id=123]" class="existing-class">link</a>',
+			array('test' => '123')
+		);
+		$this->assertEquals(substr_count($content, 'ss-broken'), 1, 'A ss-broken class is added to the broken link.');
+		$this->assertEquals(substr_count($content, 'existing-class'), 1, 'Existing class is not removed.');
+
+		$content = $this->highlight(
+			'<a href="[sitetree_link,id=123]">link</a>',
+			array('test' => '123')
+		);
+		$this->assertEquals(substr_count($content, 'ss-broken'), 1, 'ss-broken class is added to the broken link.');
+
+		$page = new Page();
+		$page->Content = '';
+		$page->write();
+
+		$content = $this->highlight(
+			"<a href=\"[sitetree_link,id=$page->ID]\" class=\"existing-class ss-broken ss-broken\">link</a>",
+			array('test' => '123')
+		);
+		$this->assertEquals(substr_count($content, 'ss-broken'), 0, 'All ss-broken classes are removed from good link');
+		$this->assertEquals(substr_count($content, 'existing-class'), 1, 'Existing class is not removed.');
+	}
+
 }
 
 class SiteTreeLinkTrackingTest_Field extends HtmlEditorField implements TestOnly {


### PR DESCRIPTION
It needs to allow for the case where it customises an existing
customised object, as well as customising the existing context
($this->owner)
