### PR TITLE
BUG Correctly sanitise Title

### DIFF
--- a/code/model/VirtualPage.php
+++ b/code/model/VirtualPage.php
@@ -198,7 +198,7 @@ class VirtualPage extends Page {
 				'VirtualPage.HEADERWITHLINK', 
 				"This is a virtual page copying content from \"{title}\" ({link})",
 				array(
-					'title' => $this->CopyContentFrom()->Title,
+					'title' => $this->CopyContentFrom()->obj('Title'),
 					'link' => $link
 				)
 			);


### PR DESCRIPTION
This fix ensures that titles are passed through forTemplate() and sanitised correctly in this instance.