### PR TITLE
BUG Prevent folders deleted on the filesystem from breaking asset interface

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -156,7 +156,7 @@ JS
 		$form = parent::getEditForm($id, $fields);
 		$folder = ($id && is_numeric($id)) ? DataObject::get_by_id('Folder', $id, false) : $this->currentPage();
 		$fields = $form->Fields();
-		$title = ($folder && $folder->exists()) ? $folder->Title : _t('AssetAdmin.FILES', 'Files');
+		$title = ($folder && $folder->isInDB()) ? $folder->Title : _t('AssetAdmin.FILES', 'Files');
 		$fields->push(new HiddenField('ID', false, $folder ? $folder->ID : null));
 
 		// File listing
@@ -244,7 +244,7 @@ JS
 			);
 			$tabList->addExtraClass("content-listview cms-tabset-icon list");
 			$tabTree->addExtraClass("content-treeview cms-tabset-icon tree");
-			if($fields->Count() && $folder->exists()) {
+			if($fields->Count() && $folder && $folder->isInDB()) {
 				$tabs->push($tabDetails = new Tab('DetailsView', _t('AssetAdmin.DetailsView', 'Details')));
 				$tabDetails->addExtraClass("content-galleryview cms-tabset-icon edit");
 				foreach($fields as $field) {
@@ -520,7 +520,7 @@ JS
 		$id = $this->currentPageID();
 		if($id && is_numeric($id) && $id > 0) {
 			$folder = DataObject::get_by_id('Folder', $id);
-			if($folder && $folder->exists()) {
+			if($folder && $folder->isInDB()) {
 				return $folder;
 			}
 		}


### PR DESCRIPTION
If a folder exists in the DB but not the filesystem, then sometimes editing that in the admin interface will try to show fields from both child-listview and edit-fields in the same interface, although it will not work properly.

Before:

![image](https://cloud.githubusercontent.com/assets/936064/12903613/dcc7cb7e-cf2d-11e5-843e-ce08b0354a1c.png)


After:

![image](https://cloud.githubusercontent.com/assets/936064/12903601/c575fc98-cf2d-11e5-84b9-e4badfaa08ca.png)
