### PR TITLE
BUG prevent "Home page" being selected when no selection was made

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -869,15 +869,6 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		$this->extend('updateCurrentPageID', $id);
 
-		// Fall back to homepage record
-		if(!$id) {
-			$homepageSegment = RootURLController::get_homepage_link();
-			$homepageRecord = DataObject::get_one('SiteTree', array(
-				'"SiteTree"."URLSegment"' => $homepageSegment
-			));
-			if($homepageRecord) $id = $homepageRecord->ID;
-		}
-
 		return $id;
 	}
 

--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -409,11 +409,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	public function Breadcrumbs($unlinked = false) {
 		$items = parent::Breadcrumbs($unlinked);
 
-		// The root element should point to the pages tree view,
-		// rather than the actual controller (which would just show an empty edit form)
-		$defaultTitle = self::menu_title_for_class('CMSPagesController');
-		$items[0]->Title = _t("{$this->class}.MENUTITLE", $defaultTitle);
-		$items[0]->Link = singleton('CMSPagesController')->Link();
+		if($items->count() > 1) {
+			// Specific to the SiteTree admin section, we never show the cms section and current
+			// page in the same breadcrumbs block.
+			$items->shift();
+		}
 
 		return $items;
 	}

--- a/code/controllers/CMSPageEditController.php
+++ b/code/controllers/CMSPageEditController.php
@@ -11,10 +11,4 @@ class CMSPageEditController extends CMSMain {
 	private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 	private static $session_namespace = 'CMSMain';
 
-	public function Breadcrumbs($unlinked = false) {
-		$crumbs = parent::Breadcrumbs($unlinked);
-		$crumbs[0]->Title = _t('CMSPagesController.MENUTITLE');
-		return $crumbs;
-	}
-
 }

--- a/templates/Includes/CMSMain_Content.ss
+++ b/templates/Includes/CMSMain_Content.ss
@@ -4,19 +4,7 @@
 		
 
 		<div class="cms-content-header-nav">
-			<div class="breadcrumbs-wrapper" data-pjax-fragment="Breadcrumbs">
-				<h2 id="page-title-heading">
-					<% loop $Breadcrumbs %>
-						<% if $First %>
-						<% else_if $Last %>
-							<span class="cms-panel-link crumb last">$Title.XML</span>
-						<% else %>
-							<a class="cms-panel-link crumb" href="$Link">$Title.XML</a>
-							<span class="sep">/</span>
-						<% end_if %>
-					<% end_loop %>
-				</h2>
-			</div>
+			<% include CMSBreadcrumbs %>
 
 			<div class="cms-content-header-tabs">
 				<ul class="cms-tabset-nav-primary">


### PR DESCRIPTION
Fixes #1351 and #1358

This looks like old intentional behaviour we don't really want anymore; Selecting "pages" no longer auto-selects a page.

I've also refactored an old update to breadcrumbs which wasn't working with the partial template loading; It should be ok now. ;)