### PR TITLE
API Update uses of versioned

### DIFF
--- a/code/batchactions/CMSBatchActions.php
+++ b/code/batchactions/CMSBatchActions.php
@@ -119,7 +119,6 @@ class CMSBatchAction_Restore extends CMSBatchAction {
  *
  * @package cms
  * @subpackage batchaction
- * @deprecated since version 4.0
  */
 class CMSBatchAction_Delete extends CMSBatchAction {
 	public function getActionTitle() {
@@ -127,7 +126,6 @@ class CMSBatchAction_Delete extends CMSBatchAction {
 	}
 
 	public function run(SS_List $pages) {
-		Deprecation::notice('4.0', 'Delete is deprecated. Use Archive instead');
 		$status = array(
 			'modified'=>array(),
 			'deleted'=>array(),
@@ -161,55 +159,5 @@ class CMSBatchAction_Delete extends CMSBatchAction {
 
 	public function applicablePages($ids) {
 		return $this->applicablePagesHelper($ids, 'canDelete', true, false);
-	}
-}
-
-/**
- * Unpublish (delete from live site) items batch action.
- *
- * @package cms
- * @subpackage batchaction
- * @deprecated since version 4.0
- */
-class CMSBatchAction_DeleteFromLive extends CMSBatchAction {
-	public function getActionTitle() {
-		return _t('CMSBatchActions.DELETE_PAGES', 'Delete from published site');
-	}
-
-	public function run(SS_List $pages) {
-		Deprecation::notice('4.0', 'Delete From Live is deprecated. Use Unpublish instead');
-		$status = array(
-			'modified'=>array(),
-			'deleted'=>array()
-		);
-
-		/** @var SiteTree $page */
-		foreach($pages as $page) {
-			$id = $page->ID;
-
-			// Perform the action
-			if($page->canUnpublish()) {
-				$page->doUnpublish();
-			}
-
-			// check to see if the record exists on the stage site, if it doesn't remove the tree node
-			$stageRecord = Versioned::get_one_by_stage( 'SiteTree', 'Stage', array(
-				'"SiteTree"."ID"' => $id
-			));
-			if($stageRecord) {
-				$status['modified'][$stageRecord->ID] = array(
-					'TreeTitle' => $stageRecord->TreeTitle,
-				);
-			} else {
-				$status['deleted'][$id] = array();
-			}
-
-		}
-
-		return $this->response(_t('CMSBatchActions.DELETED_PAGES', 'Deleted %d pages from published site, %d failures'), $status);
-	}
-
-	public function applicablePages($ids) {
-		return $this->applicablePagesHelper($ids, 'canDelete', false, true);
 	}
 }

--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -63,7 +63,7 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider{
 	public function init() {
 		parent::init();
 
-		Versioned::reading_stage("Stage");
+		Versioned::set_stage(Versioned::DRAFT);
 
 		Requirements::javascript(CMS_DIR . "/javascript/dist/AssetAdmin.js");
 		Requirements::add_i18n_javascript(CMS_DIR . '/javascript/lang', false, true);

--- a/code/controllers/SilverStripeNavigator.php
+++ b/code/controllers/SilverStripeNavigator.php
@@ -297,7 +297,7 @@ class SilverStripeNavigatorItem_StageLink extends SilverStripeNavigatorItem {
 
 	public function isActive() {
 		return (
-			Versioned::current_stage() == 'Stage'
+			Versioned::get_stage() == 'Stage'
 			&& !(ClassInfo::exists('SiteTreeFutureState') && SiteTreeFutureState::get_future_datetime())
 			&& !$this->isArchived()
 		);
@@ -350,7 +350,7 @@ class SilverStripeNavigatorItem_LiveLink extends SilverStripeNavigatorItem {
 
 	public function isActive() {
 		return (
-			(!Versioned::current_stage() || Versioned::current_stage() == 'Live')
+			(!Versioned::get_stage() || Versioned::get_stage() == 'Live')
 			&& !$this->isArchived()
 		);
 	}

--- a/code/model/SiteTreeFileExtension.php
+++ b/code/model/SiteTreeFileExtension.php
@@ -109,7 +109,7 @@ class SiteTreeFileExtension extends DataExtension {
 	 */
 	public function onAfterDelete() {
 		// Skip live stage
-		if(\Versioned::current_stage() === \Versioned::get_live_stage()) {
+		if(\Versioned::get_stage() === Versioned::LIVE) {
 			return;
 		}
 
@@ -143,7 +143,7 @@ class SiteTreeFileExtension extends DataExtension {
 	 */
 	public function updateLinks() {
 		// Skip live stage
-		if(\Versioned::current_stage() === \Versioned::get_live_stage()) {
+		if(\Versioned::get_stage() === \Versioned::LIVE) {
 			return;
 		}
 

--- a/code/model/SiteTreeLinkTracking.php
+++ b/code/model/SiteTreeLinkTracking.php
@@ -28,11 +28,38 @@
  */
 class SiteTreeLinkTracking extends DataExtension {
 
-	public $parser;
+	/**
+	 * @var SiteTreeLinkTracking_Parser
+	 */
+	protected $parser;
 
+	/**
+	 * Inject parser for each page
+	 *
+	 * @var array
+	 * @config
+	 */
 	private static $dependencies = array(
-		'parser' => '%$SiteTreeLinkTracking_Parser'
+		'Parser' => '%$SiteTreeLinkTracking_Parser'
 	);
+
+	/**
+	 * Parser for link tracking
+	 *
+	 * @return SiteTreeLinkTracking_Parser
+	 */
+	public function getParser() {
+		return $this->parser;
+	}
+
+	/**
+	 * @param SiteTreeLinkTracking_Parser $parser
+	 * @return $this
+	 */
+	public function setParser($parser) {
+		$this->parser = $parser;
+		return $this;
+	}
 
 	private static $db = array(
 		"HasBrokenFile" => "Boolean",
@@ -178,7 +205,7 @@ class SiteTreeLinkTracking extends DataExtension {
 	 */
 	public function augmentSyncLinkTracking() {
 		// Skip live tracking
-		if(\Versioned::current_stage() == \Versioned::get_live_stage()) {
+		if(\Versioned::get_stage() == \Versioned::LIVE) {
 			return;
 		}
 

--- a/tests/controller/AssetAdminTest.php
+++ b/tests/controller/AssetAdminTest.php
@@ -10,22 +10,22 @@ class AssetAdminTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 
+		AssetStoreTest_SpyStore::activate('AssetAdminTest');
+
 		if(!file_exists(ASSETS_PATH)) mkdir(ASSETS_PATH);
 
 		// Create a test folders for each of the fixture references
-		$folderIDs = $this->allFixtureIDs('Folder');
-		foreach($folderIDs as $folderID) {
-			$folder = DataObject::get_by_id('Folder', $folderID);
-			if(!file_exists(BASE_PATH."/$folder->Filename")) mkdir(BASE_PATH."/$folder->Filename");
+		foreach(File::get()->filter('ClassName', 'Folder') as $folder) {
+			/** @var Folder $folder */
+			$folder->doPublish();
 		}
 
 		// Create a test files for each of the fixture references
-		$fileIDs = $this->allFixtureIDs('File');
-		foreach($fileIDs as $fileID) {
-			$file = DataObject::get_by_id('File', $fileID);
-			$fh = fopen(BASE_PATH."/$file->Filename", "w");
-			fwrite($fh, str_repeat('x',1000000));
-			fclose($fh);
+		$content = str_repeat('x',1000000);
+		foreach(File::get()->exclude('ClassName', 'Folder') as $file) {
+			/** @var File $file */
+			$file->setFromString($content, $file->generateFilename());
+			$file->doPublish();
 		}
 	}
 

--- a/tests/controller/AssetAdminTest.yml
+++ b/tests/controller/AssetAdminTest.yml
@@ -4,9 +4,9 @@ Folder:
 File:
   file1:
     Title: File1
-    Filename: assets/AssetAdminTest/file1.txt
+    Name: file1.txt
     ParentID: =>Folder.folder1
   file2:
     Title: File2
-    Filename: assets/AssetAdminTest/file2.txt
+    Name: file2.txt
     ParentID: =>Folder.folder1

--- a/tests/controller/CMSBatchActionsTest.php
+++ b/tests/controller/CMSBatchActionsTest.php
@@ -11,6 +11,8 @@ class CMSBatchActionsTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 
+		$this->logInWithPermission('ADMIN');
+
 		// published page
 		$published = $this->objFromFixture('SiteTree', 'published');
 		$published->doPublish();

--- a/tests/model/ErrorPageFileExtensionTest.php
+++ b/tests/model/ErrorPageFileExtensionTest.php
@@ -9,7 +9,7 @@ class ErrorPageFileExtensionTest extends SapphireTest {
     public function setUp() {
         parent::setUp();
         $this->versionedMode = Versioned::get_reading_mode();
-        Versioned::reading_stage('Stage');
+        Versioned::set_stage(Versioned::DRAFT);
         AssetStoreTest_SpyStore::activate('ErrorPageFileExtensionTest');
         $file = new File();
         $file->setFromString('dummy', 'dummy.txt');

--- a/tests/model/FileLinkTrackingTest.php
+++ b/tests/model/FileLinkTrackingTest.php
@@ -9,7 +9,7 @@ class FileLinkTrackingTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 
 		AssetStoreTest_SpyStore::activate('FileLinkTrackingTest');
 		$this->logInWithPermission('ADMIN');
@@ -112,18 +112,20 @@ class FileLinkTrackingTest extends SapphireTest {
 		$file->write();
 
 		// Verify that the draft virtual pages have the correct content
+		$svp = Versioned::get_by_stage('VirtualPage', Versioned::DRAFT)->byID($svp->ID);
 		$this->assertContains(
 			'<img src="/assets/55b443b601/renamed-test-file.jpg"',
-			DB::prepared_query("SELECT \"Content\" FROM \"SiteTree\" WHERE \"ID\" = ?", array($svp->ID))->value()
+			$svp->Content
 		);
 
 		// Publishing both file and page will update the live record
 		$file->doPublish();
 		$page->doPublish();
 
+		$svp = Versioned::get_by_stage('VirtualPage', Versioned::LIVE)->byID($svp->ID);
 		$this->assertContains(
 			'<img src="/assets/FileLinkTrackingTest/55b443b601/renamed-test-file.jpg"',
-			DB::prepared_query("SELECT \"Content\" FROM \"SiteTree_Live\" WHERE \"ID\" = ?", array($svp->ID))->value()
+			$svp->Content
 		);
 	}
 

--- a/tests/model/SiteTreeBacklinksTest.php
+++ b/tests/model/SiteTreeBacklinksTest.php
@@ -108,7 +108,7 @@ class SiteTreeBacklinksTest extends SapphireTest {
 		$page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
 
 		// assert hyperlink to page 1's new url exists
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
 		$this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s new url exists on page 3');
 	}
@@ -136,7 +136,7 @@ class SiteTreeBacklinksTest extends SapphireTest {
 
 		// assert hyperlink to page 1's current publish url exists
 		$page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
 		$this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
 
@@ -179,7 +179,7 @@ class SiteTreeBacklinksTest extends SapphireTest {
 
 		// assert page 3 on published site contains old page 1 url
 		$page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
 		$this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
 
@@ -223,7 +223,7 @@ class SiteTreeBacklinksTest extends SapphireTest {
 
 		// confirm that published link hasn't
 		$page2Live = Versioned::get_one_by_stage("Page", "Live", "\"SiteTree\".\"ID\" = $page2->ID");
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$this->assertEquals('<p><a href="'.Director::baseURL().'page1/">Testing page 1 link</a></p>', $page2Live->obj('ExtraContent')->forTemplate());
 
 		// publish page1 and confirm that the link on the published page2 has now been updated

--- a/tests/model/SiteTreeBrokenLinksTest.php
+++ b/tests/model/SiteTreeBrokenLinksTest.php
@@ -11,7 +11,7 @@ class SiteTreeBrokenLinksTest extends SapphireTest {
 	public function setUp() {
 		parent::setUp();
 
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 		AssetStoreTest_SpyStore::activate('SiteTreeBrokenLinksTest');
 		$this->logInWithPermission('ADMIN');
 	}

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -141,7 +141,7 @@ class SiteTreeTest extends SapphireTest {
 		$s->write();
 
 		$oldMode = Versioned::get_reading_mode();
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 
 		$checkSiteTree = DataObject::get_one("SiteTree", array(
 			'"SiteTree"."URLSegment"' => 'get-one-test-page'
@@ -264,12 +264,12 @@ class SiteTreeTest extends SapphireTest {
 
 		// Check that if we restore while on the live site that the content still gets pushed to
 		// stage
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$deletedPage = Versioned::get_latest_version('SiteTree', $page2ID);
 		$deletedPage->doRestoreToStage();
 		$this->assertFalse((bool)Versioned::get_one_by_stage("Page", "Live", "\"SiteTree\".\"ID\" = " . $page2ID));
 
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 		$requeriedPage = DataObject::get_by_id("Page", $page2ID);
 		$this->assertEquals('Products', $requeriedPage->Title);
 		$this->assertEquals('Page', $requeriedPage->class);
@@ -383,12 +383,12 @@ class SiteTreeTest extends SapphireTest {
 
 		$parentPage->doUnpublish();
 
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 
 		$this->assertFalse(DataObject::get_by_id('Page', $pageAbout->ID));
 		$this->assertTrue(DataObject::get_by_id('Page', $pageStaff->ID) instanceof Page);
 		$this->assertTrue(DataObject::get_by_id('Page', $pageStaffDuplicate->ID) instanceof Page);
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 		Config::inst()->update('SiteTree', 'enforce_strict_hierarchy', true);
 	}
 
@@ -406,11 +406,11 @@ class SiteTreeTest extends SapphireTest {
 		$parentPage = $this->objFromFixture('Page', 'about');
 		$parentPage->doUnpublish();
 
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$this->assertFalse(DataObject::get_by_id('Page', $pageAbout->ID));
 		$this->assertTrue(DataObject::get_by_id('Page', $pageStaff->ID) instanceof Page);
 		$this->assertTrue(DataObject::get_by_id('Page', $pageStaffDuplicate->ID) instanceof Page);
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 		Config::inst()->update('SiteTree', 'enforce_strict_hierarchy', true);
 	}
 
@@ -427,11 +427,11 @@ class SiteTreeTest extends SapphireTest {
 		$parentPage = $this->objFromFixture('Page', 'about');
 		$parentPage->doUnpublish();
 
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$this->assertFalse(DataObject::get_by_id('Page', $pageAbout->ID));
 		$this->assertFalse(DataObject::get_by_id('Page', $pageStaff->ID));
 		$this->assertFalse(DataObject::get_by_id('Page', $pageStaffDuplicate->ID));
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 	}
 
 	/**
@@ -1115,7 +1115,7 @@ class SiteTreeTest extends SapphireTest {
 		$member->Groups()->add($group);
 
 		// both pages are viewable in stage
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 		$about = $this->objFromFixture('Page', 'about');
 		$staff = $this->objFromFixture('Page', 'staff');
 		$this->assertFalse($about->isOrphaned());
@@ -1127,16 +1127,16 @@ class SiteTreeTest extends SapphireTest {
 		$staff->publish('Stage', 'Live');
 		$this->assertFalse($staff->isOrphaned());
 		$this->assertTrue($staff->canView($member));
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$staff = $this->objFromFixture('Page', 'staff'); // Live copy of page
 		$this->assertTrue($staff->isOrphaned()); // because parent isn't published
 		$this->assertFalse($staff->canView($member));
 
 		// Publishing the parent page should restore visibility
-		Versioned::reading_stage('Stage');
+		Versioned::set_stage(Versioned::DRAFT);
 		$about = $this->objFromFixture('Page', 'about');
 		$about->publish('Stage', 'Live');
-		Versioned::reading_stage('Live');
+		Versioned::set_stage(Versioned::LIVE);
 		$staff = $this->objFromFixture('Page', 'staff');
 		$this->assertFalse($staff->isOrphaned());
 		$this->assertTrue($staff->canView($member));


### PR DESCRIPTION
To be merged after https://github.com/silverstripe/silverstripe-framework/pull/5157

The CMS component of this change actually includes a lot of refactoring; Virtual pages were mostly refactored due to the fundamental changes in the way that related objects must be published under owned versioning.

I have no idea why so many trimmed whitespace ended up in the code... we flushed these ages ago, but I guess they made their way back into the code after merging up from 3 -> master?

