### PR TITLE
Moved image thumbnail style rules to Framework

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -176,13 +176,12 @@ JS
 		$columns = $gridField->getConfig()->getComponentByType('GridFieldDataColumns');
 		$columns->setDisplayFields(array(
 			'StripThumbnail' => '',
-			// 'Parent.FileName' => 'Folder',
-			'Title' => _t('File.Name'),
+			'Title' => _t('File.Title', 'Title'),
 			'Created' => _t('AssetAdmin.CREATED', 'Date'),
 			'Size' => _t('AssetAdmin.SIZE', 'Size'),
 		));
 		$columns->setFieldCasting(array(
-			'Created' => 'Date->Nice'
+			'Created' => 'SS_Datetime->Nice'
 		));
 		$gridField->setAttribute(
 			'data-url-folder-template', 

--- a/css/screen.css
+++ b/css/screen.css
@@ -38,9 +38,6 @@
 .cms .AssetAdmin .cms-content-toolbar .cms-page-add-button span.btn-icon-add { height: 17px; }
 .cms .AssetAdmin .cms-content-toolbar .cms-page-add-button span.ui-button-text { color: #393939; text-shadow: white 0 1px 1px; }
 .cms .AssetAdmin #Root_TreeView .cms-tree ul .class-Folder a span.text span.jstree-foldericon { background: url(../images/blue-folder-horizontal.png) no-repeat; width: 16px; height: 16px; float: left; display: block; margin-right: 4px; }
-.cms .AssetAdmin table.ss-gridfield-table td { padding-top: 0; padding-bottom: 0; }
 .cms .AssetAdmin table.ss-gridfield-table td.bottom-all { padding: 0.7em; }
-.cms .AssetAdmin table.ss-gridfield-table td.col-StripThumbnail { padding: 1px 5px; width: 32px; height: 32px; }
-.cms .AssetAdmin table.ss-gridfield-table td.col-StripThumbnail img { width: 32px; height: 32px; }
 .cms .AssetAdmin table.ss-gridfield-table tr[data-class=Folder] td.col-StripThumbnail { background: transparent url(../images/treeicons/blue-folder-horizontal.png) no-repeat center; }
 .cms .AssetAdmin table.ss-gridfield-table tr[data-class=File] td.col-StripThumbnail { background: transparent url(../images/treeicons/blue-document.png) no-repeat center; }

--- a/scss/_AssetAdmin.scss
+++ b/scss/_AssetAdmin.scss
@@ -39,21 +39,8 @@
 
 	table.ss-gridfield-table {
 		td {
-			// Taken care of by minimum image sizes
-			padding-top: 0;
-			padding-bottom: 0;
 			&.bottom-all {
 				padding:0.7em;
-			}
-		}
-		td.col-StripThumbnail {
-			padding: 1px 5px;
-			width: 32px;
-			height: 32px;
-
-			img {
-				width: 32px;
-				height: 32px;
 			}
 		}
 		tr[data-class=Folder] {


### PR DESCRIPTION
for consistent styling of image thumbnails in GridFields. This is a companion fix for https://github.com/silverstripe/silverstripe-framework/pull/4441