### PR TITLE
Decouple ErrorPage

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,6 +1,9 @@
 LeftAndMain:
   extensions:
     - LeftAndMainPageIconsExtension
-Security:
+Controller:
+  extensions:
+    - ErrorPageControllerExtension
+Form:
   extensions:
     - ErrorPageControllerExtension

--- a/code/controllers/ContentController.php
+++ b/code/controllers/ContentController.php
@@ -211,16 +211,6 @@ class ContentController extends Controller {
 	}
 
 	/**
-	 * @uses ErrorPage::response_for()
-	 */
-	public function httpError($code, $message = null) {
-		// Don't use the HTML response for media requests
-		$response = $this->getRequest()->isMedia() ? null : ErrorPage::response_for($code);
-		// Failover to $message if the HTML response is unavailable / inappropriate
-		parent::httpError($code, $response ? $response : $message);
-	}
-
-	/**
 	 * Get the project name
 	 *
 	 * @return string
@@ -423,12 +413,6 @@ HTML;
 		// Return 410 Gone if this site is not actually a fresh installation
 		if (!file_exists(BASE_PATH . '/install.php')) {
 			$this->httpError(410);
-		}
-		// The manifest should be built by now, so it's safe to publish the 404 page
-		$fourohfour = Versioned::get_one_by_stage('ErrorPage', 'Stage', '"ErrorPage"."ErrorCode" = 404');
-		if($fourohfour) {
-			$fourohfour->write();
-			$fourohfour->publish("Stage", "Live");
 		}
 
 		// TODO Allow this to work when allow_url_fopen=0

--- a/code/controllers/ModelAsController.php
+++ b/code/controllers/ModelAsController.php
@@ -111,8 +111,7 @@ class ModelAsController extends Controller implements NestedController {
 		if(class_exists('Translatable')) Translatable::enable_locale_filter();
 
 		if(!$sitetree) {
-			$response = ErrorPage::response_for(404);
-			$this->httpError(404, $response ? $response : 'The requested page could not be found.');
+			$this->httpError(404, 'The requested page could not be found.');
 		}
 
 		// Enforce current locale setting to the loaded SiteTree object

--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -439,7 +439,6 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if (
 			   !($page = DataObject::get_by_id('SiteTree', $arguments['id']))         // Get the current page by ID.
 			&& !($page = Versioned::get_latest_version('SiteTree', $arguments['id'])) // Attempt link to old version.
-			&& !($page = DataObject::get_one('ErrorPage', array('"ErrorPage"."ErrorCode"' => 404)))   // Link to 404 page directly.
 		) {
 			 return; // There were no suitable matches at all.
 		}

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -613,7 +613,6 @@ class SiteTreeTest extends SapphireTest {
 
 	public function testLinkShortcodeHandler() {
 		$aboutPage = $this->objFromFixture('Page', 'about');
-		$errorPage = $this->objFromFixture('ErrorPage', '404');
 		$redirectPage = $this->objFromFixture('RedirectorPage', 'external');
 
 		$parser = new ShortcodeParser();
@@ -636,11 +635,8 @@ class SiteTreeTest extends SapphireTest {
 		$aboutShortcode = '[sitetree_link,id="-1"]';
 		$aboutEnclosed  = '[sitetree_link,id="-1"]Example Content[/sitetree_link]';
 
-		$aboutShortcodeExpected = $errorPage->Link();
-		$aboutEnclosedExpected  = sprintf('<a href="%s">Example Content</a>', $errorPage->Link());
-
-		$this->assertEquals($aboutShortcodeExpected, $parser->parse($aboutShortcode), 'Test link to 404 page if no suitable matches.');
-		$this->assertEquals($aboutEnclosedExpected, $parser->parse($aboutEnclosed));
+		$this->assertEquals('', $parser->parse($aboutShortcode), 'Test empty result if no suitable matches.');
+		$this->assertEquals('', $parser->parse($aboutEnclosed));
 
 		$redirectShortcode = sprintf('[sitetree_link,id=%d]', $redirectPage->ID);
 		$redirectEnclosed  = sprintf('[sitetree_link,id=%d]Example Content[/sitetree_link]', $redirectPage->ID);


### PR DESCRIPTION
This moves baked in ErrorPage functionality to an extension, so it can be split out in to an optional module in a subsequent PR. For motivation see https://github.com/silverstripe/silverstripe-framework/issues/4149