### PR TITLE
API Enable tree filter highlighting

### DIFF
--- a/templates/Includes/CMSMain_TreeView.ss
+++ b/templates/Includes/CMSMain_TreeView.ss
@@ -19,7 +19,18 @@ $ExtraTreeTools
 	</div>
 	<% end_if %>
 
-	<div class="cms-tree" data-url-tree="$LinkWithSearch($Link(getsubtree))" data-url-savetreenode="$Link(savetreenode)" data-url-updatetreenodes="$Link(updatetreenodes)" data-url-addpage="{$LinkPageAdd('AddForm/?action_doAdd=1', 'ParentID=%s&amp;PageType=%s')}" data-url-editpage="$LinkPageEdit('%s')" data-url-duplicate="{$Link('duplicate/%s')}" data-url-duplicatewithchildren="{$Link('duplicatewithchildren/%s')}" data-url-listview="{$Link('?view=list')}" data-hints="$SiteTreeHints.XML" data-childfilter="$Link('childfilter')" data-extra-params="SecurityID=$SecurityID">
+	<div class="cms-tree <% if $TreeIsFiltered %>filtered-list<% end_if %>"
+		data-url-tree="$LinkWithSearch($Link(getsubtree))"
+		data-url-savetreenode="$Link(savetreenode)"
+		data-url-updatetreenodes="$Link(updatetreenodes)"
+		data-url-addpage="{$LinkPageAdd('AddForm/?action_doAdd=1', 'ParentID=%s&amp;PageType=%s')}"
+		data-url-editpage="$LinkPageEdit('%s')"
+		data-url-duplicate="{$Link('duplicate/%s')}"
+		data-url-duplicatewithchildren="{$Link('duplicatewithchildren/%s')}"
+		data-url-listview="{$Link('?view=list')}"
+		data-hints="$SiteTreeHints.XML"
+		data-childfilter="$Link('childfilter')"
+		data-extra-params="SecurityID=$SecurityID">
 		$SiteTreeAsUL
 	</div>
 </div>


### PR DESCRIPTION
Decoupling of CMS / Framework

This feature allows pages matching a custom search to be highlighted in the left hand tree view. This is handy for distinguishing between pages which actually match your search, and those which are simply displayed in order to hold child results.

The class 'CMSSiteTreeFilter' has been refactored out of the core beacuse it's a CMS class, and instead a framework interface 'LeftAndMain_SearchFilter' is used as an abstract api for a search-filterable class.

See https://github.com/silverstripe/silverstripe-framework/pull/4153 for framework component