### PR TITLE
FIX: call getParent() in orphaned record checks

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -608,7 +608,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if(empty($this->ParentID)) return false;
 		
 		// Parent must exist and not be an orphan itself
-		$parent = $this->Parent();
+		$parent = $this->getParent();
 		return !$parent || !$parent->exists() || $parent->isOrphaned();
 	}
 	


### PR DESCRIPTION
In the situation where you have a record with a `Parent()` method or `ParentID` has_one this check can fail.

This was found during an upgrade from 3.1 -> 3.2 and is on the blog module - still looking where it occurred to see if its user code or blog code :)
