### PR TITLE
Increase CMSSettingsController:url_priority to suppress SiteConfigLeftAndMain

### DIFF
--- a/code/controllers/CMSSettingsController.php
+++ b/code/controllers/CMSSettingsController.php
@@ -7,4 +7,10 @@
  */
 class CMSSettingsController extends SiteConfigLeftAndMain {
 
+	/**
+	 * @config
+	 * @var int
+	 */
+	private static $url_priority = 60;
+
 }


### PR DESCRIPTION
In 3.2, there are two SiteConfigs present in the CMS:
- CMSSettingsController which extends SiteConfigLeftAndMain
- SiteConfigLeftAndMain as a own module

While SiteConfigLeftAndMain's menu item is removed in _config.php, the controller is still active and will be loaded.

Bug:
- In the CMS click the 'Settings' menu item -- its id is "li#Menu-CMSSettingsController"
- xhr is getting a response from SiteConfigLeftAndMain instead
- LeftAndMain.Menu.updateMenuFromResponse() likes to mark the menu item as selected
- ...but fails to do so because its looking for "#Menu-SiteConfigLeftAndMain" instead
- "li#Menu-CMSSettingsController" stays grey

This PR slightly increases the url_priority value of CMSSettingsController, so CMSSettingsController will be used instead of SiteConfigLeftAndMain.
