### PR TITLE
FIX (partial) for #1288 where non-submit buttons are being activated on "enter" key press. 

### DIFF
--- a/javascript/CMSMain.EditForm.js
+++ b/javascript/CMSMain.EditForm.js
@@ -122,6 +122,7 @@
 				updateURLFromTitle = $('<button />', {
 					'class': 'update ss-ui-button-small',
 					'text': ss.i18n._t('URLSEGMENT.UpdateURL'),
+					'type': 'button',
 					'click': function(e) {
 						e.preventDefault();
 						self.updateURLSegment(self.val());

--- a/templates/Includes/CMSPagesController_ContentToolActions.ss
+++ b/templates/Includes/CMSPagesController_ContentToolActions.ss
@@ -3,7 +3,7 @@
 		<a class="ss-ui-button cms-content-addpage-button tool-button font-icon-plus" href="$LinkPageAdd" data-url-addpage="{$LinkPageAdd('', 'ParentID=%s')}"><% _t('CMSMain.AddNewButton', 'Add new') %></a>
 
 		<% if $View == 'Tree' %>
-		<button class="cms-content-batchactions-button tool-button font-icon-check-mark-2" data-toolid="batch-actions">
+		<button type="button" class="cms-content-batchactions-button tool-button font-icon-check-mark-2" data-toolid="batch-actions">
 			<% _t("CMSPagesController_ContentToolbar_ss.MULTISELECT","Batch actions") %>
 		</button>
 		<% end_if %>

--- a/templates/forms/SiteTreeURLSegmentField.ss
+++ b/templates/forms/SiteTreeURLSegmentField.ss
@@ -2,16 +2,16 @@
 	<a class="preview" href="$URL" target="_blank">
 		$URL
 	</a>
-	<button class="ss-ui-button ss-ui-button-small edit">
+	<button type="button" class="ss-ui-button ss-ui-button-small edit">
 		<% _t('URLSegmentField.Edit', 'Edit') %>
 	</button>
 </div>
 <div class="edit-holder">
 	<input $AttributesHTML />
-	<button class="update ss-ui-button-small">
+	<button type="button" class="update ss-ui-button-small">
 		<% _t('URLSegmentField.OK', 'OK') %>
 	</button>
-	<button class="cancel ss-ui-button-small ss-ui-action-minor">
+	<button type="button" class="cancel ss-ui-button-small ss-ui-action-minor">
 		<% _t('URLSegmentField.Cancel', 'Cancel') %>
 	</button>
 	<% if $HelpText %><p class="help">$HelpText</p><% end_if %>


### PR DESCRIPTION
Now based on `3` branch. Copied from (and supersedes) previous PR https://github.com/silverstripe/silverstripe-cms/pull/1290 which was based on `3.1`

---

This issue (and fix for  #1288) relates to framework issue at https://github.com/silverstripe/silverstripe-framework/issues/3181 and associated pull request: https://github.com/silverstripe/silverstripe-framework/pull/4662

**PLEASE NOTE:** This is a combined fix across both repositories. The actual bug reported in #1288 is addressed in the *other* pull request ([linked above and here](https://github.com/silverstripe/silverstripe-framework/pull/4651)). 

* **CMS:**
  * Issue: https://github.com/silverstripe/silverstripe-cms/issues/1288 
  * PR: https://github.com/silverstripe/silverstripe-cms/pull/1292 (you are here)
* **Framework:**
  * Issue: https://github.com/silverstripe/silverstripe-framework/issues/3181
  * PR: https://github.com/silverstripe/silverstripe-framework/pull/4651