### PR TITLE
Remove the default search text from Searchform

### DIFF
--- a/code/search/ContentControllerSearchExtension.php
+++ b/code/search/ContentControllerSearchExtension.php
@@ -15,7 +15,7 @@ class ContentControllerSearchExtension extends Extension {
 	 * Site search form
 	 */
 	public function SearchForm() {
-		$searchText =  _t('SearchForm.SEARCH', 'Search');
+		$searchText =  '';
 
 		if($this->owner->request && $this->owner->request->getVar('Search')) {
 			$searchText = $this->owner->request->getVar('Search');


### PR DESCRIPTION
Stop the tyranny of the default value in SearchForm templates. Rise up against our string oppressors!