### PR TITLE
FIX: don't use magic accessors to call explicit get functions

### DIFF
--- a/code/batchactions/CMSBatchActions.php
+++ b/code/batchactions/CMSBatchActions.php
@@ -68,7 +68,6 @@ class CMSBatchAction_Delete extends CMSBatchAction {
 			// if it doesn't remove the tree node
 			$liveRecord = Versioned::get_one_by_stage( 'SiteTree', 'Live', "\"SiteTree\".\"ID\"=$id");
 			if($liveRecord) {
-				$liveRecord->IsDeletedFromStage = true;
 				$status['modified'][$liveRecord->ID] = array(
 					'TreeTitle' => $liveRecord->TreeTitle,
 				);
@@ -113,7 +112,6 @@ class CMSBatchAction_DeleteFromLive extends CMSBatchAction {
 			// check to see if the record exists on the stage site, if it doesn't remove the tree node
 			$stageRecord = Versioned::get_one_by_stage( 'SiteTree', 'Stage', "\"SiteTree\".\"ID\"=$id");
 			if($stageRecord) {
-				$stageRecord->IsAddedToStage = true;
 				$status['modified'][$stageRecord->ID] = array(
 					'TreeTitle' => $stageRecord->TreeTitle,
 				);

--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -576,8 +576,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$actions = $form->Actions();
 
 		if($record) {
-			$deletedFromStage = $record->IsDeletedFromStage;
-			$deleteFromLive = !$record->ExistsOnLive;
+			$deletedFromStage = $record->getIsDeletedFromStage();
+			$deleteFromLive = !$record->getExistsOnLive();
 
 			$fields->push($idField = new HiddenField("ID", false, $id));
 			// Necessary for different subsites

--- a/code/controllers/CMSSiteTreeFilter.php
+++ b/code/controllers/CMSSiteTreeFilter.php
@@ -247,7 +247,7 @@ class CMSSIteTreeFilter_PublishedPages extends CMSSiteTreeFilter {
 		$pages = Versioned::get_including_deleted('SiteTree');
 		$pages = $this->applyDefaultFilters($pages);
 		$pages = $pages->filterByCallback(function($page) {
-			return $page->ExistsOnLive;
+			return $page->getExistsOnLive();
 		});
 		return $pages;
 	}
@@ -327,7 +327,7 @@ class CMSSiteTreeFilter_StatusRemovedFromDraftPages extends CMSSiteTreeFilter {
 		$pages = $this->applyDefaultFilters($pages);
 		$pages = $pages->filterByCallback(function($page) {
 			// If page is removed from stage but not live
-			return $page->IsDeletedFromStage && $page->ExistsOnLive;
+			return $page->getIsDeletedFromStage() && $page->getExistsOnLive();
 		});
 		return $pages;
 	}	
@@ -356,7 +356,7 @@ class CMSSiteTreeFilter_StatusDraftPages extends CMSSiteTreeFilter {
 		$pages = $this->applyDefaultFilters($pages);
 		$pages = $pages->filterByCallback(function($page) {
 			// If page exists on stage but not on live
-			return (!$page->IsDeletedFromStage && $page->IsAddedToStage);
+			return (!$page->getIsDeletedFromStage() && $page->getIsAddedToStage());
 		});
 		return $pages;
 	}	
@@ -396,7 +396,7 @@ class CMSSiteTreeFilter_StatusDeletedPages extends CMSSiteTreeFilter {
 
 		$pages = $pages->filterByCallback(function($page) {
 			// Doesn't exist on either stage or live
-			return $page->IsDeletedFromStage && !$page->ExistsOnLive;
+			return $page->getIsDeletedFromStage() && !$page->getExistsOnLive();
 		});
 		return $pages;
 	}	

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2235,7 +2235,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			return $actions;
 		}
 
-		if($this->isPublished() && $this->canPublish() && !$this->IsDeletedFromStage && $this->canDeleteFromLive()) {
+		if($this->isPublished() && $this->canPublish() && !$this->getIsDeletedFromStage() && $this->canDeleteFromLive()) {
 			// "unpublish"
 			$moreOptions->push(
 				FormAction::create('unpublish', _t('SiteTree.BUTTONUNPUBLISH', 'Unpublish'), 'delete')
@@ -2244,7 +2244,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			);
 		}
 
-		if($this->stagesDiffer('Stage', 'Live') && !$this->IsDeletedFromStage) {
+		if($this->stagesDiffer('Stage', 'Live') && !$this->getIsDeletedFromStage()) {
 			if($this->isPublished() && $this->canEdit())	{
 				// "rollback"
 				$moreOptions->push(
@@ -2255,7 +2255,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 
 		if($this->canEdit()) {
-			if($this->IsDeletedFromStage) {
+			if($this->getIsDeletedFromStage()) {
 				// The usual major actions are not available, so we provide alternatives here.
 				if($existsOnLive) {
 					// "restore"
@@ -2290,7 +2290,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			}
 		}
 
-		if($this->canPublish() && !$this->IsDeletedFromStage) {
+		if($this->canPublish() && !$this->getIsDeletedFromStage()) {
 			// "publish", as with "save", it supports an alternate state to show when action is needed.
 			$majorActions->push(
 				$publish = FormAction::create('publish', _t('SiteTree.BUTTONPUBLISHED', 'Published'))
@@ -2340,7 +2340,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if($linkedPages) foreach($linkedPages as $page) {
 			$page->copyFrom($page->CopyContentFrom());
 			$page->write();
-			if($page->ExistsOnLive) $page->doPublish();
+			if($page->getExistsOnLive()) $page->doPublish();
 		}
 		
 		// Need to update pages linking to this one as no longer broken, on the live site
@@ -2643,8 +2643,8 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function getStatusFlags($cached = true) {
 		if(!$this->_cache_statusFlags || !$cached) {
 			$flags = array();
-			if($this->IsDeletedFromStage) {
-				if($this->ExistsOnLive) {
+			if($this->getIsDeletedFromStage()) {
+				if($this->getExistsOnLive()) {
 					$flags['removedfromdraft'] = array(
 						'text' => _t('SiteTree.REMOVEDFROMDRAFTSHORT', 'Removed from draft'),
 						'title' => _t('SiteTree.REMOVEDFROMDRAFTHELP', 'Page is published, but has been deleted from draft'),
@@ -2655,12 +2655,12 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 						'title' => _t('SiteTree.DELETEDPAGEHELP', 'Page is no longer published'),
 					);
 				}
-			} else if($this->IsAddedToStage) {
+			} else if($this->getIsAddedToStage()) {
 				$flags['addedtodraft'] = array(
 					'text' => _t('SiteTree.ADDEDTODRAFTSHORT', 'Draft'),
 					'title' => _t('SiteTree.ADDEDTODRAFTHELP', "Page has not been published yet")
 				);
-			} else if($this->IsModifiedOnStage) {
+			} else if($this->getIsModifiedOnStage()) {
 				$flags['modified'] = array(
 					'text' => _t('SiteTree.MODIFIEDONDRAFTSHORT', 'Modified'),
 					'title' => _t('SiteTree.MODIFIEDONDRAFTHELP', 'Page has unpublished changes'),

--- a/tests/model/FileLinkTrackingTest.php
+++ b/tests/model/FileLinkTrackingTest.php
@@ -71,7 +71,7 @@ class FileLinkTrackingTest extends SapphireTest {
 		// Publish the source page
 		$page = $this->objFromFixture('Page', 'page1');
 		$this->assertTrue($page->doPublish());
-		$this->assertFalse($page->IsModifiedOnStage);
+		$this->assertFalse($page->getIsModifiedOnStage());
 
 		// Rename the file
 		$file = $this->objFromFixture('File', 'file1');
@@ -83,7 +83,7 @@ class FileLinkTrackingTest extends SapphireTest {
 		Versioned::prepopulate_versionnumber_cache('SiteTree', 'Live', array($page->ID));
 
 		// Confirm that the page hasn't gone green.
-		$this->assertFalse($page->IsModifiedOnStage);
+		$this->assertFalse($page->getIsModifiedOnStage());
 	}
 
 	public function testTwoFileRenamesInARowWork() {

--- a/tests/model/SiteTreeBrokenLinksTest.php
+++ b/tests/model/SiteTreeBrokenLinksTest.php
@@ -280,11 +280,11 @@ class SiteTreeBrokenLinksTest extends SapphireTest {
 		$this->assertFalse((bool)$rp->HasBrokenLink);
 
 		// However, the page isn't marked as modified on stage
-		$this->assertFalse($p2->IsModifiedOnStage);
-		$this->assertFalse($rp->IsModifiedOnStage);
+		$this->assertFalse($p2->getIsModifiedOnStage());
+		$this->assertFalse($rp->getIsModifiedOnStage());
 
 		// This is something that we know to be broken
-		//$this->assertFalse($vp->IsModifiedOnStage);
+		//$this->assertFalse($vp->getIsModifiedOnStage());
 
 	}
 }

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -192,17 +192,17 @@ class SiteTreeTest extends SapphireTest {
 		// newly created page
 		$createdPage = new SiteTree();
 		$createdPage->write();
-		$this->assertFalse($createdPage->IsDeletedFromStage);
-		$this->assertTrue($createdPage->IsAddedToStage);
-		$this->assertTrue($createdPage->IsModifiedOnStage);
+		$this->assertFalse($createdPage->getIsDeletedFromStage());
+		$this->assertTrue($createdPage->getIsAddedToStage());
+		$this->assertTrue($createdPage->getIsModifiedOnStage());
 
 		// published page
 		$publishedPage = new SiteTree();
 		$publishedPage->write();
 		$publishedPage->publish('Stage','Live');
-		$this->assertFalse($publishedPage->IsDeletedFromStage);
-		$this->assertFalse($publishedPage->IsAddedToStage);
-		$this->assertFalse($publishedPage->IsModifiedOnStage);
+		$this->assertFalse($publishedPage->getIsDeletedFromStage());
+		$this->assertFalse($publishedPage->getIsAddedToStage());
+		$this->assertFalse($publishedPage->getIsModifiedOnStage());
 
 		// published page, deleted from stage
 		$deletedFromDraftPage = new SiteTree();
@@ -210,9 +210,9 @@ class SiteTreeTest extends SapphireTest {
 		$deletedFromDraftPageID = $deletedFromDraftPage->ID;
 		$deletedFromDraftPage->publish('Stage','Live');
 		$deletedFromDraftPage->deleteFromStage('Stage');
-		$this->assertTrue($deletedFromDraftPage->IsDeletedFromStage);
-		$this->assertFalse($deletedFromDraftPage->IsAddedToStage);
-		$this->assertFalse($deletedFromDraftPage->IsModifiedOnStage);
+		$this->assertTrue($deletedFromDraftPage->getIsDeletedFromStage());
+		$this->assertFalse($deletedFromDraftPage->getIsAddedToStage());
+		$this->assertFalse($deletedFromDraftPage->getIsModifiedOnStage());
 
 		// published page, deleted from live
 		$deletedFromLivePage = new SiteTree();
@@ -220,9 +220,9 @@ class SiteTreeTest extends SapphireTest {
 		$deletedFromLivePage->publish('Stage','Live');
 		$deletedFromLivePage->deleteFromStage('Stage');
 		$deletedFromLivePage->deleteFromStage('Live');
-		$this->assertTrue($deletedFromLivePage->IsDeletedFromStage);
-		$this->assertFalse($deletedFromLivePage->IsAddedToStage);
-		$this->assertFalse($deletedFromLivePage->IsModifiedOnStage);
+		$this->assertTrue($deletedFromLivePage->getIsDeletedFromStage());
+		$this->assertFalse($deletedFromLivePage->getIsAddedToStage());
+		$this->assertFalse($deletedFromLivePage->getIsModifiedOnStage());
 
 		// published page, modified
 		$modifiedOnDraftPage = new SiteTree();
@@ -230,9 +230,9 @@ class SiteTreeTest extends SapphireTest {
 		$modifiedOnDraftPage->publish('Stage','Live');
 		$modifiedOnDraftPage->Content = 'modified';
 		$modifiedOnDraftPage->write();
-		$this->assertFalse($modifiedOnDraftPage->IsDeletedFromStage);
-		$this->assertFalse($modifiedOnDraftPage->IsAddedToStage);
-		$this->assertTrue($modifiedOnDraftPage->IsModifiedOnStage);
+		$this->assertFalse($modifiedOnDraftPage->getIsDeletedFromStage());
+		$this->assertFalse($modifiedOnDraftPage->getIsAddedToStage());
+		$this->assertTrue($modifiedOnDraftPage->getIsModifiedOnStage());
 	}
 
 	/**

--- a/tests/model/VirtualPageTest.php
+++ b/tests/model/VirtualPageTest.php
@@ -209,46 +209,46 @@ class VirtualPageTest extends SapphireTest {
 		$vp->write();
 
 		// VP is oragne
-		$this->assertTrue($vp->IsAddedToStage);
+		$this->assertTrue($vp->getIsAddedToStage());
 
 		// VP is still orange after we publish
 		$p->doPublish();
 		$this->fixVersionNumberCache($vp);
-		$this->assertTrue($vp->IsAddedToStage);
+		$this->assertTrue($vp->getIsAddedToStage());
 		
 		// A new VP created after P's initial construction
 		$vp2 = new VirtualPage();
 		$vp2->CopyContentFromID = $p->ID;
 		$vp2->write();
-		$this->assertTrue($vp2->IsAddedToStage);
+		$this->assertTrue($vp2->getIsAddedToStage());
 		
 		// Also remains orange after a republish
 		$p->Content = "new content";
 		$p->write();
 		$p->doPublish();
 		$this->fixVersionNumberCache($vp2);
-		$this->assertTrue($vp2->IsAddedToStage);
+		$this->assertTrue($vp2->getIsAddedToStage());
 		
 		// VP is now published
 		$vp->doPublish();
 
 		$this->fixVersionNumberCache($vp);
-		$this->assertTrue($vp->ExistsOnLive);
-		$this->assertFalse($vp->IsModifiedOnStage);
+		$this->assertTrue($vp->getExistsOnLive());
+		$this->assertFalse($vp->getIsModifiedOnStage());
 		
 		// P edited, VP and P both go green
 		$p->Content = "third content";
 		$p->write();
 
 		$this->fixVersionNumberCache($vp, $p);
-		$this->assertTrue($p->IsModifiedOnStage);
-		$this->assertTrue($vp->IsModifiedOnStage);
+		$this->assertTrue($p->getIsModifiedOnStage());
+		$this->assertTrue($vp->getIsModifiedOnStage());
 
 		// Publish, VP goes black
 		$p->doPublish();
 		$this->fixVersionNumberCache($vp);
-		$this->assertTrue($vp->ExistsOnLive);
-		$this->assertFalse($vp->IsModifiedOnStage);
+		$this->assertTrue($vp->getExistsOnLive());
+		$this->assertFalse($vp->getIsModifiedOnStage());
 	}
 	
 	public function testVirtualPagesCreateVersionRecords() {


### PR DESCRIPTION
I was fixing a bug on a site where getStatusFlags() is used to determine what information to show in a GridField and these get functions weren't being accessed properly from that code - possibly due to the misrepresentation of the functionality within SiteTree. This is a minor change but improves readability and documentation-ability.

Let me know if this should be further upstream, but as no API is being changed here this should be good for 3.1?