### PR TITLE
SiteTree configurable css classes

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -105,6 +105,27 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @var string
 	 */
 	private static $hide_ancestor = null;
+	
+	/**
+	 * @see \SiteTree::LinkingMode, \SiteTree::LinkOrSection, \SiteTree::LinkOrCurrent
+	 * @config
+	 * @var string
+	 */
+	private static $link_css_class = 'link';
+
+	/**
+	 * @see \SiteTree::LinkingMode, \SiteTree::LinkOrSection, \SiteTree::LinkOrCurrent
+	 * @config
+	 * @var string
+	 */
+	private static $current_css_class = 'current';
+
+	/**
+	 * @see \SiteTree::LinkingMode, \SiteTree::LinkOrSection, \SiteTree::LinkOrCurrent
+	 * @config
+	 * @var string
+	 */
+	private static $section_css_class = 'section';
 
 	private static $db = array(
 		"URLSegment" => "Varchar(255)",
@@ -564,7 +585,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return string
 	 */
 	public function LinkOrCurrent() {
-		return $this->isCurrent() ? 'current' : 'link';
+		return $this->isCurrent() ? self::config()->current_css_class : self::config()->link_css_class;
 	}
 
 	/**
@@ -573,7 +594,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return string
 	 */
 	public function LinkOrSection() {
-		return $this->isSection() ? 'section' : 'link';
+		return $this->isSection() ? self::config()->section_css_class : self::config()->link_css_class;
 	}
 
 	/**
@@ -584,12 +605,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	public function LinkingMode() {
 		if($this->isCurrent()) {
-			return 'current';
+			return self::config()->current_css_class;
 		} elseif($this->isSection()) {
-			return 'section';
-		} else {
-			return 'link';
+			return self::config()->section_css_class;
 		}
+		return self::config()->link_css_class;
 	}
 
 	/**


### PR DESCRIPTION
Same as https://github.com/silverstripe/silverstripe-cms/pull/1325
Red the thread.

- Yes, maybe a framework should not take care of this.
- But, silverstripe sitetree is a kind of its own and that is very good.
- So, we use css frameworks that have other active states for css classes.
- And, we don't want if/else in our template classes, nor override these methods in Page.php just for .active
- Now, we are going from 3 to 4. this might be a good moment to fix this...

Let me know if you want me to check documentation references for checks like <% if $LinkingMode = 'section' %>