### PR TITLE
FIX: Setting hide_ancestor=true causes a random page type to be hidden

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -392,7 +392,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 *
 	 * @return array
 	 */
-	static public function page_type_classes() {
+	public static function page_type_classes() {
 		$classes = ClassInfo::getValidSubClasses();
 
 		$baseClassIndex = array_search('SiteTree', $classes);
@@ -417,8 +417,10 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$kill_ancestors = array_unique($kill_ancestors);
 			foreach($kill_ancestors as $mark) {
 				// unset from $classes
-				$idx = array_search($mark, $classes);
-				unset($classes[$idx]);
+				$idx = array_search($mark, $classes, true);
+				if ($idx !== false) {
+					unset($classes[$idx]);
+				}
 			}
 		}
 

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -871,6 +871,15 @@ class SiteTreeTest extends SapphireTest {
 		$classes = SiteTree::page_type_classes();
 		$this->assertNotContains('SiteTree', $classes, 'Page types do not include base class');
 		$this->assertContains('Page', $classes, 'Page types do contain subclasses');
+
+		// Testing what happens in an incorrect config value is set - hide_ancestor should be a string
+		Config::inst()->update('SiteTreeTest_ClassA', 'hide_ancestor', true);
+		$newClasses = SiteTree::page_type_classes();
+		$this->assertEquals(
+			$classes,
+			$newClasses,
+			'Setting hide_ancestor to a boolean (incorrect) value caused a page class to be hidden'
+		);
 	}
 
 	public function testAllowedChildren() {


### PR DESCRIPTION
Yes, I know that `hide_ancestor` is meant to be a string, not boolean! However as the config system can’t warn us about that, this prevents the first page type (usually `Page`) from incorrectly being hidden if it’s set to true (the name _does_ suggest it’s a boolean after all). Plus stricter code = better code, right?

tldr:
```php
array_search(true, array('somestring')) === 0 // meaning that the first class is removed
array_search(true, array('somestring'), true) === false // so we can correctly do nothing
```