### PR TITLE
Fix duplicate not having the correct permission check

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -1316,7 +1316,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		
 		if(($id = $this->urlParams['ID']) && is_numeric($id)) {
 			$page = DataObject::get_by_id("SiteTree", $id);
-			if($page && (!$page->canEdit() || !$page->canCreate())) return Security::permissionFailure($this);
+			if($page && (!$page->canEdit() || !$page->canCreate(null, array('Parent' => $page->Parent())))) {
+				return Security::permissionFailure($this);
+			}
 			if(!$page || !$page->ID) throw new SS_HTTPResponse_Exception("Bad record ID #$id", 404);
 
 			$newPage = $page->duplicate();
@@ -1352,7 +1354,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		increase_time_limit_to();
 		if(($id = $this->urlParams['ID']) && is_numeric($id)) {
 			$page = DataObject::get_by_id("SiteTree", $id);
-			if($page && (!$page->canEdit() || !$page->canCreate())) return Security::permissionFailure($this);
+			if($page && (!$page->canEdit() || !$page->canCreate(null, array('Parent' => $page->Parent())))) {
+				return Security::permissionFailure($this);
+			}
 			if(!$page || !$page->ID) throw new SS_HTTPResponse_Exception("Bad record ID #$id", 404);
 
 			$newPage = $page->duplicateWithChildren();


### PR DESCRIPTION
These checks aren't required -- you can duplicate a page regardless of whether you can edit it.

I secretly presume these are required for something, but if not, here's a nice PR to remove them. If they are, why?