### PR TITLE
NEW Update functionality around setMenuTitle

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2674,11 +2674,8 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @param string $value
 	 */
 	public function setMenuTitle($value) {
-		if($value == $this->getField("Title")) {
-			$this->setField("MenuTitle", null);
-		} else {
-			$this->setField("MenuTitle", $value);
-		}
+		Deprecation::notice(4.0, 'SiteTree::setMenuTitle is deprecated from 4.0');
+		$this->setField("MenuTitle", $value);
 	}
 	
 	/**

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -900,25 +900,6 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertContains('inherited-class', $treeTitle);
 	}
 
-	public function testMenuTitleIsUnsetWhenEqualsTitle() {
-		$page = new SiteTree();
-		$page->Title = 'orig';
-		$page->MenuTitle = 'orig';
-		$page->write();
-		
-		// change menu title
-		$page->MenuTitle = 'changed';
-		$page->write();
-		$page = SiteTree::get()->byID($page->ID);
-		$this->assertEquals('changed', $page->getField('MenuTitle'));
-
-		// change menu title back
-		$page->MenuTitle = 'orig';
-		$page->write();
-		$page = SiteTree::get()->byID($page->ID);
-		$this->assertEquals(null, $page->getField('MenuTitle'));
-	}
-
 	public function testMetaTagGeneratorDisabling() {
 		$generator = Config::inst()->get('SiteTree', 'meta_generator');
 


### PR DESCRIPTION
At the moment, if Title is the same as MenuTitle then MenuTitle will be set to null which I think is really odd behaviour and isn't what is expected. It also means you can't (easily) query using the MenuTitle column.