### PR TITLE
Update pl.yml for ContentController.StartEditing

### DIFF
--- a/lang/pl.yml
+++ b/lang/pl.yml
@@ -179,7 +179,7 @@ pl:
     PUBLISHEDSITE: 'Opublikowana witryna'
     Password: Hasło
     PostInstallTutorialIntro: 'Ta strona jest uproszczoną wersją witryny SilverStripe 3. Aby ją rozszerzyć, zajrzyj proszę na stronę: {link}'
-    StartEditing: 'Możesz zacząć edytować Twoją stronę otwierając <a href=\\"{link}\\">CMS</a>.'
+    StartEditing: 'Możesz zacząć edytować Twoją stronę otwierając <a href="{link}">CMS</a>.'
     UnableDeleteInstall: 'Nie można usunąć plików instalacyjnych. Proszę usunąć je ręcznie'
     VIEWPAGEIN: 'Zobacz stronę w:'
   ErrorPage:


### PR DESCRIPTION
For over a year, here is an error, resulting in the display of the broken link to the Polish version of CMS, after installation: Before fix: http://%22admin///%22 After fix: http://example.com/admin/
