### PR TITLE
FIX for #586: Don't perform validation upon deletion, since it isn't necessary.

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -644,7 +644,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			// if($form->Fields()->hasTabset()) $form->Fields()->findOrMakeTab('Root')->setTemplate('CMSTabSet');
 			$form->setAttribute('data-pjax-fragment', 'CurrentForm');
 			// Set validation exemptions for specific actions
-			$form->setValidationExemptActions(array('restore', 'revert', 'deletefromlive', 'rollback'));
+			$form->setValidationExemptActions(array('restore', 'revert', 'deletefromlive', 'delete', 'rollback'));
 
 			// Announce the capability so the frontend can decide whether to allow preview or not.
 			if(in_array('CMSPreviewable', class_implements($record))) {


### PR DESCRIPTION
Fix for #586 and possible fix for #736 and relates to https://github.com/kinglozzer/silverstripe-cms/commit/66bfff4d150ce5a6544ff5a21c2644c1469a1761. I believe this addresses bugs relating to removing a newly created draft page which also happens to have validation on it. May also apply to any other validated objects being handled via `CMSForm`.