### PR TITLE
Fix typo

### DIFF
--- a/code/controllers/CMSPageHistoryController.php
+++ b/code/controllers/CMSPageHistoryController.php
@@ -369,7 +369,7 @@ class CMSPageHistoryController extends CMSMain {
 			$fromVersion = $versionID;
 		}
 
-		if(!$toVersion || !$toVersion) return false;
+		if(!$toVersion || !$fromVersion) return false;
 		
 		$id = $this->currentPageID();
 		$page = DataObject::get_by_id("SiteTree", $id);


### PR DESCRIPTION
Varaible $toVersion is checked twice, but $fromVersion is not checked.

This possible defect found by AppChecker