### PR TITLE
BUG Fix CMSMainTest attempting to render page on Security permission error

### DIFF
--- a/tests/controller/CMSMainTest.php
+++ b/tests/controller/CMSMainTest.php
@@ -245,7 +245,15 @@ class CMSMainTest extends FunctionalTest {
 		$this->get('admin/pages/add');
 		$response = $this->post(
 			'admin/pages/add/AddForm', 
-			array('ParentID' => '0', 'ClassName' => 'Page', 'Locale' => 'en_US', 'action_doAdd' => 1)
+			array(
+				'ParentID' => '0',
+				'ClassName' => 'Page',
+				'Locale' => 'en_US',
+				'action_doAdd' => 1,
+				'ajax' => 1,
+			), array(
+				'X-Pjax' => 'CurrentForm,Breadcrumbs',
+			)
 		);
 		// should redirect, which is a permission error
 		$this->assertEquals(403, $response->getStatusCode(), 'Add TopLevel page must fail for normal user');
@@ -256,11 +264,19 @@ class CMSMainTest extends FunctionalTest {
 
 		$response = $this->post(
 			'admin/pages/add/AddForm', 
-			array('ParentID' => '0', 'ClassName' => 'Page', 'Locale' => 'en_US', 'action_doAdd' => 1)
+			array(
+				'ParentID' => '0',
+				'ClassName' => 'Page',
+				'Locale' => 'en_US',
+				'action_doAdd' => 1,
+				'ajax' => 1,
+			), array(
+				'X-Pjax' => 'CurrentForm,Breadcrumbs',
+			)
 		);
 
-		$this->assertEquals(302, $response->getStatusCode(), 'Must be a redirect on success');
-		$location=$response->getHeader('Location');
+		$location = $response->getHeader('X-ControllerURL');
+		$this->assertNotEmpty($location, 'Must be a redirect on success');
 		$this->assertContains('/show/',$location, 'Must redirect to /show/ the new page');
 		// TODO Logout
 		$this->session()->inst_set('loggedInAs', NULL);


### PR DESCRIPTION
Normally this method is posted via ajax. Leaving out the ajax parameter during mocking of these functions can occasionally cause the `Security::permissionFailure` method to attempt to render a page using the default `Page` class, occasionally breaking due to user-code (especially with custom Requirements).

Basically, this just makes the tests behave a bit more like real life and breaks less unit tests with certain usercode in place.