### PR TITLE
FIX for #1447 to ensure proper type-safe checking of file_put_contents() in ErrorPage->writeStaticPage()

### DIFF
--- a/code/model/ErrorPage.php
+++ b/code/model/ErrorPage.php
@@ -250,7 +250,7 @@ class ErrorPage extends Page {
 		// if the page is published in a language other than default language,
 		// write a specific language version of the HTML page
 		$filePath = self::get_filepath_for_errorcode($this->ErrorCode, $this->Locale);
-		if (!file_put_contents($filePath, $errorContent)) {
+		if (file_put_contents($filePath, $errorContent) === false) {
 			$fileErrorText = _t(
 				'ErrorPage.ERRORFILEPROBLEM',
 				'Error opening file "{filename}" for writing. Please check file permissions.',


### PR DESCRIPTION
Addresses #1447 by simply performing a type-safe check instead of using loose type handling in `if (...)`. Ensuring error message is relevant to the error that actually occurs.