### PR TITLE
Fixing failing ErrorPageTest when site is run as a sub-dir off webroot.

### DIFF
--- a/tests/model/ErrorPageTest.php
+++ b/tests/model/ErrorPageTest.php
@@ -64,9 +64,9 @@ class ErrorPageTest extends FunctionalTest {
 	public function testBehaviourOf403() {
 		$page = $this->objFromFixture('ErrorPage', '403');
 		$page->publish('Stage', 'Live');
-		
-		$response = $this->get($page->Link());
-		
+
+		$response = $this->get($page->RelativeLink());
+
 		$this->assertEquals($response->getStatusCode(), '403');
 		$this->assertNotNull($response->getBody(), 'We have body text from the error page');
 	}


### PR DESCRIPTION
$page->Link() returns "/<sitedir>/urlsegment", but this should just
be passing in "urlsegment" to the get() call. This fixes that to use
$page->RelativeLink(), which works in all cases regardless of whether
the site is running on it's own vhost or in a shared webroot.
