### PR TITLE
FIX: "Page type" dropdown respects allowed_children

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2518,6 +2518,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$classes = self::page_type_classes();
 		$currentClass = null;
 		$result = array();
+		$parent = $this->getParent();
 		
 		$result = array();
 		foreach($classes as $class) {
@@ -2526,6 +2527,14 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			// if the current page type is this the same as the class type always show the page type in the list see open ticket 5880 for why
 			if ($this->ClassName != $instance->ClassName) {
 				if((($instance instanceof HiddenClass) || !$instance->canCreate())) continue;
+			}
+
+			if($parent && $parent->exists()) {
+				$allowed = $parent->allowedChildren();
+				
+				if( ! in_array($class, $allowed)) {
+					continue;
+				}
 			}
 			
 			if($perms = $instance->stat('need_permission')) {

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -865,6 +865,19 @@ class SiteTreeTest extends SapphireTest {
 		
 		$this->loginWithPermission('CMS_ACCESS_CMSMain');
 		$this->assertArrayHasKey('SiteTreeTest_ClassA', $method->invoke($sitetree));
+
+		// Test that allowed_children configuration is respected
+		$this->loginWithPermission('ADMIN');
+		$page = new SiteTreeTest_ClassB();
+		$page->write();
+		$child = new SiteTreeTest_ClassC();
+		$child->setParent($page);
+		$child->write();
+
+		$method = new ReflectionMethod($child, 'getClassDropdown');
+		$method->setAccessible(true);
+		$this->assertArrayHasKey('SiteTreeTest_ClassC', $method->invoke($child));
+		$this->assertArrayNotHasKey('SiteTreeTest_ClassB', $method->invoke($child));
 		
 		Session::set("loggedInAs", null);
 	}


### PR DESCRIPTION
As reported on the [SilverStripe forums](http://www.silverstripe.org/community/forums/general-questions/show/77550).
