### PR TITLE
Pulls/inherited allowed children test

### DIFF
--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -882,9 +882,9 @@ class SiteTreeTest extends SapphireTest {
 		$valid = $classB->validate();
 		$this->assertFalse($valid->valid(), "Doesnt allow child on parents disallowing all children");
 
-		$classB->ParentID = $classC->ID;
+		$classB->ParentID = $classCext->ID;
 		$valid = $classB->validate();
-		$this->assertFalse($valid->valid(), "Doesnt allow child on parents disallowing all children");
+		$this->assertTrue($valid->valid(), "Extensions of allowed classes are incorrectly reported as invalid");
 
 		$classCext->ParentID = $classD->ID;
 		$valid = $classCext->validate();


### PR DESCRIPTION
There's a redundant test in `SiteTreeTest@testAllowedChildrenValidation` and no test for inherited `allowed_children` checking.

I've now changed the test so this is tested.

Somewhat related to https://github.com/silverstripe/silverstripe-framework/issues/3816