### PR TITLE
Correctly require CMS lang files

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -76,7 +76,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		Requirements::css(CMS_DIR . '/css/screen.css');
 		Requirements::customCSS($this->generatePageIconsCss());
-		Requirements::add_i18n_javascript(CMS_DIR . '/javascript/lang', true, true);
+		Requirements::add_i18n_javascript(CMS_DIR . '/javascript/lang', false, true);
 		Requirements::javascript(CMS_DIR . '/javascript/dist/bundle-lib.js', [
 			'provides' => [
 				CMS_DIR . '/javascript/dist/CMSMain.AddForm.js',


### PR DESCRIPTION
Was broken at https://github.com/silverstripe/silverstripe-cms/pull/1375/files#diff-be3d9d3389b70ee37e226dd91acf851dL94 (oops :stuck_out_tongue:)