### PR TITLE
BUG: Fixes #3422 revealing controller info via media extensions

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -216,9 +216,13 @@ class ContentController extends Controller {
 	public function httpError($code, $message = null) {
 		// Don't use the HTML response for media requests
 		$response = $this->request->isMedia() ? null : ErrorPage::response_for($code);
+		// if we have a broken error and response is null do not reveal controller info
+		if (!$response && ($code < 200 || $code > 302)) {
+			$response = ErrorPage::response_for($code);
+		}
 		// Failover to $message if the HTML response is unavailable / inappropriate
 		parent::httpError($code, $response ? $response : $message);
-		}
+	}
 
 	/**
 	 * Get the project name

--- a/tests/controller/ContentControllerTest.php
+++ b/tests/controller/ContentControllerTest.php
@@ -46,6 +46,16 @@ class ContentControllerTest extends FunctionalTest {
 	}
 
 	/**
+	 * Tests that a non-existant media url does not leak controller info
+	 */
+	public function testNonExistantMediaUrl() {
+		RootURLController::reset();
+		Config::inst()->update('SiteTree', 'nested_urls', true);
+
+		$this->assertContains('Page not found',$this->get('/home/second-level/foo.css')->getBody());
+	}
+
+	/**
 	 * Tests {@link ContentController::ChildrenOf()}
 	 */
 	public function testChildrenOf() {
@@ -142,3 +152,4 @@ class ContentControllerTest_Page_Controller extends Page_Controller {
 	}
 
 }
+


### PR DESCRIPTION
Fixes a bug where appending a media file extension to a non-existent sub url results in controller info being leaked

https://github.com/silverstripe/silverstripe-framework/issues/3422