### PR TITLE
NEW allow for setting Current, Section and Link values via Config system

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -235,6 +235,30 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	private static $meta_generator = 'SilverStripe - http://silverstripe.org';
 
 	protected $_cache_statusFlags = null;
+
+	/**
+	 * CSS Class to use for links matching the currently viewed page.
+	 *
+	 * @config
+	 * @var string
+	 */
+	private static $linking_mode_current = 'current';
+
+	/**
+	 * CSS Class to use for links matching the currently viewed page.
+	 *
+	 * @config
+	 * @var string
+	 */
+	private static $linking_mode_section = 'section';
+
+	/**
+	 * CSS Class to use for links matching the currently viewed page.
+	 *
+	 * @config
+	 * @var string
+	 */
+	private static $linking_mode_link = 'link';
 	
 	/**
 	 * Determines if the system should avoid orphaned pages
@@ -618,7 +642,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return string
 	 */
 	public function LinkOrCurrent() {
-		return $this->isCurrent() ? 'current' : 'link';
+		return $this->isCurrent()
+            ? $this->config()->get('SiteTree', 'linking_mode_current')
+            : $this->config()->get('SiteTree', 'linking_mode_link');
 	}
 	
 	/**
@@ -627,7 +653,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return string
 	 */
 	public function LinkOrSection() {
-		return $this->isSection() ? 'section' : 'link';
+		return $this->isSection()
+            ? $this->config()->get('SiteTree', 'linking_mode_section')
+            : $this->config()->get('SiteTree', 'linking_mode_link');
 	}
 	
 	/**
@@ -638,11 +666,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	public function LinkingMode() {
 		if($this->isCurrent()) {
-			return 'current';
+			return $this->config()->get('SiteTree', 'linking_mode_current');
 		} elseif($this->isSection()) {
-			return 'section';
+			return $this->config()->get('SiteTree', 'linking_mode_section');
 		} else {
-			return 'link';
+			return $this->config()->get('SiteTree', 'linking_mode_link');
 		}
 	}
 	

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -676,6 +676,14 @@ class SiteTreeTest extends SapphireTest {
 
 		Director::set_current_page($newPage = new SiteTree());
 		$this->assertTrue($newPage->isCurrent(), 'Assert that isCurrent works on unsaved pages.');
+
+		$this->assertEquals($newPage->LinkOrCurrent(), 'current');
+		Config::inst()->update('SiteTree', 'linking_mode_current', 'active');
+		$this->assertEquals($newPage->LinkOrCurrent(), 'active');
+		
+		$this->assertEquals($aboutPage->LinkOrCurrent(), 'link');
+		Config::inst()->update('SiteTree', 'linking_mode_link', 'just-a-link');
+		$this->assertEquals($aboutPage->LinkOrCurrent(), 'just-a-link');
 	}
 
 	public function testIsSection() {
@@ -697,6 +705,10 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertTrue($about->isSection());
 		$this->assertTrue($staff->isSection());
 		$this->assertTrue($ceo->isSection());
+
+		$this->assertEquals($about->LinkOrSection(), 'section');
+		Config::inst()->update('SiteTree', 'linking_mode_section', 'active-section');
+		$this->assertEquals($about->LinkOrSection(), 'active-section');
 	}
 
 	public function testURLSegmentAutoUpdate() {


### PR DESCRIPTION
The goal of this is to allow for setting the `current`, `section` and `link` return values for easier use with various front-end frameworks such as bootstrap. It uses the Config system to set the default value and allow the developer to override that value depending on their project need.