### PR TITLE
FIX: Prevent OldPageRedirector 404 redirect loop

### DIFF
--- a/code/controllers/OldPageRedirector.php
+++ b/code/controllers/OldPageRedirector.php
@@ -10,21 +10,24 @@ class OldPageRedirector extends Extension {
 	 * @throws SS_HTTPResponse_Exception
 	 */
 	public function onBeforeHTTPError404($request) {
+
 		// Build up the request parameters
 		$params = array_filter(array_values($request->allParams()), function($v) { return ($v !== NULL); });
-
+		
 		$getvars = $request->getVars();
-		unset($getvars['url']);
-
+		
 		$page = self::find_old_page($params);
-
-		if ($page) {
+		
+		if ($page && $page !== $getvars['url']) {
+			unset($getvars['url']);
+			
 			$res = new SS_HTTPResponse();
 			$res->redirect(
 				Controller::join_links(
 					$page,
 					($getvars) ? '?' . http_build_query($getvars) : null
 				), 301);
+			
 			throw new SS_HTTPResponse_Exception($res);
 		}
 	}


### PR DESCRIPTION
Redirect should check to ensure the new redirect location does not match the provided one. This was triggered when a website homepage was unpublished. Instead of throwing a 404 page the method previously caused a redirect loop. @cc ss23 #cwp