### PR TITLE
BUG Correct framework/module dependencies for cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
 	"require": {
 		"php": ">=5.3.3",
 		"composer/installers": "*",
-		"silverstripe/framework": "~3.3",
-		"silverstripe/reports": "~3.3",
-		"silverstripe/siteconfig": "~3.3"
+		"silverstripe/framework": "~3.4",
+		"silverstripe/reports": "~3.4",
+		"silverstripe/siteconfig": "~3.4"
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
Fixes https://github.com/silverstripe-labs/silverstripe-fulltextsearch/pull/117

Discovered when testing an install of 3.3 was bringing in 3 branch (alias 3.4) of cms. That cms branch relied on features not present in the 3.3 branch of framework, and busted everything.