### PR TITLE
Removed branch alias which should only apply to latest release branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,6 @@
 		"silverstripe/reports": "~3.3",
 		"silverstripe/siteconfig": "~3.3"
 	},
-	"extra": {
-		"branch-alias": {
-			"3.x-dev": "3.3.x-dev"
-		}
-	},
 	"autoload": {
 		"classmap": ["tests/behat/"]
 	},


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/commit/070ae2555b4b6beddec71cd2b9e54057a03e872d
for similar commit when going from 3.1 to 3.2.

See https://github.com/silverstripe/silverstripe-lumberjack/pull/40 for context.

Merge with https://github.com/silverstripe/silverstripe-framework/pull/5561