### PR TITLE
Improve UX of asset management

### DIFF
--- a/code/model/SiteTreeFileExtension.php
+++ b/code/model/SiteTreeFileExtension.php
@@ -10,11 +10,39 @@ class SiteTreeFileExtension extends DataExtension {
 	);
 
 	public function updateCMSFields(FieldList $fields) {
-		$fields->insertAfter(new ReadonlyField('BackLinkCount', 
-			_t('AssetTableField.BACKLINKCOUNT', 'Used on:'), 
-			$this->BackLinkTracking()->Count() . ' ' . _t('AssetTableField.PAGES', 'page(s)')), 
+		$fields->insertAfter(
+			ReadonlyField::create(
+				'BackLinkCount', 
+				_t('AssetTableField.BACKLINKCOUNT', 'Used on:'), 
+				$this->BackLinkTracking()->Count() . ' ' . _t('AssetTableField.PAGES', 'page(s)'))
+			->addExtraClass('cms-description-toggle')
+			->setDescription($this->BackLinkHTMLList()),
 			'LastEdited'
 		);
+	}
+
+	/**
+	 * Generate an HTML list which provides links to where a file is used.
+	 *
+	 * @return String
+	 */
+	public function BackLinkHTMLList() {
+		$html = '<em>' . _t('SiteTreeFileExtension.BACKLINK_LIST_DESCRIPTION', 'This list shows all pages where the file has been added through a WYSIWYG editor.') . '</em>';
+		$html .= '<ul>';
+
+		foreach ($this->BackLinkTracking() as $backLink) {
+			$listItem = '<li>';
+
+			// Add the page link
+			$listItem .= '<a href="' . $backLink->Link() . '" target="_blank">' . Convert::raw2xml($backLink->MenuTitle) . '</a> &ndash; ';
+
+			// Add the CMS link
+			$listItem .= '<a href="' . $backLink->CMSEditLink() . '">' . _t('SiteTreeFileExtension.EDIT', 'Edit') . '</a>';
+
+			$html .= $listItem . '</li>';
+		}
+
+		return $html .= '</ul>';
 	}
 
 	/**


### PR DESCRIPTION
This is an improvement to the UX of asset management, specifically the 'used on' field.

![used-on-page-closed](https://cloud.githubusercontent.com/assets/878176/7360931/17c2922e-eda5-11e4-971a-4f35bc99a03b.png)

User clicks the 'info' icon...
![used-on-page](https://cloud.githubusercontent.com/assets/878176/7360916/e7663036-eda4-11e4-83e5-1671ab0d22a3.png)
 