### PR TITLE
FIX: SiteTree hints not escaped correctly

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -422,7 +422,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 			$this->extend('updateSiteTreeHints', $def);
 
-			$json = Convert::raw2json($def);
+			$json = Convert::raw2xml(Convert::raw2json($def));
 			$cache->save($json, $cacheKey);
 		}
 		return $json;


### PR DESCRIPTION
Looks like this was overlooked in #1177. 3.1’s default cast is `Text`, but not 3.0 so we have to manually escape this. Marked as blocker because it breaks the entire “Pages” section of the CMS.

This has probably been waiting in the wings for a while as SiteTree hints are cached, so no one would spot this unless that cache was wiped (which you can only do by manually removing the files, or visiting `admin/pages/add?flush=1` - it’s not wiped by a regular flush/build in 3.0).