### PR TITLE
FIX for #1294 to workaround ErrorPage fatal errors (and undefined var) when publishing.

### DIFF
--- a/code/model/ErrorPage.php
+++ b/code/model/ErrorPage.php
@@ -222,11 +222,10 @@ class ErrorPage extends Page {
 	 * content, so the page can be shown even when SilverStripe is not
 	 * functioning correctly before publishing this page normally.
 	 *
-	 * @return void
+	 * @return bool
 	 */
 	public function doPublish() {
-		parent::doPublish();
-
+		if (!parent::doPublish()) return false;
 		return $this->writeStaticPage();
 	}
 
@@ -255,10 +254,10 @@ class ErrorPage extends Page {
 			$fileErrorText = _t(
 				'ErrorPage.ERRORFILEPROBLEM',
 				'Error opening file "{filename}" for writing. Please check file permissions.',
-				array('filename' => $errorFile)
+				array('filename' => $filePath)
 			);
-			$this->response->addHeader('X-Status', rawurlencode($fileErrorText));
-			return $this->httpError(405);
+			user_error($fileErrorText, E_USER_WARNING);
+			return false;
 		}
 		return true;
 	}


### PR DESCRIPTION
Addresses #1294. Also ensuring the method follows the parent method definition! Should return `bool`.

**Note:** I'm assuming that `user_error()` is the best route here. I'm not sure how else to register that sort of error.