### PR TITLE
Change testing approach to eliminate caching effects

### DIFF
--- a/code/model/SiteTreeLinkTracking.php
+++ b/code/model/SiteTreeLinkTracking.php
@@ -151,12 +151,8 @@ class SiteTreeLinkTracking_Highlighter extends Extension {
 	 * to make sure all pages listed in the BrokenLinkChecker highlight these in their content.
 	 */
 	public function onBeforeRender($field) {
-		// Handle situation when the field has been customised, i.e. via $properties on the HtmlEditorField::Field call.
-		$obj = $this->owner->getCustomisedObj() ?: $this->owner;
-		$value = $obj->value;
-
 		// Parse the text as DOM.
-		$htmlValue = Injector::inst()->create('HTMLValue', $value);
+		$htmlValue = Injector::inst()->create('HTMLValue', $this->owner->value);
 		$links = $this->parser->process($htmlValue);
 
 		foreach ($links as $link) {
@@ -172,9 +168,15 @@ class SiteTreeLinkTracking_Highlighter extends Extension {
 			$link['DOMReference']->setAttribute('class', implode(' ', $classes));
 		}
 
-		$obj->customise(array(
+		$this->owner->customise(array(
 			'Value' => htmlentities($htmlValue->getContent(), ENT_COMPAT, 'UTF-8')
 		));
+
+		// Handle situation when the field has been customised, i.e. via $properties on the HtmlEditorField::Field call.
+		$customisedObj = $this->owner->getCustomisedObj();
+		if($customisedObj) {
+			$customisedObj->Value = htmlentities($htmlValue->getContent(), ENT_COMPAT, 'UTF-8');
+		}
 	}
 
 }

--- a/tests/model/SiteTreeHTMLEditorFieldTest.php
+++ b/tests/model/SiteTreeHTMLEditorFieldTest.php
@@ -6,16 +6,17 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 
 	public function testLinkTracking() {
 		$sitetree = $this->objFromFixture('SiteTree', 'home');
-		$editor   = new HtmlEditorField('Content');
 
 		$aboutID   = $this->idFromFixture('SiteTree', 'about');
 		$contactID = $this->idFromFixture('SiteTree', 'contact');
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue("<a href=\"[sitetree_link,id=$aboutID]\">Example Link</a>");
 		$editor->saveInto($sitetree);
 		$sitetree->write();
 		$this->assertEquals(array($aboutID => $aboutID), $sitetree->LinkTracking()->getIdList(), 'Basic link tracking works.');
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue (
 			"<a href=\"[sitetree_link,id=$aboutID]\"></a><a href=\"[sitetree_link,id=$contactID]\"></a>"
 		);
@@ -27,12 +28,14 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 			'Tracking works on multiple links'
 		);
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(null);
 		$editor->saveInto($sitetree);
 		$sitetree->write();
 		$this->assertEquals(array(), $sitetree->LinkTracking()->getIdList(), 'Link tracking is removed when links are.');
 
 		// Legacy support - old CMS versions added link shortcodes with spaces instead of commas
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue("<a href=\"[sitetree_link id=$aboutID]\">Example Link</a>");
 		$editor->saveInto($sitetree);
 		$sitetree->write();
@@ -45,9 +48,9 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 
 	public function testFileLinkTracking() {
 		$sitetree = $this->objFromFixture('SiteTree', 'home');
-		$editor   = new HtmlEditorField('Content');
 		$fileID   = $this->idFromFixture('File', 'example_file');
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(sprintf(
 			'<p><a href="[file_link,id=%d]">Example File</a></p>',
 			$fileID
@@ -58,12 +61,14 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 			array($fileID => $fileID), $sitetree->ImageTracking()->getIDList(), 'Links to assets are tracked.'
 		);
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(null);
 		$editor->saveInto($sitetree);
 		$sitetree->write();
 		$this->assertEquals(array(), $sitetree->ImageTracking()->getIdList(), 'Asset tracking is removed with links.');
 
 		// Legacy support - old CMS versions added link shortcodes with spaces instead of commas
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(sprintf(
 			'<p><a href="[file_link id=%d]">Example File</a></p>',
 			$fileID
@@ -79,8 +84,8 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 
 	public function testImageInsertion() {
 		$sitetree = new SiteTree();
-		$editor   = new HtmlEditorField('Content');
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue('<img src="assets/example.jpg" />');
 		$editor->saveInto($sitetree);
 		$sitetree->write();
@@ -90,6 +95,7 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 		$this->assertEquals('', (string)$xml[0]['alt'], 'Alt tags are added by default.');
 		$this->assertEquals('', (string)$xml[0]['title'], 'Title tags are added by default.');
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue('<img src="assets/example.jpg" alt="foo" title="bar" />');
 		$editor->saveInto($sitetree);
 		$sitetree->write();
@@ -105,6 +111,7 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 		$editor   = new HtmlEditorField('Content');
 		$fileID   = $this->idFromFixture('Image', 'example_image');
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue('<img src="assets/example.jpg" />');
 		$editor->saveInto($sitetree);
 		$sitetree->write();
@@ -112,6 +119,7 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 			array($fileID => $fileID), $sitetree->ImageTracking()->getIDList(), 'Inserted images are tracked.'
 		);
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(null);
 		$editor->saveInto($sitetree);
 		$sitetree->write();
@@ -122,16 +130,17 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 
 	public function testBrokenSiteTreeLinkTracking() {
 		$sitetree = new SiteTree();
-		$editor   = new HtmlEditorField('Content');
 
 		$this->assertFalse((bool) $sitetree->HasBrokenLink);
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue('<p><a href="[sitetree_link,id=0]">Broken Link</a></p>');
 		$editor->saveInto($sitetree);
 		$sitetree->write();
 
 		$this->assertTrue($sitetree->HasBrokenLink);
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(sprintf (
 			'<p><a href="[sitetree_link,id=%d]">Working Link</a></p>',
 			$this->idFromFixture('SiteTree', 'home')
@@ -145,16 +154,17 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 
 	public function testBrokenFileLinkTracking() {
 		$sitetree = new SiteTree();
-		$editor   = new HtmlEditorField('Content');
 
 		$this->assertFalse((bool) $sitetree->HasBrokenFile);
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue('<p><a href="[file_link,id=0]">Broken Link</a></p>');
 		$editor->saveInto($sitetree);
 		$sitetree->write();
 
 		$this->assertTrue($sitetree->HasBrokenFile);
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(sprintf (
 			'<p><a href="[file_link,id=%d]">Working Link</a></p>',
 			$this->idFromFixture('File', 'example_file')
@@ -168,14 +178,15 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 
 	public function testBrokenLinkHighlighting() {
 		$sitetree = new SiteTree();
-		$editor   = new HtmlEditorField('Content');
 
 		// SiteTree link highlighting
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue('<a href="[sitetree_link,id=0]">Broken Link</a>');
 
 		$element = new SimpleXMLElement(html_entity_decode((string) new SimpleXMLElement($editor->Field())));
 		$this->assertContains('ss-broken', (string) $element['class'], 'A broken SiteTree link is highlighted');
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(sprintf (
 			'<a href="[sitetree_link,id=%d]">Working Link</a>',
 			$this->idFromFixture('SiteTree', 'home')
@@ -185,11 +196,13 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 		$this->assertNotContains('ss-broken', (string) $element['class']);
 
 		// File link highlighting
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue('<a href="[file_link,id=0]">Broken Link</a>');
 
 		$element = new SimpleXMLElement(html_entity_decode((string) new SimpleXMLElement($editor->Field())));
 		$this->assertContains('ss-broken', (string) $element['class'], 'A broken File link is highlighted');
 
+		$editor = new HtmlEditorField('Content');
 		$editor->setValue(sprintf (
 			'<a href="[file_link,id=%d]">Working Link</a>',
 			$this->idFromFixture('File', 'example_file')

--- a/tests/model/SiteTreeLinkTrackingTest.php
+++ b/tests/model/SiteTreeLinkTrackingTest.php
@@ -34,10 +34,10 @@ class SiteTreeLinkTrackingTest extends SapphireTest {
 		$this->assertFalse($this->isBroken("<a href=\"[file_link,id=$file->ID]\">link</a>"));
 	}
 
-	function highlight($content) {
+	function highlight($content, $parameters = array()) {
 		$field = new SiteTreeLinkTrackingTest_Field('Test');
 		$field->setValue($content);
-		$newContent = html_entity_decode($field->Field(), ENT_COMPAT, 'UTF-8');
+		$newContent = html_entity_decode($field->Field($parameters), ENT_COMPAT, 'UTF-8');
 		return $newContent;
 	}
 
@@ -59,6 +59,33 @@ class SiteTreeLinkTrackingTest extends SapphireTest {
 		$this->assertEquals(substr_count($content, 'ss-broken'), 0, 'All ss-broken classes are removed from good link');
 		$this->assertEquals(substr_count($content, 'existing-class'), 1, 'Existing class is not removed.');
 	}
+
+	function testHighlighterCustomisedObj() {
+		$content = $this->highlight(
+			'<a href="[sitetree_link,id=123]" class="existing-class">link</a>',
+			array('test' => '123')
+		);
+		$this->assertEquals(substr_count($content, 'ss-broken'), 1, 'A ss-broken class is added to the broken link.');
+		$this->assertEquals(substr_count($content, 'existing-class'), 1, 'Existing class is not removed.');
+
+		$content = $this->highlight(
+			'<a href="[sitetree_link,id=123]">link</a>',
+			array('test' => '123')
+		);
+		$this->assertEquals(substr_count($content, 'ss-broken'), 1, 'ss-broken class is added to the broken link.');
+
+		$page = new Page();
+		$page->Content = '';
+		$page->write();
+
+		$content = $this->highlight(
+			"<a href=\"[sitetree_link,id=$page->ID]\" class=\"existing-class ss-broken ss-broken\">link</a>",
+			array('test' => '123')
+		);
+		$this->assertEquals(substr_count($content, 'ss-broken'), 0, 'All ss-broken classes are removed from good link');
+		$this->assertEquals(substr_count($content, 'existing-class'), 1, 'Existing class is not removed.');
+	}
+
 }
 
 class SiteTreeLinkTrackingTest_Field extends HtmlEditorField implements TestOnly {


### PR DESCRIPTION
The $editor->Field() sometimes provides stale value if value is changed
several times in a row.
