### PR TITLE
API Add page/admin redirect to admin section for that page

### DIFF
--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -25,6 +25,7 @@ class ContentController extends Controller {
 	private static $extensions = array('OldPageRedirector');
 
 	private static $allowed_actions = array(
+		'admin',
 		'successfullyinstalled',
 		'deleteinstallfiles', // secured through custom code
 		'LoginForm'
@@ -488,5 +489,27 @@ HTML;
 			"Title" => $title,
 			"Content" => $content,
 		);
+	}
+
+	/**
+	 * Redirect the user to the admin section for this page
+	 *
+	 * @return SS_HTTPResponse
+	 */
+	public function admin() {
+		// Verify record exists
+		$record = $this->data();
+		if(!$record || !$record->exists()) {
+			return $this->httpError(404);
+		}
+
+		// Check permissions
+		if(!$record->canEdit()) {
+			return Security::permissionFailure(
+				$this,
+				_t('ContentController.EDITPAGE', 'Please log in to edit this page')
+			);
+		}
+		return $this->redirect($record->CMSEditLink());
 	}
 }

--- a/tests/controller/ContentControllerTest.php
+++ b/tests/controller/ContentControllerTest.php
@@ -179,6 +179,31 @@ class ContentControllerTest extends FunctionalTest {
 		});
 	}
 
+	public function testAdminRedirect() {
+		// Check that a security message is raised
+		$this->autoFollowRedirection = false;
+		Session::clear('loggedInAs');
+		$page = $this->objFromFixture('ContentControllerTest_Page', 'second_level_page');
+		
+		$response = $this->get('home/second-level/');
+		$this->assertEquals(200, $response->getStatusCode());
+		
+		$response = $this->get('home/second-level/admin/');
+		$this->assertEquals(302, $response->getStatusCode());
+		$this->assertContains('Security/login', $response->getHeader('Location'));
+
+		// Test redirect as admin
+		$this->logInWithPermission('ADMIN');
+
+		$response = $this->get('home/second-level/');
+		$this->assertEquals(200, $response->getStatusCode());
+
+		$response = $this->get('home/second-level/admin/');
+		$this->assertEquals(302, $response->getStatusCode());
+		$this->assertContains($page->CMSEditLink(), $response->getHeader('Location'));
+		$this->autoFollowRedirection = true;
+	}
+
 }
 
 class ContentControllerTest_Page extends Page {  }


### PR DESCRIPTION
Because I am so lazy and hate having to find the page again after logging into the CMS.


mypage/admin will send me to the right place to immediately edit that page.