### PR TITLE
API VirtualPage permissions now can be set independently of the mirrored pages

### DIFF
--- a/code/model/VirtualPage.php
+++ b/code/model/VirtualPage.php
@@ -27,6 +27,8 @@ class VirtualPage extends Page {
 		'Version',
 		"Embargo",
 		"Expiry",
+		"CanViewType",
+		"CanEditType",
 	);
 	
 	/**

--- a/tests/model/VirtualPageTest.php
+++ b/tests/model/VirtualPageTest.php
@@ -204,6 +204,42 @@ class VirtualPageTest extends FunctionalTest {
 		$this->assertTrue($vp->doDeleteFromLive());
 		$this->assertNull(DB::query("SELECT \"ID\" FROM \"SiteTree_Live\" WHERE \"ID\" = $vp->ID")->value());
 	}
+
+	public function testCanEdit() {
+		$parentPage = $this->objFromFixture('Page', 'master3');
+		$virtualPage = $this->objFromFixture('VirtualPage', 'vp3');
+		$bob = $this->objFromFixture('Member', 'bob');
+		$andrew = $this->objFromFixture('Member', 'andrew');
+
+		// Bob can edit the mirrored page, but he shouldn't be able to edit the virtual page.
+		$this->logInAs($bob);
+		$this->assertTrue($parentPage->canEdit());
+		$this->assertFalse($virtualPage->canEdit());
+
+		//  Andrew can only edit the virtual page, but not the original.
+		$this->logInAs($andrew);
+		$this->assertFalse($parentPage->canEdit());
+		$this->assertTrue($virtualPage->canEdit());
+	}
+
+	public function testCanView() {
+		$parentPage = $this->objFromFixture('Page', 'master3');
+		$parentPage->publish('Stage', 'Live');
+		$virtualPage = $this->objFromFixture('VirtualPage', 'vp3');
+		$virtualPage->publish('Stage', 'Live');
+		$cindy = $this->objFromFixture('Member', 'cindy');
+		$alice = $this->objFromFixture('Member', 'alice');
+
+		// Cindy can see both pages
+		$this->logInAs($cindy);
+		$this->assertTrue($parentPage->canView());
+		$this->assertTrue($virtualPage->canView());
+
+		// Alice can't see the virtual page, since it's restricted to cindy
+		$this->logInAs($alice);
+		$this->assertTrue($parentPage->canView());
+		$this->assertFalse($virtualPage->canView());
+	}
 	
 	public function testVirtualPagesArentInappropriatelyPublished() {
 		// Fixture

--- a/tests/model/VirtualPageTest.yml
+++ b/tests/model/VirtualPageTest.yml
@@ -1,17 +1,61 @@
+Group:
+  bobgroup:
+    Title: BobGroup
+    code: bobgroup
+  andrewgroup:
+    Title: AndrewGroup
+    code: andrewgroup
+  cindygroup:
+    Title: CindyGroup
+    code: cindygroup
+  alicegroup:
+    Title: AliceGroup
+    code: alicegrouip
+Permission:
+  bobpermission:
+    Code: CMS_ACCESS_CMSMain
+    Group: =>Group.bobgroup
+  andrewpermission:
+    Code: CMS_ACCESS_CMSMain
+    Group: =>Group.andrewgroup
+Member:
+  bob:
+    Email: bob@bobby.com
+    Groups: =>Group.bobgroup
+  andrew:
+    Email: andrew@andrew.com
+    Groups: =>Group.andrewgroup
+  cindy:
+    Email: cindy@cindy.com
+    Groups: =>Group.cindygroup
+  alice:
+    Email: alice@alice.com
+    Groups: =>Group.alicegroup
 Page:
-   master:
-      Title: My Page
-      MenuTitle: My Page Nav
-   master2:
-      Title: My Other Page
-      MenuTitle: My Other Page Nav
-   holder:
-      Title: Sub-pages
+  master:
+    Title: My Page
+    MenuTitle: My Page Nav
+  master2:
+    Title: My Other Page
+    MenuTitle: My Other Page Nav
+  holder:
+    Title: Sub-pages
+  master3:
+    Title: CanEditBob
+    CanEditType: OnlyTheseUsers
+    CanViewType: Inherit
+    EditorGroups: =>Group.bobgroup
 VirtualPage:
-   vp1:
-      CopyContentFrom: =>Page.master
-      Parent: =>Page.holder
-   vp2:
-      CopyContentFrom: =>Page.master
-      Parent: =>Page.holder
-
+  vp1:
+    CopyContentFrom: =>Page.master
+    Parent: =>Page.holder
+  vp2:
+    CopyContentFrom: =>Page.master
+    Parent: =>Page.holder
+  vp3:
+    CopyContentFrom: =>Page.master3
+    Parent: =>Page.holder
+    CanEditType: OnlyTheseUsers
+    CanViewType: OnlyTheseUsers
+    EditorGroups: =>Group.andrewgroup
+    ViewerGroups: =>Group.cindygroup


### PR DESCRIPTION
Fixes #1318

Apologies for the late fix, but I couldn't find a way to resolve this that doesn't introduce new api / behaviour, so it has to be targetted for 3.4.