### PR TITLE
Ensure we have a ParentID before trying to limit children by page type (fixes #1273)

### DIFF
--- a/javascript/CMSMain.AddForm.js
+++ b/javascript/CMSMain.AddForm.js
@@ -52,7 +52,7 @@
 						? (parentTree.getValue() || this.getParentID())
 						: null,
 					newClassName = metadata ? metadata.ClassName : null,
-					hintKey = (newClassName && parentMode === 'child')
+					hintKey = (newClassName && parentMode === 'child' && id)
 						? newClassName
 						: 'Root',
 					hint = (typeof hints[hintKey] !== 'undefined') ? hints[hintKey] : null,


### PR DESCRIPTION
Pretty simple fix, it was trying to get SiteTree hints for “SiteTree” instead of “Root” when no parent page is selected (so it _should_ be trying to get the hints for “Root”).
