### PR TITLE
Generated files API

### DIFF
--- a/_config/cmslogging.yml
+++ b/_config/cmslogging.yml
@@ -1,0 +1,9 @@
+---
+Name: cms-logging
+After: '#live-logging'
+Except:
+  environment: dev
+---
+Injector:
+  FriendlyErrorFormatter:
+    class: SilverStripe\Cms\Logging\ErrorPageErrorFormatter

--- a/code/logging/ErrorPageErrorFormatter.php
+++ b/code/logging/ErrorPageErrorFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SilverStripe\Cms\Logging;
+
+use ErrorPage;
+use SilverStripe\Framework\Logging\DebugViewFriendlyErrorFormatter;
+
+/**
+ * Provides {@see ErrorPage}-gnostic error handling
+ */
+class ErrorPageErrorFormatter extends DebugViewFriendlyErrorFormatter {
+	
+	public function output($statusCode) {
+		// Ajax content is plain-text only
+		if(\Director::is_ajax()) {
+			return $this->getTitle();
+		}
+		
+		// Determine if cached ErrorPage content is available
+		$content = ErrorPage::get_content_for_errorcode($statusCode);
+		if($content) {
+			return $content;
+		}
+
+		// Fallback to default output
+		return parent::output($statusCode);
+	}
+}

--- a/tests/model/ErrorPageTest.yml
+++ b/tests/model/ErrorPageTest.yml
@@ -1,11 +1,11 @@
 ErrorPage:
-   404:
-      Title: Page Not Found
-      URLSegment: page-not-found
-      Content: My error page body
-      ErrorCode: 404
-   403:
-      Title: Permission Failure
-      URLSegment: permission-denied
-      Content: You do not have permission to view this page
-      ErrorCode: 403
+  404:
+    Title: Page Not Found
+    URLSegment: page-not-found
+    Content: My error page body
+    ErrorCode: 404
+  403:
+    Title: Permission Failure
+    URLSegment: permission-denied
+    Content: You do not have permission to view this page
+    ErrorCode: 403


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/pull/4680 for the core pull request

CMS-specific errorpage handling has been refactored out of framework module into a separate FriendlyErrorFormatter, which replaces the core framework FriendlyErrorFormatter when cms module is installed.

The ErrorPage static caching has been refactored into the new generated file handling API. However, for the sake of apache error handling (which relies on a physical file at `/assets/error-XXX.html`) an option to continue to write to this specific location (`ErrorPage.enable_static_file`) is included (on by default).