### PR TITLE
FIX 'Settings' fields being overwritten by 'Content' fields

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -592,7 +592,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	 */
 	public function getEditForm($id = null, $fields = null) {
 		if(!$id) $id = $this->currentPageID();
-		$form = parent::getEditForm($id);
+		$form = parent::getEditForm($id, $fields);
 
 		// TODO Duplicate record fetching (see parent implementation)
 		$record = $this->getRecord($id);


### PR DESCRIPTION
CMSMain::getEditForm wasn't passing the $fields parameter to the parent. The the "Settings" fields we being replaced with the "Content" settings when requesting /admin/pages/settings/show/123345