### PR TITLE
Reformat .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,40 @@
 language: php 
 
 php:
-  - 5.3
+  - 5.4
 
 addons:
   firefox: "31.0"
 
 env:
   global:
+    - CORE_RELEASE=3.1
     - "ARTIFACTS_AWS_REGION=us-east-1"
     - "ARTIFACTS_S3_BUCKET=silverstripe-travis-artifacts"
     - secure: "7V20Qk3bIG2AlTJaA5D/uzB8vUVvRwQp+xjRYUxlahtj9FcuqEV3HIyjwwJe0T6Z1bnRYuu28ZnCT2CfP9BBZ3FE7AwSZbPase9c0/at2qDJNqkvIdC1xZ1H6Fcy2LSwNB9wLQPe613ItVdanitEuwE41iowxBPslxUUTnwx7eY="
     - secure: "f/GWlbnNri2YpCOrJfZl7tkhpMmcRVUbCdmb+beAY90gFBJQPHtljzf8M4KaCP0OkLOtRFuGoMFdIcpadl4J6IG1XP18IJNz+nKzCL/sJj/FF9y77RdMHWE9jr21G9ar5tywkn7JM6vrnTCY89OnHeQx67SKvxqX5CpVx+rdcEU="
   matrix:
-    - DB=MYSQL CORE_RELEASE=3.1
+    - DB=MYSQL
+    - DB=SQLITE
+    - DB=PGSQL
 
 matrix:
-  include:
-    - php: 5.3
-      env: DB=PGSQL CORE_RELEASE=3.1
-    - php: 5.3
-      env: DB=SQLITE CORE_RELEASE=3.1
-    - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=3.1 BEHAT_TEST=1
   allow_failures:
+    - php: hhvm-nightly
+  include:
+    - php: 5.5
+      env: DB=MYSQL
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
+      env: DB=MYSQL
+    - php: 5.4
+      env: DB=MYSQL BEHAT_TEST=1
+    - php: 5.3
+      env: DB=MYSQL
+    - php: hhvm-nightly
+      env: DB=MYSQL
+      before_install:
+        - sudo apt-get update -qq
+        - sudo apt-get install -y tidy
 
 before_script:
  - composer self-update


### PR DESCRIPTION
Similar to https://github.com/silverstripe/silverstripe-framework/commit/3cfb2851227f7c9b68feef86a9b8de1da8bc5769, but also adds hhvm-nightly as an allowed failure and promotes PHP 5.6 to the standard test suite. This makes it consistent with framework.
