### PR TITLE
FIX This link breaks when get params are added to report URLs

### DIFF
--- a/code/reports/BrokenLinksReport.php
+++ b/code/reports/BrokenLinksReport.php
@@ -84,7 +84,7 @@ class BrokenLinksReport extends SS_Report {
 			"Title" => array(
 				"title" => _t('BrokenLinksReport.PageName', 'Page name'),
 				'formatting' => sprintf(
-					'<a href=\"' . $linkBase . '$ID\" title=\"%s\">$value</a>',
+					'<a href=\"' . Controller::join_links($linkBase, '$ID') . '\" title=\"%s\">$value</a>',
 					_t('BrokenLinksReport.HoverTitleEditPage', 'Edit page')
 				)
 			),


### PR DESCRIPTION
This fixes a conflict where GET params are automatically added to the URL and ID is put in the wrong place. 

Example:
Before: http://localhost:8080/admin/pages/edit/show?locale=en_NZ/11834
After: http://localhost:8080/admin/pages/edit/show/11834?locale=en_NZ

ps. This is generating a template - $ID isn't actually being rendered yet which is why its in single quotes.