### PR TITLE
Implement `TemplateGlobalProvider` on `SiteConfig`

### DIFF
--- a/code/model/SiteConfig.php
+++ b/code/model/SiteConfig.php
@@ -17,7 +17,7 @@
  * @author Tom Rix
  * @package cms
  */
-class SiteConfig extends DataObject implements PermissionProvider {
+class SiteConfig extends DataObject implements PermissionProvider, TemplateGlobalProvider {
 	private static $db = array(
 		"Title" => "Varchar(255)",
 		"Tagline" => "Varchar(255)",
@@ -309,4 +309,14 @@ class SiteConfig extends DataObject implements PermissionProvider {
 
 		return false;
 	}
+
+	/**
+	 * Add $SiteConfig to all SSViewers
+	 */
+	public static function get_template_global_variables() {
+		return array(
+			'SiteConfig' => 'current_site_config',
+		);
+	}
+	
 }


### PR DESCRIPTION
Seeing as the `SiteConfig` is a site wide and "global" object, it makes sense to have it universally available to the templates
