### PR TITLE
Correct doubly-escaped " marks

### DIFF
--- a/code/reports/BrokenLinksReport.php
+++ b/code/reports/BrokenLinksReport.php
@@ -83,7 +83,7 @@ class BrokenLinksReport extends SS_Report {
 			"Title" => array(
 				"title" => _t('BrokenLinksReport.PageName', 'Page name'),
 				'formatting' => function($value, $item) use ($linkBase) {
-					return sprintf('<a href=\"%s\" title=\"%s\">%s</a>',
+					return sprintf('<a href="%s" title="%s">%s</a>',
 						Controller::join_links($linkBase, $item->ID),
 						_t('BrokenLinksReport.HoverTitleEditPage', 'Edit page'),
 						$value


### PR DESCRIPTION
The links in the Broken Links Report had extraneous " marks that made
them unusable. This fixes the links.

This patch can and should be merged to 3.2, 3, and master, as well.
