### PR TITLE
API Remove references to class aliases; Use correct classname

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -812,8 +812,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		$columns->setDisplayFields($fields);
 		$columns->setFieldCasting(array(
-			'Created' => 'Datetime->Ago',
-			'LastEdited' => 'Datetime->FormatFromSettings',
+			'Created' => 'SS_Datetime->Ago',
+			'LastEdited' => 'SS_Datetime->FormatFromSettings',
 			'getTreeTitle' => 'HTMLText'
 		));
 


### PR DESCRIPTION
Can be merged at any time, but no later than when https://github.com/silverstripe/silverstripe-framework/pull/4992 is merged.

This fix essentially removes reliance on the Object::useCustomClass definitions which will be removed.