### PR TITLE
Disable xdebug on Travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
 before_script:
  - composer self-update || true
  - phpenv rehash
+ - phpenv config-rm xdebug.ini
  - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
  - "if [ \"$BEHAT_TEST\" = \"\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss; fi"
  - "if [ \"$BEHAT_TEST\" = \"1\" ]; then php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss --require silverstripe/behat-extension; fi"


### PR DESCRIPTION
We're not using it for code coverage,
and it's slowing down both composer and phpunit builds.

Recommended by Travis:
https://docs.travis-ci.com/user/speeding-up-the-build/#PHP-optimisations

Merge together with https://github.com/silverstripe/silverstripe-framework/pull/5146