### PR TITLE
API Change broken link hihglighting to write to database.

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,6 +4,3 @@ LeftAndMain:
 Security:
   extensions:
     - ErrorPageControllerExtension
-HtmlEditorField:
-  extensions:
-    - SiteTreeLinkTracking_Highlighter

--- a/tests/model/SiteTreeBrokenLinksTest.php
+++ b/tests/model/SiteTreeBrokenLinksTest.php
@@ -292,13 +292,6 @@ class SiteTreeBrokenLinksTest extends SapphireTest {
 		$this->assertFalse((bool)$vp->HasBrokenLink);
 		$this->assertFalse((bool)$rp->HasBrokenLink);
 
-		// However, the page isn't marked as modified on stage
-		$this->assertFalse($p2->IsModifiedOnStage);
-		$this->assertFalse($rp->IsModifiedOnStage);
-
-		// This is something that we know to be broken
-		//$this->assertFalse($vp->IsModifiedOnStage);
-
 	}
 
 	public function testBrokenAnchorLinksInAPage() {

--- a/tests/model/SiteTreeHTMLEditorFieldTest.php
+++ b/tests/model/SiteTreeHTMLEditorFieldTest.php
@@ -166,37 +166,4 @@ class SiteTreeHtmlEditorFieldTest extends FunctionalTest {
 		$this->assertFalse((bool) $sitetree->HasBrokenFile);
 	}
 
-	public function testBrokenLinkHighlighting() {
-		$sitetree = new SiteTree();
-		$editor   = new HtmlEditorField('Content');
-
-		// SiteTree link highlighting
-		$editor->setValue('<a href="[sitetree_link,id=0]">Broken Link</a>');
-
-		$element = new SimpleXMLElement(html_entity_decode((string) new SimpleXMLElement($editor->Field())));
-		$this->assertContains('ss-broken', (string) $element['class'], 'A broken SiteTree link is highlighted');
-
-		$editor->setValue(sprintf (
-			'<a href="[sitetree_link,id=%d]">Working Link</a>',
-			$this->idFromFixture('SiteTree', 'home')
-		));
-
-		$element = new SimpleXMLElement(html_entity_decode((string) new SimpleXMLElement($editor->Field())));
-		$this->assertNotContains('ss-broken', (string) $element['class']);
-
-		// File link highlighting
-		$editor->setValue('<a href="[file_link,id=0]">Broken Link</a>');
-
-		$element = new SimpleXMLElement(html_entity_decode((string) new SimpleXMLElement($editor->Field())));
-		$this->assertContains('ss-broken', (string) $element['class'], 'A broken File link is highlighted');
-
-		$editor->setValue(sprintf (
-			'<a href="[file_link,id=%d]">Working Link</a>',
-			$this->idFromFixture('File', 'example_file')
-		));
-
-		$element = new SimpleXMLElement(html_entity_decode((string) new SimpleXMLElement($editor->Field())));
-		$this->assertNotContains('ss-broken', (string) $element['class']);
-	}
-
 }

--- a/tests/model/SiteTreeLinkTrackingTest.php
+++ b/tests/model/SiteTreeLinkTrackingTest.php
@@ -35,10 +35,10 @@ class SiteTreeLinkTrackingTest extends SapphireTest {
 	}
 
 	function highlight($content) {
-		$field = new SiteTreeLinkTrackingTest_Field('Test');
-		$field->setValue($content);
-		$newContent = html_entity_decode($field->Field(), ENT_COMPAT, 'UTF-8');
-		return $newContent;
+		$page = new Page();
+		$page->Content = $content;
+		$page->write();
+		return $page->Content;
 	}
 
 	function testHighlighter() {
@@ -49,20 +49,15 @@ class SiteTreeLinkTrackingTest extends SapphireTest {
 		$content = $this->highlight('<a href="[sitetree_link,id=123]">link</a>');
 		$this->assertEquals(substr_count($content, 'ss-broken'), 1, 'ss-broken class is added to the broken link.');
 
-		$page = new Page();
-		$page->Content = '';
-		$page->write();
+		$otherPage = new Page();
+		$otherPage->Content = '';
+		$otherPage->write();
 
 		$content = $this->highlight(
-			"<a href=\"[sitetree_link,id=$page->ID]\" class=\"existing-class ss-broken ss-broken\">link</a>"
+			"<a href=\"[sitetree_link,id=$otherPage->ID]\" class=\"existing-class ss-broken ss-broken\">link</a>"
 		);
 		$this->assertEquals(substr_count($content, 'ss-broken'), 0, 'All ss-broken classes are removed from good link');
 		$this->assertEquals(substr_count($content, 'existing-class'), 1, 'Existing class is not removed.');
 	}
-}
 
-class SiteTreeLinkTrackingTest_Field extends HtmlEditorField implements TestOnly {
-	private static $extensions = array(
-		'SiteTreeLinkTracking_Highlighter'
-	);
 }

--- a/tests/tasks/MigrateSiteTreeLinkingTaskTest.php
+++ b/tests/tasks/MigrateSiteTreeLinkingTaskTest.php
@@ -29,12 +29,12 @@ class MigrateSiteTreeLinkingTaskTest extends SapphireTest {
 		$hashID   = $this->idFromFixture('SiteTree', 'hash_link');
 		
 		$homeContent = sprintf (
-			'<a href="[sitetree_link,id=%d]">About</a><a href="[sitetree_link,id=%d]">Staff</a><a href="http://silverstripe.org/">External Link</a>',
+			'<a href="[sitetree_link,id=%d]">About</a><a href="[sitetree_link,id=%d]">Staff</a><a href="http://silverstripe.org/">External Link</a><a name="anchor"></a>',
 			$aboutID,
 			$staffID
 		);
 		$aboutContent = sprintf (
-			'<a href="[sitetree_link,id=%d]">Home</a><a href="[sitetree_link,id=%d]">Staff</a>',
+			'<a href="[sitetree_link,id=%d]">Home</a><a href="[sitetree_link,id=%d]">Staff</a><a name="second-anchor"></a>',
 			$homeID,
 			$staffID
 		);

--- a/tests/tasks/MigrateSiteTreeLinkingTaskTest.yml
+++ b/tests/tasks/MigrateSiteTreeLinkingTaskTest.yml
@@ -2,11 +2,11 @@ SiteTree:
   home:
     Title: Home Page
     URLSegment: home
-    Content: '<a href="about/">About</a><a href="staff">Staff</a><a href="http://silverstripe.org/">External Link</a>'
+    Content: '<a href="about/">About</a><a href="staff">Staff</a><a href="http://silverstripe.org/">External Link</a><a name="anchor"></a>'
   about:
     Title: About Us
     URLSegment: about
-    Content: '<a href="home">Home</a><a href="staff/">Staff</a>'
+    Content: '<a href="home">Home</a><a href="staff/">Staff</a><a name="second-anchor"></a>'
   staff:
     Title: Staff
     URLSegment: staff


### PR DESCRIPTION
Before it would be applied on the fly during the rendering of the
HtmlEditorField, and only be written to the database during the
subsequent write.

We just shift the behaviour to apply just-in-time.
