### PR TITLE
FIX: Remove tab - invalid YAML

### DIFF
--- a/tests/model/SiteTreeBrokenLinksTest.yml
+++ b/tests/model/SiteTreeBrokenLinksTest.yml
@@ -20,7 +20,7 @@ File:
         Name: privacypolicy.pdf
         Title: privacypolicy.pdf
         Filename: assets/privacypolicy.pdf
-    	
+
 ErrorPage:
     404:
         Title: Page not Found


### PR DESCRIPTION
If https://github.com/silverstripe/silverstripe-framework/pull/4591 is merged, this invalid YAML syntax will cause tests to fail