### PR TITLE
Integrated asset gallery view

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -296,7 +296,7 @@ JS
 		$tab = $fields->findOrMakeTab('Root.GalleryView');
 		$tab->push(CompositeField::create($actionButtonsComposite)->addExtraClass('cms-content-toolbar field'));
 		$tab->push($galleryUploadField);
-		$tab->push(AssetGalleryField::create('Files')->setCurrentPath('assets')->setLimit(15));
+		$tab->push(AssetGalleryField::create('Files')->setCurrentPath('')->setLimit(15));
 
 		// Move actions to "details" tab (they don't make sense on list/tree view)
 		$actions = $form->Actions();

--- a/javascript/AssetAdmin.js
+++ b/javascript/AssetAdmin.js
@@ -101,6 +101,7 @@
 			onsubmit: function(e) {
 				var button = jQuery(this).find(':submit:first');
 				button.addClass('loading');
+
 				$.ajax({
 					url: jQuery(this).attr('action'),
 					data: this.serializeArray(),

--- a/templates/Includes/AssetAdmin_Content.ss
+++ b/templates/Includes/AssetAdmin_Content.ss
@@ -16,7 +16,7 @@
 			<div class="icon-button-group">
 				<ul class="cms-tabset-nav-primary ss-tabset">
 				<% loop $Tabs %>
-					<li<% if $extraClass %> class="$extraClass"<% end_if %>><a class="cms-panel-link icon-button <% if $Title == 'List View' %>font-icon-list<% else_if $Title == 'Tree View' %>font-icon-icon-tree<% else %>font-icon-pencil<% end_if %>" href="#$id" title="$Title"></a></li>
+					<li<% if $extraClass %> class="$extraClass"<% end_if %>><a class="cms-panel-link icon-button <% if $Title == 'List View' %>font-icon-list<% else_if $Title == 'Tree View' %>font-icon-icon-tree<% else %>font-icon-thumbnails<% end_if %>" href="#$id" title="$Title"></a></li>
 				<% end_loop %>
 				</ul>
 			</div>


### PR DESCRIPTION
This integrates the work we're doing for Assets (4.0). 

@scott1702, @tractorcow 

**Edit** this integrates the [asset gallery module](https://github.com/open-sausages/silverstripe-assets-gallery) we've been working on. It's ReactJS-based, so I guess the core team need to decide if they want ReactJS in the CMS and what the effects are...

The `composer.json` dependency is missing. The module isn't stable yet, but I've open this PR to begin discussions around this...