### PR TITLE
FIX: #981 Added missing CMS GridFieldToolbarHeader

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -736,7 +736,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	public function ListViewForm() {
 		$params = $this->request->requestVar('q');
 		$list = $this->getList($params, $parentID = $this->request->requestVar('ParentID'));
-		$gridFieldConfig = GridFieldConfig::create()->addComponents(			
+		$gridFieldConfig = GridFieldConfig::create()->addComponents(
+			new GridFieldToolbarHeader(),
 			new GridFieldSortableHeader(),
 			new GridFieldDataColumns(),
 			new GridFieldPaginator(self::config()->page_length)
@@ -748,7 +749,12 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 					->setAttributes(array('data-pjax' => 'ListViewForm,Breadcrumbs'))
 			);
 		}
-		$gridField = new GridField('Page','Pages', $list, $gridFieldConfig);
+		$gridField = new GridField(
+			'Page',
+			_t("CMSPagesController.MENUTITLE", LeftAndMain::menu_title_for_class('CMSPagesController')),
+			$list,
+			$gridFieldConfig
+		);
 		$columns = $gridField->getConfig()->getComponentByType('GridFieldDataColumns');
 
 		// Don't allow navigating into children nodes on filtered lists

--- a/code/controllers/ReportAdmin.php
+++ b/code/controllers/ReportAdmin.php
@@ -165,7 +165,12 @@ class ReportAdmin extends LeftAndMain implements PermissionProvider {
 				new GridFieldDataColumns(),
 				new GridFieldFooter()
 			);
-			$gridField = new GridField('Reports',false, $this->Reports(), $gridFieldConfig);
+			$gridField = new GridField(
+				'Reports',
+				_t("ReportAdmin.MENUTITLE", LeftAndMain::menu_title_for_class('ReportAdmin')),
+				$this->Reports(),
+				$gridFieldConfig
+			);
 			$columns = $gridField->getConfig()->getComponentByType('GridFieldDataColumns');
 			$columns->setDisplayFields(array(
 				'title' => _t('ReportAdmin.ReportTitle', 'Title'),


### PR DESCRIPTION
- Adds missing GridFieldToolbarHeader in CMS ModelAdmins.
- Adds missing GridField titles for display in GridFieldToolbarHeader.
  Note: Relies on silverstripe-framework/pull/3771
