### PR TITLE
FIX for 556, resolves SiteConfig validation problems.

### DIFF
--- a/code/controllers/CMSSettingsController.php
+++ b/code/controllers/CMSSettingsController.php
@@ -14,15 +14,6 @@ class CMSSettingsController extends LeftAndMain {
 		Requirements::javascript(CMS_DIR . '/javascript/CMSMain.EditForm.js');
 	}
 
-	public function getResponseNegotiator() {
-		$neg = parent::getResponseNegotiator();
-		$controller = $this;
-		$neg->setCallback('CurrentForm', function() use(&$controller) {
-			return $controller->renderWith($controller->getTemplatesWithSuffix('_Content'));
-		});
-		return $neg;
-	}
-
 	/**
 	 * @param null $id Not used.
 	 * @param null $fields Not used.
@@ -39,12 +30,12 @@ class CMSSettingsController extends LeftAndMain {
 		$navField->setAllowHTML(true);
 
 		$actions = $siteConfig->getCMSActions();
-		$form = CMSForm::create( 
+		$form = CMSForm::create(
 			$this, 'EditForm', $fields, $actions
 		)->setHTMLID('Form_EditForm');
 		$form->setResponseNegotiator($this->getResponseNegotiator());
 		$form->addExtraClass('cms-content center cms-edit-form');
-		// don't add data-pjax-fragment=CurrentForm, its added in the content template instead
+		$form->setAttribute('data-pjax-fragment', 'CurrentForm');
 
 		if($form->Fields()->hasTabset()) $form->Fields()->findOrMakeTab('Root')->setTemplate('CMSTabSet');
 		$form->setHTMLID('Form_EditForm');
@@ -88,7 +79,8 @@ class CMSSettingsController extends LeftAndMain {
 		}
 		
 		$this->response->addHeader('X-Status', rawurlencode(_t('LeftAndMain.SAVEDUP', 'Saved.')));
-		return $this->getResponseNegotiator()->respond($this->request);
+	
+		return $form->forTemplate();
 	}
 	
 	public function LinkPreview() {

--- a/templates/Includes/CMSSettingsController_Content.ss
+++ b/templates/Includes/CMSSettingsController_Content.ss
@@ -1,4 +1,4 @@
-<div id="settings-controller-cms-content" class="cms-content center cms-tabset $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content CurrentForm" data-ignore-tab-state="true">
+<div id="settings-controller-cms-content" class="cms-content center cms-tabset $BaseCSSClasses" data-layout-type="border" data-pjax-fragment="Content" data-ignore-tab-state="true">
 
 	<div class="cms-content-header north">
 		<% with $EditForm %>


### PR DESCRIPTION
Ping @chillu 

Fixes #556. Ensuring pjax-fragment points to form instead of full content, allowing for standard validation without breaking content. I believe this commit (https://github.com/silverstripe/silverstripe-cms/commit/b74178e7fd2a0ba2b08cd11b41f0085b1dd4eee6) broke this functionality by consolidating both "Content" and "CurrentForm" `pjax-fragment`'s to address another issue (which I cannot find) which may no longer be a problem. Pinging you, Ingo, since I'm not 100% positive what the original bug was which caused you to setup the above commit. 