### PR TITLE
Display the name of a deleted members in the page history

### DIFF
--- a/code/controllers/CMSPageHistoryController.php
+++ b/code/controllers/CMSPageHistoryController.php
@@ -209,6 +209,13 @@ class CMSPageHistoryController extends CMSMain {
 				foreach($versions as $k => $version) {
 					$active = false;
 
+                    if ($version->AuthorID && !$version->Author) {
+                        $version->DeletedAuthor = DataObject::get_by_id("DeletedMember", $version->AuthorID);
+                    }
+                    if ($version->PublisherID && !$version->Publisher) {
+                        $version->DeletedPublisher = DataObject::get_by_id("DeletedMember", $version->PublisherID);
+                    }
+
 					if($version->Version == $versionID || $version->Version == $otherVersionID) {
 						$active = true;
 

--- a/templates/CMSPageHistoryController_versions.ss
+++ b/templates/CMSPageHistoryController_versions.ss
@@ -15,8 +15,16 @@
 			<% with $LastEdited %>
 				<td class="last-edited first-column" title="$Ago - $Nice">$Nice</td>
 			<% end_with %>
-			<td><% if $Author %>$Author.FirstName $Author.Surname.Initial<% else %><% _t('CMSPageHistoryController_versions_ss.UNKNOWN','Unknown') %><% end_if %></td>
-			<td class="last-column"><% if $Published %><% if $Publisher %>$Publisher.FirstName $Publisher.Surname.Initial<% else %><% _t('CMSPageHistoryController_versions_ss.UNKNOWN','Unknown') %><% end_if %><% else %><% _t('CMSPageHistoryController_versions_ss.NOTPUBLISHED','Not published') %><% end_if %></td>
+            <td>
+                <% if $Author %>$Author.FirstName $Author.Surname.Initial
+                <% else_if $DeletedAuthor %>$DeletedAuthor.FirstName $DeletedAuthor.Surname.Initial
+                <% else %><% _t('CMSPageHistoryController_versions_ss.UNKNOWN','Unknown') %><% end_if %>
+            </td>
+            <td class="last-column"><% if $Published %>
+                <% if $Publisher %>$Publisher.FirstName $Publisher.Surname.Initial
+                <% else_if $DeletedPublisher %>$DeletedPublisher.FirstName $DeletedPublisher.Surname.Initial
+                <% else %><% _t('CMSPageHistoryController_versions_ss.UNKNOWN','Unknown') %><% end_if %><% else %><% _t('CMSPageHistoryController_versions_ss.NOTPUBLISHED','Not published') %><% end_if %>
+            </td>
 		</tr>
 		<% end_loop %>
 	</tbody>


### PR DESCRIPTION
Requires https://github.com/silverstripe/silverstripe-framework/pull/5482

When a page has been edited/published by a Member that has since been deleted currently we display "Unknown" as the editor or publisher making it difficult to work out what changes were previously made.

This change relies on a change in framework that creates a DeletedMember record when a Member is deleted. If the Author or Publisher ID for a version doesn't match and existing member it checks for a deleted member and displays their name. DeletedMember automatically prefixes the name with "(deleted) ".