### PR TITLE
Make page steps use the same styles, consistent markup

### DIFF
--- a/code/controllers/CMSPageAddController.php
+++ b/code/controllers/CMSPageAddController.php
@@ -32,7 +32,7 @@ class CMSPageAddController extends CMSPageEditController {
 			$pageTypes = array_merge(array('Page' => $pageTitle), $pageTypes);
 		}
 
-		$numericLabelTmpl = '<div class="field"><label class="left"><span class="step-label"><span class="flyout">%d</span><span class="arrow"></span><span class="title">%s</span></span></label></div>';
+		$numericLabelTmpl = '<div><label class="left"><span class="step-label"><span class="flyout">%d</span><span class="arrow"></span><span class="title">%s</span></span></label></div>';
 
 		$topTitle = _t('CMSPageAddController.ParentMode_top', 'Top level');
 		$childTitle = _t('CMSPageAddController.ParentMode_child', 'Under another page');

--- a/code/controllers/CMSPageAddController.php
+++ b/code/controllers/CMSPageAddController.php
@@ -32,7 +32,7 @@ class CMSPageAddController extends CMSPageEditController {
 			$pageTypes = array_merge(array('Page' => $pageTitle), $pageTypes);
 		}
 
-		$numericLabelTmpl = '<span class="step-label"><span class="flyout">%d</span><span class="arrow"></span><span class="title">%s</span></span>';
+		$numericLabelTmpl = '<div class="field"><label class="left"><span class="step-label"><span class="flyout">%d</span><span class="arrow"></span><span class="title">%s</span></span></label></div>';
 
 		$topTitle = _t('CMSPageAddController.ParentMode_top', 'Top level');
 		$childTitle = _t('CMSPageAddController.ParentMode_child', 'Under another page');


### PR DESCRIPTION
This will require style changes within framework which I will link to shortly.

Before:
![pasted_image_6_05_16__1_25_pm](https://cloud.githubusercontent.com/assets/555033/15063312/379b6d7c-139d-11e6-9417-83d832416fda.png)

After:
![pasted_image_6_05_16__3_21_pm](https://cloud.githubusercontent.com/assets/555033/15063415/455e78e0-139e-11e6-9ad7-9868bfe8bd50.png)

