### PR TITLE
Ensure all form fields have a form set

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -647,6 +647,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				$form->setFields($readonlyFields);
 			}
 
+			$form->Fields()->setForm($form);
+
 			$this->extend('updateEditForm', $form);
 			return $form;
 		} else if($id) {


### PR DESCRIPTION
This should really be handled by `FieldList->push()`, but that's too much of a global change for our purpose here (which was generating structured form schemas for React-powered CMS UIs)

/cc @flashbackzoo