### PR TITLE
BUG Check csrf timeout error and preserve unsaved form data

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -688,6 +688,16 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				$form->setFields($readonlyFields);
 			}
 
+			// retain stored session information if a CSRF error timeout was triggered
+			$data = Session::get("FormInfo.{$form->FormName()}.data");
+			$message = $form->Message();
+			// check against error, and whether data exists in the session
+			// and override the form data if so.
+			if($message === _t("Form.CSRF_EXPIRED_MESSAGE", "Your session has expired. Please re-submit the form.")
+				&& $data) {
+				$form->loadDataFrom($data);
+			}
+			
 			$this->extend('updateEditForm', $form);
 			return $form;
 		} else if($id) {


### PR DESCRIPTION
Added a check to getEditForm() to ensure data doesn't get lost if a CSRF error is triggered on Form submission.

When editing any page in the CMS, the SecurityID token becomes invalid after some time. On those ocassions, the unaware user tries to save the data and gets a "Your session has expired. Please re-submit the form." error and the user loses all the modified data.

The [framework saves that data on session](https://github.com/silverstripe/silverstripe-framework/commit/058219c0ee62a7f6313ae5be109956a0e498bed3) when that happens, but CMS doesn't load it back.

Added a fix to check if there's form data present in session, and if only that CSRF error was triggered, and then load the session data into the form so the user can resubmit it.
