### PR TITLE
FIX Use SearchForm::create to instantiate SearchForm

### DIFF
--- a/code/search/ContentControllerSearchExtension.php
+++ b/code/search/ContentControllerSearchExtension.php
@@ -27,7 +27,7 @@ class ContentControllerSearchExtension extends Extension {
 		$actions = new FieldList(
 			new FormAction('results', _t('SearchForm.GO', 'Go'))
 		);
-		$form = new SearchForm($this->owner, 'SearchForm', $fields, $actions);
+		$form = SearchForm::create($this->owner, 'SearchForm', $fields, $actions);
 		$form->classesToSearch(FulltextSearchable::get_searchable_classes());
 		return $form;
 	}


### PR DESCRIPTION
It's not currently possible to use injector to customise the SearchForm at the moment due to the way it is instantiated.


This fixes that problem by using the `::create()` function