### PR TITLE
Enforced the published/draft selection for SS reports, which was bein…

### DIFF
--- a/code/reports/BrokenLinksReport.php
+++ b/code/reports/BrokenLinksReport.php
@@ -29,9 +29,8 @@ class BrokenLinksReport extends SS_Report {
 				$sort = '';
 			}
 		}
-		if (!isset($_REQUEST['CheckSite']) || $params['CheckSite'] == 'Published') $ret = Versioned::get_by_stage('SiteTree', 'Live', '("SiteTree"."HasBrokenLink" = 1 OR "SiteTree"."HasBrokenFile" = 1)', $sort, $join, $limit);
-		else $ret = DataObject::get('SiteTree', '("SiteTree"."HasBrokenFile" = 1 OR "HasBrokenLink" = 1)', $sort, $join, $limit);
-		
+		$ret = Versioned::get_by_stage('SiteTree', ((!isset($params['CheckSite']) || ($params['CheckSite'] == 'Published')) ? 'Live' : 'Stage'), '("SiteTree"."HasBrokenLink" = 1 OR "SiteTree"."HasBrokenFile" = 1)', $sort, $join, $limit);
+
 		$returnSet = new ArrayList();
 		if ($ret) foreach($ret as $record) {
 			$reason = false;
@@ -73,7 +72,7 @@ class BrokenLinksReport extends SS_Report {
 		return $returnSet;
 	}
 	public function columns() {
-		if(isset($_REQUEST['CheckSite']) && $_REQUEST['CheckSite'] == 'Draft') {
+		if(isset($_REQUEST['filters']['CheckSite']) && $_REQUEST['filters']['CheckSite'] == 'Draft') {
 			$dateTitle = _t('BrokenLinksReport.ColumnDateLastModified', 'Date last modified');
 		} else {
 			$dateTitle = _t('BrokenLinksReport.ColumnDateLastPublished', 'Date last published');

--- a/code/reports/SideReport.php
+++ b/code/reports/SideReport.php
@@ -199,9 +199,8 @@ class SideReport_BrokenLinks extends SS_Report {
 		// Get class names for page types that are not virtual pages or redirector pages
 		$classes = array_diff(ClassInfo::subclassesFor('SiteTree'), ClassInfo::subclassesFor('VirtualPage'), ClassInfo::subclassesFor('RedirectorPage'));
 		$classNames = "'".join("','", $classes)."'";
-		
-		if (isset($_REQUEST['OnLive'])) $ret = Versioned::get_by_stage('SiteTree', 'Live', "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
-		else $ret = DataObject::get('SiteTree', "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
+
+		$ret = Versioned::get_by_stage('SiteTree', ((isset($params['OnLive']) && $params['OnLive']) ? 'Live' : 'Stage'), "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
 		return $ret;
 	}
 	public function columns() {
@@ -212,7 +211,7 @@ class SideReport_BrokenLinks extends SS_Report {
 			),
 		);
 	}
-	public function getParameterFields() {
+	public function parameterFields() {
 		return new FieldList(
 			new CheckboxField('OnLive', _t('SideReport.ParameterLiveCheckbox', 'Check live site'))
 		);
@@ -237,9 +236,8 @@ class SideReport_BrokenFiles extends SS_Report {
 		// Get class names for page types that are not virtual pages or redirector pages
 		$classes = array_diff(ClassInfo::subclassesFor('SiteTree'), ClassInfo::subclassesFor('VirtualPage'), ClassInfo::subclassesFor('RedirectorPage'));
 		$classNames = "'".join("','", $classes)."'";
-		
-		if (isset($_REQUEST['OnLive'])) $ret = Versioned::get_by_stage('SiteTree', 'Live', "\"ClassName\" IN ($classNames) AND \"HasBrokenFile\" = 1");
-		else $ret = DataObject::get('SiteTree', "\"ClassName\" IN ($classNames) AND \"HasBrokenFile\" = 1");
+
+		$ret = Versioned::get_by_stage('SiteTree', ((isset($params['OnLive']) && $params['OnLive']) ? 'Live' : 'Stage'), "\"ClassName\" IN ($classNames) AND \"HasBrokenFile\" = 1");
 		return $ret;
 	}
 	public function columns() {
@@ -251,7 +249,7 @@ class SideReport_BrokenFiles extends SS_Report {
 		);
 	}
 
-	public function getParameterFields() {
+	public function parameterFields() {
 		return new FieldList(
 			new CheckboxField('OnLive', _t('SideReport.ParameterLiveCheckbox', 'Check live site'))
 		);
@@ -271,8 +269,8 @@ class SideReport_BrokenVirtualPages extends SS_Report {
 	}
 	public function sourceRecords($params = null) {
 		$classNames = "'".join("','", ClassInfo::subclassesFor('VirtualPage'))."'";
-		if (isset($_REQUEST['OnLive'])) $ret = Versioned::get_by_stage('SiteTree', 'Live', "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
-		else $ret = DataObject::get('SiteTree', "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
+
+		$ret = Versioned::get_by_stage('SiteTree', ((isset($params['OnLive']) && $params['OnLive']) ? 'Live' : 'Stage'), "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
 		return $ret;
 	}
 	
@@ -285,7 +283,7 @@ class SideReport_BrokenVirtualPages extends SS_Report {
 		);
 	}
 
-	public function getParameterFields() {
+	public function parameterFields() {
 		return new FieldList(
 			new CheckboxField('OnLive', _t('SideReport.ParameterLiveCheckbox', 'Check live site'))
 		);
@@ -305,9 +303,8 @@ class SideReport_BrokenRedirectorPages extends SS_Report {
 	}
 	public function sourceRecords($params = null) {
 		$classNames = "'".join("','", ClassInfo::subclassesFor('RedirectorPage'))."'";
-		
-		if (isset($_REQUEST['OnLive'])) $ret = Versioned::get_by_stage('SiteTree', 'Live', "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
-		else $ret = DataObject::get('SiteTree', "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
+
+		$ret = Versioned::get_by_stage('SiteTree', ((isset($params['OnLive']) && $params['OnLive']) ? 'Live' : 'Stage'), "\"ClassName\" IN ($classNames) AND \"HasBrokenLink\" = 1");
 		return $ret;
 	}
 	
@@ -320,7 +317,7 @@ class SideReport_BrokenRedirectorPages extends SS_Report {
 		);
 	}
 	
-	public function getParameterFields() {
+	public function parameterFields() {
 		return new FieldList(
 			new CheckboxField('OnLive', _t('SideReport.ParameterLiveCheckbox', 'Check live site'))
 		);

--- a/tests/reports/ReportTest.php
+++ b/tests/reports/ReportTest.php
@@ -2,6 +2,33 @@
 
 class ReportTest extends SapphireTest {
 
+	/**
+	 *	ASSERT whether a report is returning the correct results, based on a broken "draft" and/or "published" page, both with and without the "reason".
+	 *
+	 *	@parameter ss_report
+	 *	@parameter boolean
+	 *	@parameter boolean
+	 *	@parameter string
+	 */
+
+	public function isReportBroken($report, $isDraftBroken, $isPublishedBroken, $reason) {
+
+		$class = get_class($report);
+		$parameters = array();
+
+		// ASSERT that the "draft" report is returning the correct results, both with and without the "reason".
+
+		$parameters['CheckSite'] = 'Draft';
+		$results = (count($report->sourceRecords($parameters, null, null)) > 0) && (count($report->sourceRecords(array_merge($parameters, array('Reason' => $reason)), null, null)) > 0);
+		$isDraftBroken ? $this->assertTrue($results, "{$class} has NOT returned the correct DRAFT results, as NO pages were found.") : $this->assertFalse($results, "{$class} has NOT returned the correct DRAFT results, as pages were found.");
+
+		// ASSERT that the "published" report is returning the correct results, both with and without the "reason".
+
+		$parameters['CheckSite'] = 'Published';
+		$results = (count($report->sourceRecords($parameters, null, null)) > 0) && (count($report->sourceRecords(array_merge($parameters, array('Reason' => $reason)), null, null)) > 0);
+		$isPublishedBroken ? $this->assertTrue($results, "{$class} has NOT returned the correct PUBLISHED results, as NO pages were found.") : $this->assertFalse($results, "{$class} has NOT returned the correct PUBLISHED results, as pages were found.");
+	}
+
 	public function testGetReports() {
 		$reports = SS_Report::get_reports();
 		$this->assertNotNull($reports, "Reports returned");
@@ -52,6 +79,218 @@ class ReportTest extends SapphireTest {
 			$reportNames,
 			'ReportTest_FakeTest_Abstract is NOT in reports list as it is abstract');
 	}
+
+	/**
+	 *	Test the broken links report.
+	 */
+
+	public function testBrokenLinksReport() {
+
+		// ---
+		// BROKEN LINKS
+		// ---
+
+		// Create a "draft" page with a broken link.
+
+		$page = Page::create();
+		$page->Content = "<a href='[sitetree_link,id=987654321]'>This</a> is a broken link.";
+		$page->writeToStage('Stage');
+
+		// Retrieve the broken links report.
+
+		$reports = SS_Report::get_reports();
+		$brokenLinksReport = null;
+		foreach($reports as $report) {
+			if($report instanceof BrokenLinksReport) {
+				$brokenLinksReport = $report;
+				break;
+			}
+		}
+
+		// Determine that the report exists, otherwise it has been excluded.
+
+		if($brokenLinksReport) {
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
+
+			$this->isReportBroken($brokenLinksReport, true, false, 'BROKENLINK');
+
+			// Make sure the page is now "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link.
+
+			$this->isReportBroken($brokenLinksReport, true, true, 'BROKENLINK');
+
+			// Correct the "draft" broken link.
+
+			$page->Content = str_replace('987654321', $page->ID, $page->Content);
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
+
+			$this->isReportBroken($brokenLinksReport, false, true, 'BROKENLINK');
+
+			// Make sure the change has now been "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link.
+
+			$this->isReportBroken($brokenLinksReport, false, false, 'BROKENLINK');
+			$page->delete();
+
+			// ---
+			// BROKEN FILES
+			// ---
+
+			// Create a "draft" page with a broken file.
+
+			$page = Page::create();
+			$page->Content = "<a href='[file_link,id=987654321]'>This</a> is a broken file.";
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has detected the page having a broken file.
+			// ASSERT that the "published" report has NOT detected the page having a broken file, as the page has not been "published" yet.
+
+			$this->isReportBroken($brokenLinksReport, true, false, 'BROKENFILE');
+
+			// Make sure the page is now "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has detected the page having a broken file.
+			// ASSERT that the "published" report has detected the page having a broken file.
+
+			$this->isReportBroken($brokenLinksReport, true, true, 'BROKENFILE');
+
+			// Correct the "draft" broken file.
+
+			$file = File::create();
+			$file->Filename = 'name.pdf';
+			$file->write();
+			$page->Content = str_replace('987654321', $file->ID, $page->Content);
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken file.
+			// ASSERT that the "published" report has detected the page having a broken file, as the previous content remains "published".
+
+			$this->isReportBroken($brokenLinksReport, false, true, 'BROKENFILE');
+
+			// Make sure the change has now been "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken file.
+			// ASSERT that the "published" report has NOT detected the page having a broken file.
+
+			$this->isReportBroken($brokenLinksReport, false, false, 'BROKENFILE');
+			$page->delete();
+
+			// ---
+			// BROKEN VIRTUAL PAGES
+			// ---
+
+			// Create a "draft" virtual page with a broken link.
+
+			$page = VirtualPage::create();
+			$page->CopyContentFromID = 987654321;
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
+
+			$this->isReportBroken($brokenLinksReport, true, false, 'VPBROKENLINK');
+
+			// Make sure the page is now "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link.
+
+			$this->isReportBroken($brokenLinksReport, true, true, 'VPBROKENLINK');
+
+			// Correct the "draft" broken link.
+
+			$contentPage = Page::create();
+			$contentPage->Content = 'This is some content.';
+			$contentPage->writeToStage('Stage');
+			$contentPage->writeToStage('Live');
+			$page->CopyContentFromID = $contentPage->ID;
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
+
+			$this->isReportBroken($brokenLinksReport, false, true, 'VPBROKENLINK');
+
+			// Make sure the change has now been "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link.
+
+			$this->isReportBroken($brokenLinksReport, false, false, 'VPBROKENLINK');
+			$contentPage->delete();
+			$page->delete();
+
+			// ---
+			// BROKEN REDIRECTOR PAGES
+			// ---
+
+			// Create a "draft" redirector page with a broken link.
+
+			$page = RedirectorPage::create();
+			$page->RedirectionType = 'Internal';
+			$page->LinkToID = 987654321;
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
+
+			$this->isReportBroken($brokenLinksReport, true, false, 'RPBROKENLINK');
+
+			// Make sure the page is now "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link.
+
+			$this->isReportBroken($brokenLinksReport, true, true, 'RPBROKENLINK');
+
+			// Correct the "draft" broken link.
+
+			$contentPage = Page::create();
+			$contentPage->Content = 'This is some content.';
+			$contentPage->writeToStage('Stage');
+			$contentPage->writeToStage('Live');
+			$page->LinkToID = $contentPage->ID;
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
+
+			$this->isReportBroken($brokenLinksReport, false, true, 'RPBROKENLINK');
+
+			// Make sure the change has now been "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link.
+
+			$this->isReportBroken($brokenLinksReport, false, false, 'RPBROKENLINK');
+		}
+	}
+
 }
 
 class ReportTest_FakeTest extends SS_Report implements TestOnly {

--- a/tests/reports/SideReportTest.php
+++ b/tests/reports/SideReportTest.php
@@ -24,6 +24,31 @@ class SideReportTest extends SapphireTest {
 		DB::query("UPDATE \"SiteTree\" SET \"Created\"='2009-01-01 00:00:00', \"LastEdited\"='".date('Y-m-d H:i:s', $beforeThreshold)."' WHERE \"ID\"='".$before->ID."'");
 	}
 
+	/**
+	 *	ASSERT whether a report is returning the correct results, based on a broken "draft" and/or "published" page.
+	 *
+	 *	@parameter ss_report
+	 *	@parameter boolean
+	 *	@parameter boolean
+	 */
+
+	public function isReportBroken($report, $isDraftBroken, $isPublishedBroken) {
+
+		$class = get_class($report);
+
+		// ASSERT that the "draft" report is returning the correct results.
+
+		$results = count($report->sourceRecords(array())) > 0;
+		$isDraftBroken ? $this->assertTrue($results, "{$class} has NOT returned the correct DRAFT results, as NO pages were found.") : $this->assertFalse($results, "{$class} has NOT returned the correct DRAFT results, as pages were found.");
+
+		// ASSERT that the "published" report is returning the correct results.
+
+		$results = count($report->sourceRecords(array(
+			'OnLive' => 1
+		))) > 0;
+		$isPublishedBroken ? $this->assertTrue($results, "{$class} has NOT returned the correct PUBLISHED results, as NO pages were found.") : $this->assertFalse($results, "{$class} has NOT returned the correct PUBLISHED results, as pages were found.");
+	}
+
 	public function testRecentlyEdited() {
 		SS_Datetime::set_mock_now('31-06-2009 00:00:00');
 
@@ -39,4 +64,265 @@ class SideReportTest extends SapphireTest {
 		
 		SS_DateTime::clear_mock_now();
 	}
+
+	/**
+	 *	Test the broken links side report.
+	 */
+
+	public function testBrokenLinks() {
+
+		// Create a "draft" page with a broken link.
+
+		$page = Page::create();
+		$page->Content = "<a href='[sitetree_link,id=987654321]'>This</a> is a broken link.";
+		$page->writeToStage('Stage');
+
+		// Retrieve the broken links side report.
+
+		$reports = SS_Report::get_reports();
+		$brokenLinksReport = null;
+		foreach($reports as $report) {
+			if($report instanceof SideReport_BrokenLinks) {
+				$brokenLinksReport = $report;
+				break;
+			}
+		}
+
+		// Determine that the report exists, otherwise it has been excluded.
+
+		if($brokenLinksReport) {
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
+
+			$this->isReportBroken($brokenLinksReport, true, false);
+
+			// Make sure the page is now "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link.
+
+			$this->isReportBroken($brokenLinksReport, true, true);
+
+			// Correct the "draft" broken link.
+
+			$page->Content = str_replace('987654321', $page->ID, $page->Content);
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
+
+			$this->isReportBroken($brokenLinksReport, false, true);
+
+			// Make sure the change has now been "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link.
+
+			$this->isReportBroken($brokenLinksReport, false, false);
+		}
+	}
+
+	/**
+	 *	Test the broken files side report.
+	 */
+
+	public function testBrokenFiles() {
+
+		// Create a "draft" page with a broken file.
+
+		$page = Page::create();
+		$page->Content = "<a href='[file_link,id=987654321]'>This</a> is a broken file.";
+		$page->writeToStage('Stage');
+
+		// Retrieve the broken files side report.
+
+		$reports = SS_Report::get_reports();
+		$brokenFilesReport = null;
+		foreach($reports as $report) {
+			if($report instanceof SideReport_BrokenFiles) {
+				$brokenFilesReport = $report;
+				break;
+			}
+		}
+
+		// Determine that the report exists, otherwise it has been excluded.
+
+		if($brokenFilesReport) {
+
+			// ASSERT that the "draft" report has detected the page having a broken file.
+			// ASSERT that the "published" report has NOT detected the page having a broken file, as the page has not been "published" yet.
+
+			$this->isReportBroken($brokenFilesReport, true, false);
+
+			// Make sure the page is now "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has detected the page having a broken file.
+			// ASSERT that the "published" report has detected the page having a broken file.
+
+			$this->isReportBroken($brokenFilesReport, true, true);
+
+			// Correct the "draft" broken file.
+
+			$file = File::create();
+			$file->Filename = 'name.pdf';
+			$file->write();
+			$page->Content = str_replace('987654321', $file->ID, $page->Content);
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken file.
+			// ASSERT that the "published" report has detected the page having a broken file, as the previous content remains "published".
+
+			$this->isReportBroken($brokenFilesReport, false, true);
+
+			// Make sure the change has now been "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken file.
+			// ASSERT that the "published" report has NOT detected the page having a broken file.
+
+			$this->isReportBroken($brokenFilesReport, false, false);
+		}
+	}
+
+	/**
+	 *	Test the broken virtual pages side report.
+	 */
+
+	public function testBrokenVirtualPages() {
+
+		// Create a "draft" virtual page with a broken link.
+
+		$page = VirtualPage::create();
+		$page->CopyContentFromID = 987654321;
+		$page->writeToStage('Stage');
+
+		// Retrieve the broken virtual pages side report.
+
+		$reports = SS_Report::get_reports();
+		$brokenVirtualPagesReport = null;
+		foreach($reports as $report) {
+			if($report instanceof SideReport_BrokenVirtualPages) {
+				$brokenVirtualPagesReport = $report;
+				break;
+			}
+		}
+
+		// Determine that the report exists, otherwise it has been excluded.
+
+		if($brokenVirtualPagesReport) {
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
+
+			$this->isReportBroken($brokenVirtualPagesReport, true, false);
+
+			// Make sure the page is now "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link.
+
+			$this->isReportBroken($brokenVirtualPagesReport, true, true);
+
+			// Correct the "draft" broken link.
+
+			$contentPage = Page::create();
+			$contentPage->Content = 'This is some content.';
+			$contentPage->writeToStage('Stage');
+			$contentPage->writeToStage('Live');
+			$page->CopyContentFromID = $contentPage->ID;
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
+
+			$this->isReportBroken($brokenVirtualPagesReport, false, true);
+
+			// Make sure the change has now been "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link.
+
+			$this->isReportBroken($brokenVirtualPagesReport, false, false);
+		}
+	}
+
+	/**
+	 *	Test the broken redirector pages side report.
+	 */
+
+	public function testBrokenRedirectorPages() {
+
+		// Create a "draft" redirector page with a broken link.
+
+		$page = RedirectorPage::create();
+		$page->RedirectionType = 'Internal';
+		$page->LinkToID = 987654321;
+		$page->writeToStage('Stage');
+
+		// Retrieve the broken redirector pages side report.
+
+		$reports = SS_Report::get_reports();
+		$brokenRedirectorPagesReport = null;
+		foreach($reports as $report) {
+			if($report instanceof SideReport_BrokenRedirectorPages) {
+				$brokenRedirectorPagesReport = $report;
+				break;
+			}
+		}
+
+		// Determine that the report exists, otherwise it has been excluded.
+
+		if($brokenRedirectorPagesReport) {
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
+
+			$this->isReportBroken($brokenRedirectorPagesReport, true, false);
+
+			// Make sure the page is now "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link.
+
+			$this->isReportBroken($brokenRedirectorPagesReport, true, true);
+
+			// Correct the "draft" broken link.
+
+			$contentPage = Page::create();
+			$contentPage->Content = 'This is some content.';
+			$contentPage->writeToStage('Stage');
+			$contentPage->writeToStage('Live');
+			$page->LinkToID = $contentPage->ID;
+			$page->writeToStage('Stage');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
+
+			$this->isReportBroken($brokenRedirectorPagesReport, false, true);
+
+			// Make sure the change has now been "published".
+
+			$page->writeToStage('Live');
+
+			// ASSERT that the "draft" report has NOT detected the page having a broken link.
+			// ASSERT that the "published" report has NOT detected the page having a broken link.
+
+			$this->isReportBroken($brokenRedirectorPagesReport, false, false);
+		}
+	}
+
 }


### PR DESCRIPTION
…g ignored due to previous code refactoring.

So the first problem is that most reports are currently returning incorrect result sets based on the published/draft selection. This selection is currently being ignored due to previous code refactoring, resulting in `isset($_REQUEST['CheckSite'])` and `isset($_REQUEST['OnLive'])` being false, and therefore always returning the published result set. I believe this problem is in relation to the following, which is through almost every version of 3.0 and 3.1.

https://github.com/silverstripe/silverstripe-cms/commit/57c615d6b232deb00e0275227ae6e5d109b625d0

The second problem is now that this correctly falls back to checking the draft pages, a `DataObject::get` is being called, as opposed to checking the specific stage. If a user has recently viewed a page with `&stage=Live` in the URL, this result set will display all published pages (when clearly it should still be displaying all draft pages).

Something I also thought worth bringing up, is there any reason the individual reports are duplicating the broken links report? They don't seem do anything on top of what's already there. I found this only causes confusion, and therefore I have opted to hide these side reports from the CMS. Would these happen to be for legacy support?

Cheers :)