### PR TITLE
FIX: ContentController::getViewer() not returning all found templates (fixes #1244)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,13 @@ env:
 
 matrix:
   allow_failures:
-    - php: hhvm-nightly
+    - php: hhvm
+    - php: 7.0
+    - php: nightly
+
   include:
+    - php: 5.4
+      env: DB=MYSQL PDO=1
     - php: 5.5
       env: DB=MYSQL
     - php: 5.6
@@ -37,7 +42,11 @@ matrix:
       env: DB=MYSQL BEHAT_TEST=1
     - php: 5.3
       env: DB=MYSQL
-    - php: hhvm-nightly
+    - php: 7.0
+      env: DB=MYSQL
+    - php: nightly
+      env: DB=MYSQL
+    - php: hhvm
       env: DB=MYSQL
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
-language: php 
+language: php
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - tidy
 
 php:
   - 5.4
@@ -32,9 +39,6 @@ matrix:
       env: DB=MYSQL
     - php: hhvm-nightly
       env: DB=MYSQL
-      before_install:
-        - sudo apt-get update -qq
-        - sudo apt-get install -y tidy
 
 before_script:
  - composer self-update || true

--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -402,15 +402,15 @@ HTML;
 		if($action == "index") $action = "";
 		else $action = '_' . $action;
 
-		// Find templates by dataRecord
-		$templates = SSViewer::get_templates_by_class(get_class($this->dataRecord), $action, "SiteTree");
-
-		// Next, we need to add templates for all controllers
-		$templates += SSViewer::get_templates_by_class(get_class($this), $action, "Controller");
-
-		// Fail-over to the same for the "index" action
-		$templates += SSViewer::get_templates_by_class(get_class($this->dataRecord), "", "SiteTree");
-		$templates += SSViewer::get_templates_by_class(get_class($this), "", "Controller");
+		$templates = array_merge(
+			// Find templates by dataRecord
+			SSViewer::get_templates_by_class(get_class($this->dataRecord), $action, "SiteTree"),
+			// Next, we need to add templates for all controllers
+			SSViewer::get_templates_by_class(get_class($this), $action, "Controller"),
+			// Fail-over to the same for the "index" action
+			SSViewer::get_templates_by_class(get_class($this->dataRecord), "", "SiteTree"),
+			SSViewer::get_templates_by_class(get_class($this), "", "Controller")
+		);
 
 		return new SSViewer($templates);
 	}

--- a/tests/controller/ContentControllerTest.php
+++ b/tests/controller/ContentControllerTest.php
@@ -168,6 +168,14 @@ class ContentControllerTest extends FunctionalTest {
 			// to say the default Page.ss template
 			$response = $self->get($page->RelativeLink("testwithouttemplate"));
 			$self->assertEquals("Page", $response->getBody());
+
+			// Test that an action with a template will render the both action template *and* the
+			// correct parent template
+			$controller = new ContentController($page);
+			$viewer = $controller->getViewer('test');
+			$templateList = array('ContentControllerTestPage_test', 'Page');
+			$expected = SS_TemplateLoader::instance()->findTemplates($templateList, 'controllertest');
+			$self->assertEquals($expected, $viewer->templates());
 		});
 	}
 


### PR DESCRIPTION
`$arr + $arr` will overwrite values with matching numeric keys whereas `array_merge()` will append them.

The new assertion is a little messy, but I didn’t want to modify the test templates because then I’d have to modify all the other tests!