### PR TITLE
FIX add_i18n_javascript calls not being updated after JS move

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -8,7 +8,7 @@ source_lang = en
 type = YML
 
 [silverstripe-cms.master-js]
-file_filter = javascript/lang/src/<lang>.js
-source_file = javascript/lang/src/en.js
+file_filter = client/lang/src/<lang>.js
+source_file = client/lang/src/en.js
 source_lang = en
 type = KEYVALUEJSON

--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -66,7 +66,7 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider{
 		Versioned::set_stage(Versioned::DRAFT);
 
 		Requirements::javascript(CMS_DIR . "/client/dist/js/AssetAdmin.js");
-		Requirements::add_i18n_javascript(CMS_DIR . '/client/src/lang', false, true);
+		Requirements::add_i18n_javascript(CMS_DIR . '/client/lang', false, true);
 		Requirements::css(CMS_DIR . '/client/dist/styles/bundle.css');
 		CMSBatchActionHandler::register('delete', 'AssetAdmin_DeleteBatchAction', 'Folder');
 	}

--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -70,7 +70,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		Requirements::css(CMS_DIR . '/client/dist/styles/bundle.css');
 		Requirements::customCSS($this->generatePageIconsCss());
-		Requirements::add_i18n_javascript(CMS_DIR . '/client/src/lang', false, true);
+		Requirements::add_i18n_javascript(CMS_DIR . '/client/lang', false, true);
 		Requirements::javascript(CMS_DIR . '/client/dist/js/bundle-legacy.js', [
 			'provides' => [
 				CMS_DIR . '/client/dist/js/CMSMain.AddForm.js',

--- a/code/forms/SiteTreeURLSegmentField.php
+++ b/code/forms/SiteTreeURLSegmentField.php
@@ -38,7 +38,7 @@ class SiteTreeURLSegmentField extends TextField {
 
 	public function Field($properties = array()) {
 		Requirements::javascript(CMS_DIR . '/client/dist/js/SiteTreeURLSegmentField.js');
-		Requirements::add_i18n_javascript(CMS_DIR . '/client/src/lang', false, true);
+		Requirements::add_i18n_javascript(CMS_DIR . '/client/lang', false, true);
 		Requirements::css(FRAMEWORK_ADMIN_DIR . '/client/dist/styles/bundle.css');
 		return parent::Field($properties);
 	}


### PR DESCRIPTION
This fixes alert / confirm boxes that were popping up without text (for
example silverstripe-cms/issues/1476), although ideally we wouldn't
show empty dialog boxes on this sort of error - we'd have some default,
or a way to detect the issue.