### PR TITLE
Fix font-icon regression on tree view

### DIFF
--- a/templates/Includes/CMSMain_Content.ss
+++ b/templates/Includes/CMSMain_Content.ss
@@ -36,7 +36,7 @@
 			<div class="view-controls">
 				<button id="filters-button" class="icon-button font-icon-search no-text" title="<% _t('CMSPagesController_Tools_ss.FILTER', 'Filter') %>"></button>
 				<div class="icon-button-group">
-					<a href="$LinkPages#cms-content-treeview" class="icon-button font-icon-icon-tree active" title="<% _t('CMSPagesController.TreeView', 'Tree View') %>"></a><a href="$LinkPages#cms-content-listview" class="icon-button font-icon-list" title="<% _t('CMSPagesController.ListView', 'List View') %>"></a>
+					<a href="$LinkPages#cms-content-treeview" class="icon-button font-icon-tree active" title="<% _t('CMSPagesController.TreeView', 'Tree View') %>"></a><a href="$LinkPages#cms-content-listview" class="icon-button font-icon-list" title="<% _t('CMSPagesController.ListView', 'List View') %>"></a>
 				</div>
 			</div>
 		</div>

--- a/templates/Includes/CMSPagesController_Content.ss
+++ b/templates/Includes/CMSPagesController_Content.ss
@@ -10,7 +10,7 @@
 			<div class="icon-button-group">
 				<ul class="cms-tabset-nav-primary ss-tabset">
 					<li class="content-treeview<% if ViewState == tree %> ui-tabs-active ss-tabs-force-active<% end_if %> cms-tabset-icon tree">
-						<a href="#cms-content-treeview" class="cms-panel-link icon-button font-icon-icon-tree" data-href="$LinkTreeView" title="<% _t('CMSPagesController.TreeView', 'Tree View') %>"></a>
+						<a href="#cms-content-treeview" class="cms-panel-link icon-button font-icon-tree" data-href="$LinkTreeView" title="<% _t('CMSPagesController.TreeView', 'Tree View') %>"></a>
 					</li>
 					<li class="content-listview<% if ViewState == list %> ui-tabs-active ss-tabs-force-active<% end_if %> cms-tabset-icon list">
 						<a href="#cms-content-listview" class="cms-panel-link icon-button font-icon-list" data-href="$LinkListView" title="<% _t('CMSPagesController.ListView', 'List View') %>"></a>


### PR DESCRIPTION
Before:
![icons-cms-before](https://cloud.githubusercontent.com/assets/878176/14726875/c67dff16-0879-11e6-9278-9155f6386099.png)

After:
![fix-icons-cms](https://cloud.githubusercontent.com/assets/878176/14726874/c33a071e-0879-11e6-8d37-690899b166b8.png)

Caused by https://github.com/silverstripe/silverstripe-framework/commit/35e062d9f32df475eb41c78bd709059b417b8b01 updating a CSS class name.