### PR TITLE
BUG Ensure CMSMainTest uses correct siteconfig

### DIFF
--- a/tests/controller/CMSMainTest.php
+++ b/tests/controller/CMSMainTest.php
@@ -9,6 +9,18 @@ class CMSMainTest extends FunctionalTest {
 
 	static protected $orig = array();
 
+	public function setUp() {
+		parent::setUp();
+
+		// Clear automatically created siteconfigs (in case one was created outside of the specified fixtures).
+		$ids = $this->allFixtureIDs('SiteConfig');
+		if($ids) {
+			foreach(SiteConfig::get()->exclude('ID', $ids) as $config) {
+				$config->delete();
+			}
+		}
+	}
+
 	function testSiteTreeHints() {
 		$cache = SS_Cache::factory('CMSMain_SiteTreeHints');
 		// Login as user with root creation privileges
@@ -262,16 +274,16 @@ class CMSMainTest extends FunctionalTest {
 		$cmsUser->logIn();
 		$this->get('admin/pages/add');
 		$response = $this->post(
-				'admin/pages/add/AddForm',
-				array(
-						'ParentID' => '0',
-						'PageType' => 'Page',
-						'Locale' => 'en_US',
-						'action_doAdd' => 1,
-						'ajax' => 1,
-				), array(
-						'X-Pjax' => 'CurrentForm,Breadcrumbs',
-				)
+			'admin/pages/add/AddForm',
+			array(
+				'ParentID' => '0',
+				'PageType' => 'Page',
+				'Locale' => 'en_US',
+				'action_doAdd' => 1,
+				'ajax' => 1,
+			), array(
+				'X-Pjax' => 'CurrentForm,Breadcrumbs',
+			)
 		);
 		// should redirect, which is a permission error
 		$this->assertEquals(403, $response->getStatusCode(), 'Add TopLevel page must fail for normal user');
@@ -281,16 +293,16 @@ class CMSMainTest extends FunctionalTest {
 		$response = $this->get('admin/pages/add');
 
 		$response = $this->post(
-				'admin/pages/add/AddForm',
-				array(
-						'ParentID' => '0',
-						'PageType' => 'Page',
-						'Locale' => 'en_US',
-						'action_doAdd' => 1,
-						'ajax' => 1,
-				), array(
-						'X-Pjax' => 'CurrentForm,Breadcrumbs',
-				)
+			'admin/pages/add/AddForm',
+			array(
+				'ParentID' => '0',
+				'PageType' => 'Page',
+				'Locale' => 'en_US',
+				'action_doAdd' => 1,
+				'ajax' => 1,
+			), array(
+				'X-Pjax' => 'CurrentForm,Breadcrumbs',
+			)
 		);
 
 		$location = $response->getHeader('X-ControllerURL');
@@ -312,27 +324,60 @@ class CMSMainTest extends FunctionalTest {
 		// Create toplevel page
 		$this->get('admin/pages/add');
 		$response = $this->post(
-				'admin/pages/add/AddForm',
-				array('ParentID' => '0', 'PageType' => 'CMSMainTest_ClassA', 'Locale' => 'en_US', 'action_doAdd' => 1)
+			'admin/pages/add/AddForm',
+			array(
+				'ParentID' => '0',
+				'PageType' => 'CMSMainTest_ClassA',
+				'Locale' => 'en_US',
+				'action_doAdd' => 1,
+				'ajax' => 1
+			), array(
+				'X-Pjax' => 'CurrentForm,Breadcrumbs',
+			)
 		);
 		$this->assertFalse($response->isError());
-		preg_match('/edit\/show\/(\d*)/', $response->getHeader('Location'), $matches);
+		$ok = preg_match('/edit\/show\/(\d*)/', $response->getHeader('X-ControllerURL'), $matches);
+		$this->assertNotEmpty($ok);
 		$newPageId = $matches[1];
 
 		// Create allowed child
 		$this->get('admin/pages/add');
 		$response = $this->post(
-				'admin/pages/add/AddForm',
-				array('ParentID' => $newPageId, 'PageType' => 'CMSMainTest_ClassB', 'Locale' => 'en_US', 'action_doAdd' => 1)
+			'admin/pages/add/AddForm',
+			array(
+				'ParentID' => $newPageId,
+				'PageType' => 'CMSMainTest_ClassB',
+				'Locale' => 'en_US',
+				'action_doAdd' => 1,
+				'ajax' => 1
+			), array(
+				'X-Pjax' => 'CurrentForm,Breadcrumbs',
+			)
 		);
 		$this->assertFalse($response->isError());
-		$this->assertNull($response->getBody());
+		$this->assertEmpty($response->getBody());
+
+		// Verify that the page was created and redirected to accurately
+		$newerPage = SiteTree::get()->byID($newPageId)->AllChildren()->first();
+		$this->assertNotEmpty($newerPage);
+		$ok = preg_match('/edit\/show\/(\d*)/', $response->getHeader('X-ControllerURL'), $matches);
+		$this->assertNotEmpty($ok);
+		$newerPageID = $matches[1];
+		$this->assertEquals($newerPage->ID, $newerPageID);
 
 		// Create disallowed child
 		$this->get('admin/pages/add');
 		$response = $this->post(
-				'admin/pages/add/AddForm',
-				array('ParentID' => $newPageId, 'PageType' => 'Page', 'Locale' => 'en_US', 'action_doAdd' => 1)
+			'admin/pages/add/AddForm',
+			array(
+				'ParentID' => $newPageId,
+				'PageType' => 'Page',
+				'Locale' => 'en_US',
+				'action_doAdd' => 1,
+				'ajax' => 1
+			), array(
+				'X-Pjax' => 'CurrentForm,Breadcrumbs',
+			)
 		);
 		$this->assertEquals(403, $response->getStatusCode(), 'Add disallowed child should fail');
 

--- a/tests/controller/CMSMainTest.yml
+++ b/tests/controller/CMSMainTest.yml
@@ -1,142 +1,142 @@
 Page:
-   page1:
-      Title: Page 1
-      Sort: 1
-   page2:
-      Title: Page 2
-      Sort: 2
-   page3:
-      Title: Page 3
-      Sort: 3
-   page31:
-      Title: Page 3.1
-      Parent: =>Page.page3
-      Sort: 1
-   page32:
-      Title: Page 3.2
-      Parent: =>Page.page3
-      Sort: 2
-   page4:
-      Title: Page 4
-      Sort: 4
-   page5:
-      Title: Page 5
-      Sort: 5
-   page6:
-      Title: Page 6
-      Sort: 6
-   page7:
-      Title: Page 7
-      Sort: 7
-   page8:
-      Title: Page 8
-      Sort: 8
-   page9:
-      Title: Page 9
-      Sort: 9
-   page10:
-      Title: Page 10
-      Sort: 10
-   page11:
-      Title: Page 11
-      Sort: 11
-   page12:
-      Title: Page 12
-      Sort: 12
-   page13:
-      Title: Page 13
-      Sort: 13
-   page14:
-      Title: Page 14
-      Sort: 14
-   page15:
-      Title: Page 15
-      Sort: 15
-   page16:
-      Title: Page 16
-      Sort: 16
-   page17:
-      Title: Page 17
-      Sort: 17
-   page18:
-      Title: Page 18
-      Sort: 18
-   page19:
-      Title: Page 19
-      Sort: 19
-   page20:
-      Title: Page 20
-      Sort: 20
-   page21:
-      Title: Page 21
-      Sort: 21
-   page22:
-      Title: Page 22
-      Sort: 22
-   page23:
-      Title: Page 23
-      Sort: 23
-   page24:
-      Title: Page 24
-      Sort: 24
-   page25:
-      Title: Page 25
-      Sort: 25
-   page26:
-      Title: Page 26
-      Sort: 26
-   home:
-      Title: Home
-      URLSegment: home
-      Sort: 27
+  page1:
+    Title: Page 1
+    Sort: 1
+  page2:
+    Title: Page 2
+    Sort: 2
+  page3:
+    Title: Page 3
+    Sort: 3
+  page31:
+    Title: Page 3.1
+    Parent: =>Page.page3
+    Sort: 1
+  page32:
+    Title: Page 3.2
+    Parent: =>Page.page3
+    Sort: 2
+  page4:
+    Title: Page 4
+    Sort: 4
+  page5:
+    Title: Page 5
+    Sort: 5
+  page6:
+    Title: Page 6
+    Sort: 6
+  page7:
+    Title: Page 7
+    Sort: 7
+  page8:
+    Title: Page 8
+    Sort: 8
+  page9:
+    Title: Page 9
+    Sort: 9
+  page10:
+    Title: Page 10
+    Sort: 10
+  page11:
+    Title: Page 11
+    Sort: 11
+  page12:
+    Title: Page 12
+    Sort: 12
+  page13:
+    Title: Page 13
+    Sort: 13
+  page14:
+    Title: Page 14
+    Sort: 14
+  page15:
+    Title: Page 15
+    Sort: 15
+  page16:
+    Title: Page 16
+    Sort: 16
+  page17:
+    Title: Page 17
+    Sort: 17
+  page18:
+    Title: Page 18
+    Sort: 18
+  page19:
+    Title: Page 19
+    Sort: 19
+  page20:
+    Title: Page 20
+    Sort: 20
+  page21:
+    Title: Page 21
+    Sort: 21
+  page22:
+    Title: Page 22
+    Sort: 22
+  page23:
+    Title: Page 23
+    Sort: 23
+  page24:
+    Title: Page 24
+    Sort: 24
+  page25:
+    Title: Page 25
+    Sort: 25
+  page26:
+    Title: Page 26
+    Sort: 26
+  home:
+    Title: Home
+    URLSegment: home
+    Sort: 27
 Group:
-   admin:
-      Title: Administrators
-   empty:
-      Title: Empty Group
-   assetsonly:
-      Title: assetsonly
-   allcmssections:
-      Title: allcmssections
-   rooteditusers:
-      Title: rooteditusers
+  admin:
+    Title: Administrators
+  empty:
+    Title: Empty Group
+  assetsonly:
+    Title: assetsonly
+  allcmssections:
+    Title: allcmssections
+  rooteditusers:
+    Title: rooteditusers
 Member:
-   admin:
-      Email: admin@example.com
-      Password: ZXXlkwecxz2390232233
-      Groups: =>Group.admin
-   assetsonlyuser:
-      Email: assetsonlyuser@test.com
-      Groups: =>Group.assetsonly
-   allcmssectionsuser:
-      Email: allcmssectionsuser@test.com
-      Groups: =>Group.allcmssections
-   rootedituser:
-      Email: rootedituser@test.com
-      Groups: =>Group.rooteditusers
+  admin:
+    Email: admin@example.com
+    Password: ZXXlkwecxz2390232233
+    Groups: =>Group.admin
+  assetsonlyuser:
+    Email: assetsonlyuser@test.com
+    Groups: =>Group.assetsonly
+  allcmssectionsuser:
+    Email: allcmssectionsuser@test.com
+    Groups: =>Group.allcmssections
+  rootedituser:
+    Email: rootedituser@test.com
+    Groups: =>Group.rooteditusers
 Permission:
-   admin:
-      Code: ADMIN
-      GroupID: =>Group.admin
-   assetsonly:
-      Code: CMS_ACCESS_AssetAdmin
-      GroupID: =>Group.assetsonly
-   allcmssections:
-      Code: CMS_ACCESS_LeftAndMain
-      GroupID: =>Group.allcmssections
-   allcmssections2:
-      Code: CMS_ACCESS_LeftAndMain
-      GroupID: =>Group.rooteditusers
+  admin:
+    Code: ADMIN
+    GroupID: =>Group.admin
+  assetsonly:
+    Code: CMS_ACCESS_AssetAdmin
+    GroupID: =>Group.assetsonly
+  allcmssections:
+    Code: CMS_ACCESS_LeftAndMain
+    GroupID: =>Group.allcmssections
+  allcmssections2:
+    Code: CMS_ACCESS_LeftAndMain
+    GroupID: =>Group.rooteditusers
 SiteConfig:
-   siteconfig1:
-      EditorGroups: =>Group.rooteditusers
-      CanCreateTopLevelType: 'OnlyTheseUsers'
+  siteconfig1:
+    EditorGroups: =>Group.rooteditusers
+    CanCreateTopLevelType: 'OnlyTheseUsers'
 SiteConfig_CreateTopLevelGroups:
-   createtoplevelgroups1:
-      SiteConfigID:  =>SiteConfig.siteconfig1
-      GroupID: =>Group.rooteditusers
+  createtoplevelgroups1:
+    SiteConfigID: =>SiteConfig.siteconfig1
+    GroupID: =>Group.rooteditusers
 RedirectorPage:
-   page5:
-      Title: Page 5
-      RedirectionType: External
-      ExternalURL: http://www.google.com
+  page5:
+    Title: Page 5
+    RedirectionType: External
+    ExternalURL: http://www.google.com


### PR DESCRIPTION
Sometimes tests would end up with the default SiteConfig appearing alongside the one specified in the test fixtures.

Additionally, ->post requests which failed were causing Security::LoginForm() to be invoked, causing needless work being done (and potentially breaking if it encountered errors during page rendering).

Using ajax => 1 means that the tests will raise security permission failures appropriately without having to generate rendered error pages.

Some indentation was cleaned up, and a few tests strengthened.