### PR TITLE
API: reports no longer mandatory.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
 		"php": ">=5.5.0",
 		"composer/installers": "*",
 		"silverstripe/framework": "^4.0",
-		"silverstripe/reports": "*",
-		"silverstripe/siteconfig": "^4.0"
+    "silverstripe/siteconfig": "^4.0"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~4.8"


### PR DESCRIPTION
The reports and siteconfig modules should be included by our default
installer they aren't a requirement of the CMS. They were included as
requirements in 3.x to retain backwards-compatability. In master, they
can be removed.