### PR TITLE
Revert use of GeneratedAssetHandler in ErrorPage

### DIFF
--- a/tests/model/ErrorPageTest.php
+++ b/tests/model/ErrorPageTest.php
@@ -19,7 +19,6 @@ class ErrorPageTest extends FunctionalTest {
 		// Set temporary asset backend store
 		AssetStoreTest_SpyStore::activate('ErrorPageTest');
 		Config::inst()->update('ErrorPage', 'static_filepath', AssetStoreTest_SpyStore::base_path());
-		Config::inst()->update('ErrorPage', 'enable_static_file', true);
 		Config::inst()->update('Director', 'environment_type', 'live');
 	}
 
@@ -95,24 +94,5 @@ class ErrorPageTest extends FunctionalTest {
 		$this->assertNotEmpty(ErrorPage::get_content_for_errorcode('401'));
 		$expectedErrorPagePath = AssetStoreTest_SpyStore::base_path() . '/error-401.html';
 		$this->assertFileExists($expectedErrorPagePath, 'Error page is cached');
-	}
-
-	/**
-	 * Test fallback to file generation API with enable_static_file disabled
-	 */
-	public function testGeneratedFile() {
-		Config::inst()->update('ErrorPage', 'enable_static_file', false);
-		$this->logInWithPermission('ADMIN');
-
-		$page = new ErrorPage();
-		$page->ErrorCode = 405;
-		$page->Title = 'Method Not Allowed';
-		$page->write();
-		$page->doPublish();
-
-		// Error content is available, even though the static file does not exist (only in assetstore)
-		$this->assertNotEmpty(ErrorPage::get_content_for_errorcode('405'));
-		$expectedErrorPagePath = AssetStoreTest_SpyStore::base_path() . '/error-405.html';
-		$this->assertFileNotExists($expectedErrorPagePath, 'Error page is not cached in static location');
 	}
 }


### PR DESCRIPTION
Reverts much of https://github.com/silverstripe/silverstripe-cms/pull/1300

After implementing this change earlier I realised there was an architectural flaw in how ErrorPage was using the GeneratedAssetHandler service.

This service is a caching mechanism for generated content, and CANNOT be used to pre-generate content which may not be re-generated on-demand, as is possible with combined files.

The underlying caching mechanism, SS_Cache, also is only a caching mechanism, not a data store. Using it as such would be disastrous on clustered systems, with multiple nodes each having their own locale cache.

In place of this service, I have left the original functionality in place with the ability to customise the `static_filepath` via config.

See https://github.com/silverstripe/silverstripe-framework/pull/4709