### PR TITLE
Add drag/drop icons to smaller site tree

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -17,7 +17,7 @@
 .cms-content-tools #cms-content-treeview .cms-tree-view-modes, .cms-content-tools #cms-content-treeview .cms-content-batchactions { display: none; }
 .cms-content-tools #cms-content-treeview .cms-tree-expand-trigger { display: block; float: left; margin: 0 0 2px 0; }
 .cms-content-tools #cms-content-treeview .cms-tree-expand-trigger span.ui-button-text { padding-right: 8px; }
-.cms-content-tools #cms-content-treeview .cms-tree .badge, .cms-content-tools #cms-content-treeview .cms-tree a > .jstree-icon { display: none; }
+.cms-content-tools #cms-content-treeview .cms-tree .badge { display: none; }
 .cms-content-tools #cms-content-treeview .cms-tree a:hover > .text > .badge, .cms-content-tools #cms-content-treeview .cms-tree .jstree-clicked > .text > .badge { display: inline-block; }
 
 /** ------------------------------------------------------------------ URLSegment field ----------------------------------------------------------------- */

--- a/scss/_CMSMain.scss
+++ b/scss/_CMSMain.scss
@@ -76,8 +76,7 @@
 
 		.cms-tree {
 			// Hide badges and drag icons to save space
-			.badge,
-			a > .jstree-icon {
+			.badge {
 				display: none;
 			}
 


### PR DESCRIPTION
With the increased space for the site tree in 3.2 and drag/drop icons only appearing on hover they can now be included in the smaller site tree. To be merged with https://github.com/silverstripe/silverstripe-framework/pull/4292
![image](https://cloud.githubusercontent.com/assets/10215604/8196743/2679d1aa-14e3-11e5-8d21-ef736c61f637.png)
