### PR TITLE
Fix auto-setting of URL from localized page titles

### DIFF
--- a/code/forms/SiteTreeURLSegmentField.php
+++ b/code/forms/SiteTreeURLSegmentField.php
@@ -15,7 +15,7 @@ class SiteTreeURLSegmentField extends TextField {
 	/** 
 	 * @var string 
 	 */
-	protected $helpText, $urlPrefix, $urlSuffix;
+	protected $helpText, $urlPrefix, $urlSuffix, $defaultUrl;
 	
 	private static $allowed_actions = array(
 		'suggest'
@@ -30,7 +30,8 @@ class SiteTreeURLSegmentField extends TextField {
 			parent::getAttributes(),
 			array(
 				'data-prefix' => $this->getURLPrefix(),
-				'data-suffix' => '?stage=Stage'
+				'data-suffix' => '?stage=Stage',
+				'data-default-url' => $this->getDefaultURL()
 			)
 		);
 	}
@@ -74,7 +75,8 @@ class SiteTreeURLSegmentField extends TextField {
 	 * @param string $string The secondary text to show
 	 */
 	public function setHelpText($string){
-		$this->helpText = $string; 
+		$this->helpText = $string;
+		return $this;
 	}
 	
 	/**
@@ -90,6 +92,7 @@ class SiteTreeURLSegmentField extends TextField {
 	 */
 	public function setURLPrefix($url){
 		$this->urlPrefix = $url;
+		return $this;
 	}
 	
 	/**
@@ -103,8 +106,23 @@ class SiteTreeURLSegmentField extends TextField {
 		return $this->urlSuffix;
 	}
 
+	/**
+	 * @return Indicator for UI to respond to changes accurately,
+	 * and auto-update the field value if changes to the default occur.
+	 * Does not set the field default value.
+	 */
+	public function getDefaultURL(){
+		return $this->defaultUrl;
+	}
+	
+	public function setDefaultURL($url) {
+		$this->defaultUrl = $url;
+		return $this;
+	}
+
 	public function setURLSuffix($suffix) {
 		$this->urlSuffix = $suffix;
+		return $this;
 	}
 
 	public function Type() {

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1550,7 +1550,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 
 		// If there is no URLSegment set, generate one from Title
-		if((!$this->URLSegment || $this->URLSegment == 'new-page') && $this->Title) {
+		$defaultSegment = $this->generateURLSegment(_t(
+			'CMSMain.NEWPAGE',
+			array('pagetype' => $this->i18n_singular_name())
+		));
+		if((!$this->URLSegment || $this->URLSegment == $defaultSegment) && $this->Title) {
 			$this->URLSegment = $this->generateURLSegment($this->Title);
 		} else if($this->isChanged('URLSegment', 2)) {
 			// Do a strict check on change level, to avoid double encoding caused by
@@ -1988,8 +1992,12 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			(self::config()->nested_urls && $this->ParentID ? $this->Parent()->RelativeLink(true) : null)
 		);
 		
-		$urlsegment = new SiteTreeURLSegmentField("URLSegment", $this->fieldLabel('URLSegment'));
-		$urlsegment->setURLPrefix($baseLink);
+		$urlsegment = SiteTreeURLSegmentField::create("URLSegment", $this->fieldLabel('URLSegment'))
+			->setURLPrefix($baseLink)
+			->setDefaultURL($this->generateURLSegment(_t(
+				'CMSMain.NEWPAGE',
+				array('pagetype' => $this->i18n_singular_name())
+			)));
 		$helpText = (self::config()->nested_urls && count($this->Children())) ? $this->fieldLabel('LinkChangeNote') : '';
 		if(!Config::inst()->get('URLSegmentFilter', 'default_allow_multibyte')) {
 			$helpText .= $helpText ? '<br />' : '';

--- a/javascript/CMSMain.EditForm.js
+++ b/javascript/CMSMain.EditForm.js
@@ -39,7 +39,10 @@
 						self.data('OrigVal', title);
 
 						// Criteria for defining a "new" page
-						if ((urlSegmentInput.val().indexOf('new') == 0) && liveLinkInput.val() == '') {
+						if (
+							urlSegmentInput.val().indexOf(urlSegmentInput.data('defaultUrl')) === 0
+							&& liveLinkInput.val() == ''
+						) {
 							self.updateURLSegment(title);
 						} else {
 							$('.update', self.parent()).show();


### PR DESCRIPTION
Replace the hardcoded check for english locale ("new-page") with a localized version. Tested in IE8 and Chrome. See https://github.com/silverstripe/silverstripe-translatable/issues/180