### PR TITLE
Allow pages which canCreate returns false for to be re-organised in the site tree

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -386,12 +386,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$json = '';
 		$classes = SiteTree::page_type_classes();
 
-	 	$cacheCanCreate = array();
-	 	foreach($classes as $class) $cacheCanCreate[$class] = singleton($class)->canCreate();
-
 	 	// Generate basic cache key. Too complex to encompass all variations
 	 	$cache = SS_Cache::factory('CMSMain_SiteTreeHints');
-	 	$cacheKey = md5(implode('_', array(Member::currentUserID(), implode(',', $cacheCanCreate), implode(',', $classes))));
+	 	$cacheKey = md5(implode('_', array(Member::currentUserID(), implode(',', $classes))));
 	 	if($this->request->getVar('flush')) $cache->clean(Zend_Cache::CLEANING_MODE_ALL);
 	 	$json = $cache->load($cacheKey);
 	 	if(!$json) {
@@ -420,7 +417,6 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				
 				if(
 					($obj instanceof HiddenClass)
-					|| (!array_key_exists($class, $cacheCanCreate) || !$cacheCanCreate[$class])
 					|| ($needsPerm && !$this->can($needsPerm))
 				) {
 					$globalDisallowed[] = $class;


### PR DESCRIPTION
Remove the check for canCreate since really we should be checking canEdit, however for the extra code and overhead I don't think it's worth it. Users will not actually be able to re-organise items if they don't have edit permissions when they attempt the move.
