### PR TITLE
FIX: VirtualPages use correct casting for 'virtual' database fields

### DIFF
--- a/code/model/VirtualPage.php
+++ b/code/model/VirtualPage.php
@@ -450,6 +450,22 @@ class VirtualPage extends Page {
 		if(parent::hasMethod($method)) return true;
 		return $this->copyContentFrom()->hasMethod($method);
 	}
+
+	/**
+	 * Return the "casting helper" (a piece of PHP code that when evaluated creates a casted value object) for a field
+	 * on this object.
+	 *
+	 * @param string $field
+	 * @return string
+	 */
+	public function castingHelper($field) {
+		if($this->copyContentFrom()) {
+			return $this->copyContentFrom()->castingHelper($field);
+		} else {
+			return parent::castingHelper($field);
+		}
+	}
+
 }
 
 /**

--- a/tests/model/VirtualPageTest.php
+++ b/tests/model/VirtualPageTest.php
@@ -591,6 +591,19 @@ class VirtualPageTest extends SapphireTest {
 			'No field copying from previous original after page type changed'
 		);
 	}
+
+	public function testVirtualPageFindsCorrectCasting() {
+		$page = new VirtualPageTest_ClassA();
+		$page->CastingTest = "Some content";
+		$page->write();
+		$virtual = new VirtualPage();
+		$virtual->CopyContentFromID = $page->ID;
+		$virtual->write();
+
+		$this->assertEquals('VirtualPageTest_TestDBField', $virtual->castingHelper('CastingTest'));
+		$this->assertEquals('SOME CONTENT', $virtual->obj('CastingTest')->forTemplate());
+	}
+
 }
 
 class VirtualPageTest_ClassA extends Page implements TestOnly {
@@ -599,6 +612,7 @@ class VirtualPageTest_ClassA extends Page implements TestOnly {
 		'MyInitiallyCopiedField' => 'Text',
 		'MyVirtualField' => 'Text',
 		'MyNonVirtualField' => 'Text',
+		'CastingTest' => 'VirtualPageTest_TestDBField'
 	);
 	
 	private static $allowed_children = array('VirtualPageTest_ClassB');
@@ -614,6 +628,12 @@ class VirtualPageTest_ClassC extends Page implements TestOnly {
 
 class VirtualPageTest_NotRoot extends Page implements TestOnly {
 	private static $can_be_root = false;
+}
+
+class VirtualPageTest_TestDBField extends Varchar implements TestOnly {
+	public function forTemplate() {
+		return strtoupper($this->XML());
+	}
 }
 
 class VirtualPageTest_VirtualPageSub extends VirtualPage implements TestOnly {


### PR DESCRIPTION
I ran into this with a page type like:

```php
class MyPage extends Page {
    private static $db = array(
        'ExtraContent' => 'HTMLText'
    );
}
```

If you create a `VirtualPage` that links to one of an instance of this new page type, `$ExtraContent` in the template won’t work as expected as shortcodes aren’t parsed.
