### PR TITLE
Revert "FIX: Incorrect title attribute on CMS tabs"

### DIFF
--- a/templates/Includes/CMSMain_Content.ss
+++ b/templates/Includes/CMSMain_Content.ss
@@ -8,18 +8,18 @@
 		<div class="cms-content-header-tabs">
 			<ul class="cms-tabset-nav-primary">
 				<li class="content-treeview<% if class == 'CMSPageEditController' %> ui-tabs-active<% end_if %>">
-					<a href="$LinkPageEdit" class="cms-panel-link" title="<%t CMSMain.TabContent 'Content' %>" data-href="$LinkPageEdit">
-						<%t CMSMain.TabContent 'Content' %>
+					<a href="$LinkPageEdit" class="cms-panel-link" title="Form_EditForm" data-href="$LinkPageEdit">
+						<% _t('CMSMain.TabContent', 'Content') %>
 					</a>
 				</li>
 				<li class="content-listview<% if class == 'CMSPageSettingsController' %> ui-tabs-active<% end_if %>">
-					<a href="$LinkPageSettings" class="cms-panel-link" title="<%t CMSMain.TabSettings 'Settings' %>" data-href="$LinkPageSettings">
-						<%t CMSMain.TabSettings 'Settings' %>
+					<a href="$LinkPageSettings" class="cms-panel-link" title="Form_EditForm" data-href="$LinkPageSettings">
+						<% _t('CMSMain.TabSettings', 'Settings') %>
 					</a>
 				</li>
 				<li class="content-listview<% if class == 'CMSPageHistoryController' %> ui-tabs-active<% end_if %>">
-					<a href="$LinkPageHistory" class="cms-panel-link" title="<%t CMSMain.TabHistory 'History' %>" data-href="$LinkPageHistory">
-						<%t CMSMain.TabHistory 'History' %>
+					<a href="$LinkPageHistory" class="cms-panel-link" title="Form_EditForm" data-href="$LinkPageHistory">
+						<% _t('CMSMain.TabHistory', 'History') %>
 					</a>
 				</li>
 			</ul>


### PR DESCRIPTION
Reverts silverstripe/silverstripe-cms#1416

Fixes https://github.com/silverstripe/silverstripe-cms/issues/1421