### PR TITLE
Check $dataRecord existance in ContentController stage tests

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -89,6 +89,8 @@ class ContentController extends Controller {
 	public function init() {
 		parent::init();
 
+		$recordExists = ($this->dataRecord && $this->dataRecord->exists());
+
 		// If we've accessed the homepage as /home/, then we should redirect to /.
 		if(
 			$this->dataRecord
@@ -128,7 +130,8 @@ class ContentController extends Controller {
 
 		// Draft/Archive security check - only CMS users should be able to look at stage/archived content
 		if(
-			$this->URLSegment != 'Security' 
+			$recordExists
+			&& $this->URLSegment != 'Security' 
 			&& !Session::get('unsecuredDraftSite') 
 			&& (
 				Versioned::current_archived_date() 

--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -95,12 +95,11 @@ class ContentController extends Controller {
 		if(
 			$recordExists
 			&& RootURLController::should_be_on_root($this->dataRecord)
-			&& (!isset($this->urlParams['Action']) || !$this->urlParams['Action'])
-			&& !$_POST
-			&& !$_FILES
+			&& !$this->request->param('Action')
+			&& !$this->request->postVars()
 			&& !$this->redirectedTo()
 		) {
-			$getVars = $_GET;
+			$getVars = $this->getRequest()->getVars();
 			unset($getVars['url']);
 			if($getVars) {
 				$url = "?" . http_build_query($getVars);

--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -93,8 +93,7 @@ class ContentController extends Controller {
 
 		// If we've accessed the homepage as /home/, then we should redirect to /.
 		if(
-			$this->dataRecord
-			&& $this->dataRecord instanceof SiteTree
+			$recordExists
 			&& RootURLController::should_be_on_root($this->dataRecord)
 			&& (!isset($this->urlParams['Action']) || !$this->urlParams['Action'])
 			&& !$_POST
@@ -113,7 +112,7 @@ class ContentController extends Controller {
 		}
 
 		// Run extension hooks
-		if($this->dataRecord) {
+		if($recordExists) {
 			$this->dataRecord->extend('contentcontrollerInit', $this);
 		} else {
 			singleton('SiteTree')->extend('contentcontrollerInit', $this);
@@ -123,7 +122,7 @@ class ContentController extends Controller {
 			return;
 		}
 
-		// Check page permissions
+		// Check page permissions (even if record isn't in database)
 		if($this->dataRecord && $this->URLSegment != 'Security' && !$this->dataRecord->canView()) {
 			return Security::permissionFailure($this);
 		}

--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -41,9 +41,10 @@ class ContentController extends Controller {
 			$dataRecord->URLSegment = get_class($this);
 			$dataRecord->ID = -1;
 		}
-		
+
 		$this->dataRecord = $dataRecord;
 		$this->failover = $this->dataRecord;
+
 		parent::__construct();
 	}
 	
@@ -87,23 +88,38 @@ class ContentController extends Controller {
 
 	public function init() {
 		parent::init();
-		
+
 		// If we've accessed the homepage as /home/, then we should redirect to /.
-		if($this->dataRecord && $this->dataRecord instanceof SiteTree
-			 	&& RootURLController::should_be_on_root($this->dataRecord) && (!isset($this->urlParams['Action']) || !$this->urlParams['Action'] ) 
-				&& !$_POST && !$_FILES && !$this->redirectedTo() ) {
+		if(
+			$this->dataRecord
+			&& $this->dataRecord instanceof SiteTree
+			&& RootURLController::should_be_on_root($this->dataRecord)
+			&& (!isset($this->urlParams['Action']) || !$this->urlParams['Action'])
+			&& !$_POST
+			&& !$_FILES
+			&& !$this->redirectedTo()
+		) {
 			$getVars = $_GET;
 			unset($getVars['url']);
-			if($getVars) $url = "?" . http_build_query($getVars);
-			else $url = "";
+			if($getVars) {
+				$url = "?" . http_build_query($getVars);
+			} else {
+				$url = "";
+			}
 			$this->redirect($url, 301);
 			return;
 		}
-		
-		if($this->dataRecord) $this->dataRecord->extend('contentcontrollerInit', $this);
-		else singleton('SiteTree')->extend('contentcontrollerInit', $this);
 
-		if($this->redirectedTo()) return;
+		// Run extension hooks
+		if($this->dataRecord) {
+			$this->dataRecord->extend('contentcontrollerInit', $this);
+		} else {
+			singleton('SiteTree')->extend('contentcontrollerInit', $this);
+		}
+		if($this->redirectedTo()) {
+			// Check if any extension hooks have caused a redirection
+			return;
+		}
 
 		// Check page permissions
 		if($this->dataRecord && $this->URLSegment != 'Security' && !$this->dataRecord->canView()) {
@@ -119,10 +135,10 @@ class ContentController extends Controller {
 				|| (Versioned::current_stage() && Versioned::current_stage() != 'Live')
 			)
 		) {
-			if(!$this->dataRecord->canViewStage(Versioned::current_archived_date() ? 'Stage' : Versioned::current_stage())) {
+			$canView = $this->dataRecord->canViewStage(Versioned::current_archived_date() ? 'Stage' : Versioned::current_stage());
+			if(!$canView) {
 				Session::clear('currentStage');
 				Session::clear('archiveDate');
-				
 				$permissionMessage = sprintf(
 					_t(
 						"ContentController.DRAFT_SITE_ACCESS_RESTRICTION",
@@ -134,15 +150,14 @@ class ContentController extends Controller {
 
 				return Security::permissionFailure($this, $permissionMessage);
 			}
-
 		}
-		
+
 		// Use theme from the site config
 		if(($config = SiteConfig::current_site_config()) && $config->Theme) {
 			Config::inst()->update('SSViewer', 'theme', $config->Theme);
 		}
 	}
-	
+
 	/**
 	 * This acts the same as {@link Controller::handleRequest()}, but if an action cannot be found this will attempt to
 	 * fall over to a child controller in order to provide functionality for nested URLs.


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/3131.

Submitting against 3.1 because this is a fairly common feature ("anonymous" page controllers). There's a latent risk of causing a security issue due to wrong permission checks, so would appreciate some peer review.

Steps to reproduce:

1. Create controller as follows:

```php
class My_Controller extends ContentController {
    static $allowed_actions = array('mymethod');

    public function mymethod() {
        die('here');
    }
}
```

2. Login to CMS and switch a preview to draft mode

3. Open `/My_Controller/mymethod`

You'll see an "access denied" message.