### PR TITLE
Remove redundant CSS

### DIFF
--- a/css/screen.css
+++ b/css/screen.css
@@ -1,7 +1,7 @@
 /** This file is the central collection of included modules, links to custom SCSS files, and any global SCSS variable definitions.  DO NOT ADD stylesheet rules to this file directly!  Note: By prefixing files with an underscore, they won't create individual CSS files. */
 /** ----------------------------- Core Compass Libraries ------------------------------ */
 /** ----------------------------- CMS Components ------------------------------ */
-/** Style  custom to the CMSMain admin interface. CMSMain extends the built in  SilverStripe admin section styles. As much as possible we want to use those  built in styles. If anything in this file can be implemented in a generic  way then it should be include in the admin scss files.  @package cms */
+/** Style  custom to the CMSMain admin interface. CMSMain extends the built in SilverStripe admin section styles. As much as possible we want to use those built in styles. If anything in this file can be implemented in a generic way then it should be include in the admin scss files.  @package cms */
 /** ------------------------------------------------------------------ Page History Section. ----------------------------------------------------------------- */
 #cms-page-history-versions tr.loading { color: #999; }
 #cms-page-history-versions tr.loading td:hover { cursor: none; }
@@ -39,5 +39,3 @@
 .cms .AssetAdmin .cms-content-toolbar .cms-page-add-button span.ui-button-text { color: #393939; text-shadow: white 0 1px 1px; }
 .cms .AssetAdmin #Root_TreeView .cms-tree ul .class-Folder a span.text span.jstree-foldericon { background: url(../images/blue-folder-horizontal.png) no-repeat; width: 16px; height: 16px; float: left; display: block; margin-right: 4px; }
 .cms .AssetAdmin table.ss-gridfield-table td.bottom-all { padding: 0.7em; }
-.cms .AssetAdmin table.ss-gridfield-table tr[data-class=Folder] td.col-StripThumbnail { background: transparent url(../images/treeicons/blue-folder-horizontal.png) no-repeat center; }
-.cms .AssetAdmin table.ss-gridfield-table tr[data-class=File] td.col-StripThumbnail { background: transparent url(../images/treeicons/blue-document.png) no-repeat center; }

--- a/scss/_AssetAdmin.scss
+++ b/scss/_AssetAdmin.scss
@@ -30,7 +30,7 @@
 				text-shadow: white 0 1px 1px;
 			}
 		}
-	}	
+	}
 
 	#Root_TreeView {
 		.cms-tree ul .class-Folder a span.text span.jstree-foldericon {
@@ -49,16 +49,6 @@
 				padding:0.7em;
 			}
 		}
-		tr[data-class=Folder] {
-			td.col-StripThumbnail {
-				background: transparent url(../images/treeicons/blue-folder-horizontal.png) no-repeat center;
-			}
-		}
-		tr[data-class=File] {
-			td.col-StripThumbnail {
-				background: transparent url(../images/treeicons/blue-document.png) no-repeat center;
-			}
-		}
 	}
 }
-	
+


### PR DESCRIPTION
StripThumbnail now provides icon for all file types. To be merged after https://github.com/silverstripe/silverstripe-framework/pull/5186, if accepted