### PR TITLE
FIX Borders on CMS Actions

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2213,7 +2213,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$existsOnLive = $this->getExistsOnLive();
 
 		// Major actions appear as buttons immediately visible as page actions.
-		$majorActions = CompositeField::create()->setName('MajorActions')->setTag('fieldset')->addExtraClass('ss-ui-buttonset');
+		$majorActions = CompositeField::create()->setName('MajorActions')->setTag('fieldset')->addExtraClass('ss-ui-buttonset noborder');
 
 		// Minor options are hidden behind a drop-up and appear as links (although they are still FormActions).
 		$rootTabSet = new TabSet('ActionMenus');
@@ -2222,7 +2222,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			_t('SiteTree.MoreOptions', 'More options', 'Expands a view for more buttons')
 		);
 		$rootTabSet->push($moreOptions);
-		$rootTabSet->addExtraClass('ss-ui-action-tabset action-menus');
+		$rootTabSet->addExtraClass('ss-ui-action-tabset action-menus noborder');
 
 		// Render page information into the "more-options" drop-up, on the top.
 		$live = Versioned::get_one_by_stage('SiteTree', 'Live', array(


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/4895 (2/2)

Removes border from cms actions

Please note alignment is fixed with https://github.com/silverstripe/silverstripe-framework/pull/4984

before:
![](https://dl.dropboxusercontent.com/u/3429338/Clippings/2016-01/2016-01-26_14-19-05-MW8lTcqLjO.png)

after:
![](https://dl.dropboxusercontent.com/u/3429338/Clippings/2016-01/2016-01-26_14-45-11-3UjyNMTfGR.png)