### PR TITLE
Increase click-size of multi-selection button

### DIFF
--- a/templates/Includes/CMSPagesController_ContentToolbar.ss
+++ b/templates/Includes/CMSPagesController_ContentToolbar.ss
@@ -1,8 +1,8 @@
 <div class="cms-content-batchactions">
-	<div class="view-mode-batchactions-wrapper">
+	<label class="view-mode-batchactions-wrapper">
 		<input id="view-mode-batchactions" name="view-mode-batchactions" type="checkbox" />
-		<label for="view-mode-batchactions"><% _t("CMSPagesController_ContentToolbar_ss.MULTISELECT","Multi-selection") %></label>
-	</div>
+		<span class="view-mode-batchactions-label"><% _t("CMSPagesController_ContentToolbar_ss.MULTISELECT","Multi-selection") %></span>
+	</label>
 
 	$BatchActionsForm
 </div>


### PR DESCRIPTION
Allows the entire multi-selection button to be clicked rather than just the text and the checkbox