### PR TITLE
API Allow extensions to influence can* methods

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -174,7 +174,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @var string
 	 */
 	private static $icon = null;
-	
+
 	/**
 	 * @config
 	 * @var string Description of the class functionality, typically shown to a user
@@ -187,7 +187,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		"Versioned('Stage', 'Live')",
 		"SiteTreeLinkTracking"
 	);
-	
+
 	private static $searchable_fields = array(
 		'Title',
 		'Content',
@@ -196,22 +196,22 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	private static $field_labels = array(
 		'URLSegment' => 'URL'
 	);
-	
+
 	/**
 	 * @config
 	 */
 	private static $nested_urls = true;
-	
+
 	/**
 	 * @config
 	*/
 	private static $create_default_pages = true;
-	
+
 	/**
 	 * This controls whether of not extendCMSFields() is called by getCMSFields.
 	 */
 	private static $runCMSFieldsExtensions = true;
-	
+
 	/**
 	 * Cache for canView/Edit/Publish/Delete permissions.
 	 * Keyed by permission type (e.g. 'edit'), with an array
@@ -235,7 +235,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	private static $meta_generator = 'SilverStripe - http://silverstripe.org';
 
 	protected $_cache_statusFlags = null;
-	
+
 	/**
 	 * Determines if the system should avoid orphaned pages
 	 * by deleting all children when the their parent is deleted (TRUE),
@@ -248,7 +248,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		Deprecation::notice('4.0', 'Use the "SiteTree.enforce_strict_hierarchy" config setting instead');
 		Config::inst()->update('SiteTree', 'enforce_strict_hierarchy', $to);
 	}
-	
+
 	/**
 	 * @deprecated 4.0 Use the "SiteTree.enforce_strict_hierarchy" config setting instead
 	 * @return boolean
@@ -268,7 +268,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		Deprecation::notice('4.0', 'Use the "SiteTree.nested_urls" config setting instead');
 		return Config::inst()->get('SiteTree', 'nested_urls');
 	}
-	
+
 	/**
 	 * @deprecated 4.0 Use the "SiteTree.nested_urls" config setting instead
 	 */
@@ -276,7 +276,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		Deprecation::notice('4.0', 'Use the "SiteTree.nested_urls" config setting instead');
 		Config::inst()->update('SiteTree', 'nested_urls', true);
 	}
-	
+
 	/**
 	 * @deprecated 4.0 Use the "SiteTree.nested_urls" config setting instead
 	 */
@@ -284,7 +284,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		Deprecation::notice('4.0', 'Use the "SiteTree.nested_urls" config setting instead');
 		Config::inst()->update('SiteTree', 'nested_urls', false);
 	}
-	
+
 	/**
 	 * Set the (re)creation of default pages on /dev/build
 	 *
@@ -306,7 +306,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		Deprecation::notice('4.0', 'Use the "SiteTree.create_default_pages" config setting instead');
 		return Config::inst()->get('SiteTree', 'create_default_pages');
 	}
-	
+
 	/**
 	 * Fetches the {@link SiteTree} object that maps to a link.
 	 *
@@ -326,9 +326,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		} else {
 			$link = RootURLController::get_homepage_link();
 		}
-		
+
 		$parts = preg_split('|/+|', $link);
-		
+
 		// Grab the initial root level page to traverse down from.
 		$URLSegment = array_shift($parts);
 		$conditions = array('"SiteTree"."URLSegment"' => rawurlencode($URLSegment));
@@ -336,7 +336,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$conditions[] = array('"SiteTree"."ParentID"' => 0);
 		}
 		$sitetree = DataObject::get_one('SiteTree', $conditions, $cache);
-		
+
 		/// Fall back on a unique URLSegment for b/c.
 		if(	!$sitetree
 			&& self::config()->nested_urls
@@ -346,21 +346,21 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		) {
 			return $page;
 		}
-		
+
 		// Attempt to grab an alternative page from extensions.
 		if(!$sitetree) {
 			$parentID = self::config()->nested_urls ? 0 : null;
-			
+
 			if($alternatives = singleton('SiteTree')->extend('alternateGetByLink', $URLSegment, $parentID)) {
 				foreach($alternatives as $alternative) if($alternative) $sitetree = $alternative;
 			}
-			
+
 			if(!$sitetree) return false;
 		}
-		
+
 		// Check if we have any more URL parts to parse.
 		if(!self::config()->nested_urls || !count($parts)) return $sitetree;
-		
+
 		// Traverse down the remaining URL segments and grab the relevant SiteTree objects.
 		foreach($parts as $segment) {
 			$next = DataObject::get_one('SiteTree', array(
@@ -369,24 +369,24 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				),
 				$cache
 			);
-			
+
 			if(!$next) {
 				$parentID = (int) $sitetree->ID;
-				
+
 				if($alternatives = singleton('SiteTree')->extend('alternateGetByLink', $segment, $parentID)) {
 					foreach($alternatives as $alternative) if($alternative) $next = $alternative;
 				}
-				
+
 				if(!$next) return false;
 			}
-			
+
 			$sitetree->destroy();
 			$sitetree = $next;
 		}
-		
+
 		return $sitetree;
 	}
-	
+
 	/**
 	 * Return a subclass map of SiteTree that shouldn't be hidden through {@link SiteTree::$hide_ancestor}
 	 *
@@ -426,7 +426,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		return $classes;
 	}
-	
+
 	/**
 	 * Replace a "[sitetree_link id=n]" shortcode with a link to the page with the corresponding ID.
 	 *
@@ -437,7 +437,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	static public function link_shortcode_handler($arguments, $content = null, $parser = null) {
 		if(!isset($arguments['id']) || !is_numeric($arguments['id'])) return;
-		
+
 		if (
 			   !($page = DataObject::get_by_id('SiteTree', $arguments['id']))         // Get the current page by ID.
 			&& !($page = Versioned::get_latest_version('SiteTree', $arguments['id'])) // Attempt link to old version.
@@ -447,7 +447,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 
 		$link = Convert::raw2att($page->Link());
-		
+
 		if($content) {
 			return sprintf('<a href="%s">%s</a>', $link, $parser->parse($content));
 		} else {
@@ -467,7 +467,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function Link($action = null) {
 		return Controller::join_links(Director::baseURL(), $this->RelativeLink($action));
 	}
-	
+
 	/**
 	 * Get the absolute URL for this page, including protocol and host.
 	 *
@@ -481,7 +481,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			return Director::absoluteURL($this->Link($action));
 		}
 	}
-	
+
 	/**
 	 * Base link used for previewing. Defaults to absolute URL, in order to account for domain changes, e.g. on multi
 	 * site setups. Does not contain hints about the stage, see {@link SilverStripeNavigator} for details.
@@ -496,7 +496,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			return $this->AbsoluteLink($action);
 		}
 	}
-	
+
 	/**
 	 * Return the link for this {@link SiteTree} object relative to the SilverStripe root.
 	 *
@@ -525,9 +525,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		} else {
 			$base = $this->URLSegment;
 		}
-		
+
 		$this->extend('updateRelativeLink', $base, $action);
-		
+
 		// Legacy support: If $action === true, retain URLSegment for homepages,
 		// but don't append any action
 		if($action === true) $action = null;
@@ -557,7 +557,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		Versioned::reading_stage($oldStage);
 		return $link;
 	}
-	
+
 	/**
 	 * Generates a link to edit this page in the CMS.
 	 *
@@ -566,8 +566,8 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function CMSEditLink() {
 		return Controller::join_links(singleton('CMSPageEditController')->Link('show'), $this->ID);
 	}
-	
-		
+
+
 	/**
 	 * Return a CSS identifier generated from this page's link.
 	 *
@@ -576,7 +576,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function ElementName() {
 		return str_replace('/', '-', trim($this->RelativeLink(true), '/'));
 	}
-	
+
 	/**
 	 * Returns true if this is the currently active page being used to handle this request.
 	 *
@@ -585,7 +585,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function isCurrent() {
 		return $this->ID ? $this->ID == Director::get_current_page()->ID : $this === Director::get_current_page();
 	}
-	
+
 	/**
 	 * Check if this page is in the currently active section (e.g. it is either current or one of its children is
 	 * currently being viewed).
@@ -597,7 +597,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			Director::get_current_page() instanceof SiteTree && in_array($this->ID, Director::get_current_page()->getAncestors()->column())
 		);
 	}
-	
+
 	/**
 	 * Check if the parent of this page has been removed (or made otherwise unavailable), and is still referenced by
 	 * this child. Any such orphaned page may still require access via the CMS, but should not be shown as accessible
@@ -608,12 +608,12 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function isOrphaned() {
 		// Always false for root pages
 		if(empty($this->ParentID)) return false;
-		
+
 		// Parent must exist and not be an orphan itself
 		$parent = $this->Parent();
 		return !$parent || !$parent->exists() || $parent->isOrphaned();
 	}
-	
+
 	/**
 	 * Return "link" or "current" depending on if this is the {@link SiteTree::isCurrent()} current page.
 	 *
@@ -622,7 +622,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function LinkOrCurrent() {
 		return $this->isCurrent() ? 'current' : 'link';
 	}
-	
+
 	/**
 	 * Return "link" or "section" depending on if this is the {@link SiteTree::isSeciton()} current section.
 	 *
@@ -631,7 +631,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function LinkOrSection() {
 		return $this->isSection() ? 'section' : 'link';
 	}
-	
+
 	/**
 	 * Return "link", "current" or "section" depending on if this page is the current page, or not on the current page
 	 * but in the current section.
@@ -647,7 +647,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			return 'link';
 		}
 	}
-	
+
 	/**
 	 * Check if this page is in the given current section.
 	 *
@@ -672,18 +672,18 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return self The duplicated object
 	 */
 	 public function duplicate($doWrite = true) {
-		
+
 		$page = parent::duplicate(false);
 		$page->Sort = 0;
 		$this->invokeWithExtensions('onBeforeDuplicate', $page);
-		
+
 		if($doWrite) {
 			$page->write();
 
 			$page = $this->duplicateManyManyRelations($this, $page);
 		}
 		$this->invokeWithExtensions('onAfterDuplicate', $page);
-		
+
 		return $page;
 	}
 
@@ -720,7 +720,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$newSiteTree->Sort = 0;
 		$newSiteTree->write();
 	}
-	
+
 	/**
 	 * Return a breadcrumb trail to this page. Excludes "hidden" pages (with ShowInMenus=0) by default.
 	 *
@@ -752,7 +752,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function getBreadcrumbItems($maxDepth = 20, $stopAtPageType = false, $showHidden = false) {
 		$page = $this;
 		$pages = array();
-		
+
 		while(
 			$page
  			&& (!$maxDepth || count($pages) < $maxDepth)
@@ -761,7 +761,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			if($showHidden || $page->ShowInMenus || ($page->ID == $this->ID)) {
 				$pages[] = $page;
 			}
-			
+
 			$page = $page->Parent;
 		}
 
@@ -784,7 +784,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$this->setField("ParentID", $item);
 		}
 	}
- 	
+
 	/**
 	 * Get the parent of this page.
 	 *
@@ -835,12 +835,12 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 
 		if($member && Permission::checkMember($member, "ADMIN")) return true;
-		
+
 		if(is_string($perm) && method_exists($this, 'can' . ucfirst($perm))) {
 			$method = 'can' . ucfirst($perm);
 			return $this->$method($member);
 		}
-		
+
 		$results = $this->extend('can', $member);
 		if($results && is_array($results)) if(!min($results)) return false;
 
@@ -873,12 +873,17 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$member = Member::currentUserID();
 		}
 
-		if($member && Permission::checkMember($member, "ADMIN")) return true;
-		
 		// Standard mechanism for accepting permission changes from extensions
 		$extended = $this->extendedCan('canAddChildren', $member);
-		if($extended !== null) return $extended;
-		
+		if($extended !== null) {
+			return $extended;
+		}
+
+		// Default permissions
+		if($member && Permission::checkMember($member, "ADMIN")) {
+			return true;
+		}
+
 		return $this->canEdit($member) && $this->stat('allowed_children') != 'none';
 	}
 
@@ -903,38 +908,48 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$member = Member::currentUserID();
 		}
 
-		// admin override
-		if($member && Permission::checkMember($member, array("ADMIN", "SITETREE_VIEW_ALL"))) return true;
-		
-		// Orphaned pages (in the current stage) are unavailable, except for admins via the CMS
-		if($this->isOrphaned()) return false;
-
 		// Standard mechanism for accepting permission changes from extensions
 		$extended = $this->extendedCan('canView', $member);
-		if($extended !== null) return $extended;
-		
+		if($extended !== null) {
+			return $extended;
+		}
+
+		// admin override
+		if($member && Permission::checkMember($member, array("ADMIN", "SITETREE_VIEW_ALL"))) {
+			return true;
+		}
+
+		// Orphaned pages (in the current stage) are unavailable, except for admins via the CMS
+		if($this->isOrphaned()) {
+			return false;
+		}
+
 		// check for empty spec
-		if(!$this->CanViewType || $this->CanViewType == 'Anyone') return true;
+		if(!$this->CanViewType || $this->CanViewType == 'Anyone') {
+			return true;
+		}
 
 		// check for inherit
 		if($this->CanViewType == 'Inherit') {
 			if($this->ParentID) return $this->Parent()->canView($member);
 			else return $this->getSiteConfig()->canViewPages($member);
 		}
-		
+
 		// check for any logged-in users
 		if($this->CanViewType == 'LoggedInUsers' && $member) {
 			return true;
 		}
-		
+
 		// check for specific groups
-		if($member && is_numeric($member)) $member = DataObject::get_by_id('Member', $member);
+		if($member && is_numeric($member)) {
+			$member = DataObject::get_by_id('Member', $member);
+		}
 		if(
 			$this->CanViewType == 'OnlyTheseUsers'
 			&& $member
 			&& $member->inGroups($this->ViewerGroups())
 		) return true;
-		
+
 		return false;
 	}
 
@@ -958,18 +973,21 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if($member instanceof Member) $memberID = $member->ID;
 		else if(is_numeric($member)) $memberID = $member;
 		else $memberID = Member::currentUserID();
-		
+
+		// Standard mechanism for accepting permission changes from extensions
+		$extended = $this->extendedCan('canDelete', $memberID);
+		if($extended !== null) {
+			return $extended;
+		}
+
+		// Default permission check
 		if($memberID && Permission::checkMember($memberID, array("ADMIN", "SITETREE_EDIT_ALL"))) {
 			return true;
 		}
-		
-		// Standard mechanism for accepting permission changes from extensions
-		$extended = $this->extendedCan('canDelete', $memberID);
-		if($extended !== null) return $extended;
-				
+
 		// Regular canEdit logic is handled by can_edit_multiple
 		$results = self::can_delete_multiple(array($this->ID), $memberID);
-		
+
 		// If this page no longer exists in stage/live results won't contain the page.
 		// Fail-over to false
 		return isset($results[$this->ID]) ? $results[$this->ID] : false;
@@ -1004,13 +1022,15 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$parent = isset($context['Parent']) ? $context['Parent'] : null;
 		if($parent && !in_array(get_class($this), $parent->allowedChildren())) return false;
 
-		// Check permission
-		if($member && Permission::checkMember($member, "ADMIN")) return true;
-
 		// Standard mechanism for accepting permission changes from extensions
 		$results = $this->extend('canCreate', $member, $parent);
 		if(is_array($results) && ($results = array_filter($results, function($v) {return $v !== null;}))) {
 			return min($results);
+		}
+
+		// Check permission
+		if($member && Permission::checkMember($member, "ADMIN")) {
+			return true;
 		}
 
 		// Fall over to inherited permissions
@@ -1047,12 +1067,17 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if($member instanceof Member) $memberID = $member->ID;
 		else if(is_numeric($member)) $memberID = $member;
 		else $memberID = Member::currentUserID();
-		
-		if($memberID && Permission::checkMember($memberID, array("ADMIN", "SITETREE_EDIT_ALL"))) return true;
-		
+
 		// Standard mechanism for accepting permission changes from extensions
 		$extended = $this->extendedCan('canEdit', $memberID);
-		if($extended !== null) return $extended;
+		if($extended !== null) {
+			return $extended;
+		}
+
+		// Default permissions
+		if($memberID && Permission::checkMember($memberID, array("ADMIN", "SITETREE_EDIT_ALL"))) {
+			return true;
+		}
 
 		if($this->ID) {
 			// Regular canEdit logic is handled by can_edit_multiple
@@ -1061,7 +1086,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			// If this page no longer exists in stage/live results won't contain the page.
 			// Fail-over to false
 			return isset($results[$this->ID]) ? $results[$this->ID] : false;
-			
+
 		// Default for unsaved pages
 		} else {
 			return $this->getSiteConfig()->canEditPages($member);
@@ -1082,18 +1107,25 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return bool True if the current user can publish this page.
 	 */
 	public function canPublish($member = null) {
-		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) $member = Member::currentUser();
-		
-		if($member && Permission::checkMember($member, "ADMIN")) return true;
+		if(!$member || !(is_a($member, 'Member')) || is_numeric($member)) {
+			$member = Member::currentUser();
+		}
 
 		// Standard mechanism for accepting permission changes from extensions
 		$extended = $this->extendedCan('canPublish', $member);
-		if($extended !== null) return $extended;
+		if($extended !== null) {
+			return $extended;
+		}
+
+		// Default permissions
+		if($member && Permission::checkMember($member, "ADMIN")) {
+			return true;
+		}
 
 		// Normal case - fail over to canEdit()
 		return $this->canEdit($member);
 	}
-	
+
 	public function canDeleteFromLive($member = null) {
 		// Standard mechanism for accepting permission changes from extensions
 		$extended = $this->extendedCan('canDeleteFromLive', $member);
@@ -1101,19 +1133,19 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		return $this->canPublish($member);
 	}
-	
+
 	/**
 	 * Stub method to get the site config, unless the current class can provide an alternate.
 	 *
 	 * @return SiteConfig
 	 */
 	public function getSiteConfig() {
-		
+
 		if($this->hasMethod('alternateSiteConfig')) {
 			$altConfig = $this->alternateSiteConfig();
 			if($altConfig) return $altConfig;
 		}
-		
+
 		return SiteConfig::current_site_config();
 	}
 
@@ -1128,7 +1160,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	static public function prepopulate_permission_cache($permission = 'CanEditType', $ids, $batchCallback = null) {
 		if(!$batchCallback) $batchCallback = "SiteTree::can_{$permission}_multiple";
-		
+
 		if(is_callable($batchCallback)) {
 			call_user_func($batchCallback, $ids, Member::currentUserID(), false);
 		} else {
@@ -1161,7 +1193,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		// Sanitise the IDs
 		$ids = array_filter($ids, 'is_numeric');
-		
+
 		// This is the name used on the permission cache
 		// converts something like 'CanEditType' to 'edit'.
 		$cacheKey = strtolower(substr($typeField, 3, -4)) . "-$memberID";
@@ -1173,7 +1205,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			// Look in the cache for values
 			if($useCached && isset(self::$cache_permissions[$cacheKey])) {
 				$cachedValues = array_intersect_key(self::$cache_permissions[$cacheKey], $result);
-			
+
 				// If we can't find everything in the cache, then look up the remainder separately
 				$uncachedValues = array_diff_key($result, self::$cache_permissions[$cacheKey]);
 				if($uncachedValues) {
@@ -1181,7 +1213,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				}
 				return $cachedValues;
 			}
-		
+
 			// If a member doesn't have a certain permission then they can't edit anything
 			if(!$memberID || ($globalPermission && !Permission::checkMember($memberID, $globalPermission))) {
 				return $result;
@@ -1193,18 +1225,18 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			// If page can't be viewed, don't grant edit permissions to do - implement can_view_multiple(), so this can
 			// be enabled
 			//$ids = array_keys(array_filter(self::can_view_multiple($ids, $memberID)));
-		
+
 			// Get the groups that the given member belongs to
 			$groupIDs = DataObject::get_by_id('Member', $memberID)->Groups()->column("ID");
 			$SQL_groupList = implode(", ", $groupIDs);
 			if (!$SQL_groupList) $SQL_groupList = '0';
-			
+
 			$combinedStageResult = array();
 
 			foreach(array('Stage', 'Live') as $stage) {
 				// Start by filling the array with the pages that actually exist
 				$table = ($stage=='Stage') ? "SiteTree" : "SiteTree_$stage";
-				
+
 				if($ids) {
 					$idQuery = "SELECT \"ID\" FROM \"$table\" WHERE \"ID\" IN ($idPlaceholders)";
 					$stageIds = DB::prepared_query($idQuery, $ids)->column();
@@ -1212,7 +1244,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 					$stageIds = array();
 				}
 				$result = array_fill_keys($stageIds, false);
-				
+
 				// Get the uninherited permissions
 				$uninheritedPermissions = Versioned::get_by_stage("SiteTree", $stage)
 					->where(array(
@@ -1222,7 +1254,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 						=> $ids
 					))
 					->leftJoin($groupJoinTable, "\"$groupJoinTable\".\"SiteTreeID\" = \"SiteTree\".\"ID\" AND \"$groupJoinTable\".\"GroupID\" IN ($SQL_groupList)");
-				
+
 				if($uninheritedPermissions) {
 					// Set all the relevant items in $result to true
 					$result = array_fill_keys($uninheritedPermissions->column('ID'), true) + $result;
@@ -1262,9 +1294,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 						}
 					}
 				}
-				
+
 				$combinedStageResult = $combinedStageResult + $result;
-				
+
 			}
 		}
 
@@ -1304,11 +1336,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$deletable = array();
 		$result = array_fill_keys($ids, false);
 		$cacheKey = "delete-$memberID";
-		
+
 		// Look in the cache for values
 		if($useCached && isset(self::$cache_permissions[$cacheKey])) {
 			$cachedValues = array_intersect_key(self::$cache_permissions[$cacheKey], $result);
-			
+
 			// If we can't find everything in the cache, then look up the remainder separately
 			$uncachedValues = array_diff_key($result, self::$cache_permissions[$cacheKey]);
 			if($uncachedValues) {
@@ -1321,7 +1353,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		// You can only delete pages that you can edit
 		$editableIDs = array_keys(array_filter(self::can_edit_multiple($ids, $memberID)));
 		if($editableIDs) {
-		
+
 			// You can only delete pages whose children you can delete
 			$editablePlaceholders = DB::placeholders($editableIDs);
 			$childRecords = SiteTree::get()->where(array(
@@ -1332,7 +1364,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 				// Find out the children that can be deleted
 				$deletableChildren = self::can_delete_multiple($children->keys(), $memberID);
-				
+
 				// Get a list of all the parents that have no undeletable children
 				$deletableParents = array_fill_keys($editableIDs, true);
 				foreach($deletableChildren as $id => $canDelete) {
@@ -1355,7 +1387,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		} else {
 			$deletable = array();
 		}
-		
+
 		// Convert the array of deletable IDs into a map of the original IDs with true/false as the value
 		return array_fill_keys($deletable, true) + array_fill_keys($ids, false);
 	}
@@ -1407,7 +1439,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if($this->ExtraMeta) {
 			$tags .= $this->ExtraMeta . "\n";
 		}
-		
+
 		if(Permission::check('CMS_ACCESS_CMSMain')
 			&& in_array('CMSPreviewable', class_implements($this))
 			&& !$this instanceof ErrorPage
@@ -1442,7 +1474,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	public function requireDefaultRecords() {
 		parent::requireDefaultRecords();
-		
+
 		// default pages
 		if($this->class == 'SiteTree' && $this->config()->create_default_pages) {
 			if(!SiteTree::get_by_link(Config::inst()->get('RootURLController', 'default_homepage_link'))) {
@@ -1477,7 +1509,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				DB::alteration_message('Contact Us page created', 'created');
 			}
 		}
-		
+
 		// schema migration
 		// @todo Move to migration task once infrastructure is implemented
 		if($this->class == 'SiteTree') {
@@ -1517,7 +1549,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			// If after sanitising there is no URLSegment, give it a reasonable default
 			if(!$this->URLSegment) $this->URLSegment = "page-$this->ID";
 		}
-		
+
 		// Ensure that this object has a non-conflicting URLSegment value.
 		$count = 2;
 		while(!$this->validURLSegment()) {
@@ -1540,15 +1572,15 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$this->migrateVersion($this->Version);
 		}
 	}
-	
+
 	public function syncLinkTracking() {
 		$this->extend('augmentSyncLinkTracking');
 	}
-	
+
 	public function onAfterWrite() {
 		// Need to flush cache to avoid outdated versionnumber references
 		$this->flushCache();
-		
+
 		$linkedPages = $this->VirtualPages();
 		if($linkedPages) {
 			// The only way after a write() call to determine if it was triggered by a writeWithoutVersion(),
@@ -1561,13 +1593,13 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				 else $page->write();
 			}
 		}
-		
+
 		parent::onAfterWrite();
 	}
-	
+
 	public function onBeforeDelete() {
 		parent::onBeforeDelete();
-		
+
 		// If deleting this page, delete all its children.
 		if(SiteTree::config()->enforce_strict_hierarchy && $children = $this->AllChildren()) {
 			foreach($children as $child) {
@@ -1575,18 +1607,18 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			}
 		}
 	}
-	
+
 	public function onAfterDelete() {
 		// Need to flush cache to avoid outdated versionnumber references
 		$this->flushCache();
-		
+
 		// Need to mark pages depending to this one as broken
 		$dependentPages = $this->DependentPages();
 		if($dependentPages) foreach($dependentPages as $page) {
 			// $page->write() calls syncLinkTracking, which does all the hard work for us.
 			$page->write();
 		}
-		
+
 		parent::onAfterDelete();
 	}
 
@@ -1594,7 +1626,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		parent::flushCache($persistent);
 		$this->_cache_statusFlags = null;
 	}
-	
+
 	protected function validate() {
 		$result = parent::validate();
 
@@ -1606,7 +1638,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$allowed = $parent->allowedChildren();
 			$subject = ($this instanceof VirtualPage && $this->CopyContentFromID) ? $this->CopyContentFrom() : $this;
 			if(!in_array($subject->ClassName, $allowed)) {
-				
+
 				$result->error(
 					_t(
 						'SiteTree.PageTypeNotAllowed',
@@ -1629,10 +1661,10 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				'CAN_BE_ROOT'
 			);
 		}
-		
+
 		return $result;
 	}
-	
+
 	/**
 	 * Returns true if this object has a URLSegment value that does not conflict with any other objects. This method
 	 * checks for:
@@ -1648,11 +1680,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				if($controller instanceof Controller && $controller->hasAction($this->URLSegment)) return false;
 			}
 		}
-		
+
 		if(!self::config()->nested_urls || !$this->ParentID) {
 			if(class_exists($this->URLSegment) && is_subclass_of($this->URLSegment, 'RequestHandler')) return false;
 		}
-		
+
 		// Filters by url, id, and parent
 		$filter = array('"SiteTree"."URLSegment"' => $this->URLSegment);
 		if($this->ID) {
@@ -1661,7 +1693,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if(self::config()->nested_urls) {
 			$filter['"SiteTree"."ParentID"'] = $this->ParentID ? $this->ParentID : 0;
 		}
-		
+
 		$votes = array_filter(
 			(array)$this->extend('augmentValidURLSegment'),
 			function($v) {return !is_null($v);}
@@ -1676,7 +1708,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		return !($existingPage);
 		}
-		
+
 	/**
 	 * Generate a URL segment based on the title provided.
 	 *
@@ -1691,16 +1723,16 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function generateURLSegment($title){
 		$filter = URLSegmentFilter::create();
 		$t = $filter->filter($title);
-		
+
 		// Fallback to generic page name if path is empty (= no valid, convertable characters)
 		if(!$t || $t == '-' || $t == '-1') $t = "page-$this->ID";
-		
+
 		// Hook for extensions
 		$this->extend('updateURLSegment', $t, $title);
-		
+
 		return $t;
 	}
-	
+
 	/**
 	 * Gets the URL segment for the latest draft version of this page.
 	 *
@@ -1712,7 +1744,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		));
 		return ($stageRecord) ? $stageRecord->URLSegment : null;
 	}
-	
+
 	/**
 	 * Gets the URL segment for the currently published version of this page.
 	 *
@@ -1724,7 +1756,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		));
 		return ($liveRecord) ? $liveRecord->URLSegment : null;
 	}
-	
+
 	/**
 	 * Rewrite a file URL on this page, after its been renamed. Triggers the onRenameLinkedAsset action on extensions.
 	 */
@@ -1748,7 +1780,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 					if($numReplaced) {
 						$query = sprintf('UPDATE "%s" SET "%s" = ? WHERE "ID" = ?', $table, $fieldName);
 						DB::prepared_query($query, array($published[$fieldName], $this->ID));
-							
+
 						// Tell static caching to update itself
 						if($table == 'SiteTree_Live') {
 							$publishedClass = $origPublished['ClassName'];
@@ -1760,7 +1792,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			}
 		}
 	}
-	
+
 	/**
 	 * Returns the pages that depend on this page. This includes virtual pages, pages that link to it, etc.
 	 *
@@ -1772,7 +1804,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$origDisableSubsiteFilter = Subsite::$disable_subsite_filter;
 			Subsite::disable_subsite_filter(true);
 		}
-		
+
 		// Content links
 		$items = new ArrayList();
 
@@ -1785,7 +1817,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			}
 			$items->merge($linkList);
 		}
-		
+
 		// Virtual pages
 		if($includeVirtuals) {
 			$virtuals = $this->VirtualPages();
@@ -1814,7 +1846,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 
 		if(class_exists('Subsite')) Subsite::disable_subsite_filter($origDisableSubsiteFilter);
-		
+
 		return $items;
 	}
 
@@ -1824,10 +1856,10 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return DataList
 	 */
 	public function VirtualPages() {
-		
+
 		// Ignore new records
 		if(!$this->ID) return null;
-		
+
 		// Check subsite virtual pages
 		// @todo Refactor out subsite module specific code
 		if(class_exists('Subsite')) {
@@ -1835,14 +1867,14 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				'"VirtualPage"."CopyContentFromID"' => $this->ID
 			));
 		}
-		
+
 		// Check existing virtualpages
 		if(class_exists('VirtualPage')) {
 			return VirtualPage::get()->where(array(
 				'"VirtualPage"."CopyContentFromID"' => $this->ID
 			));
 		}
-		
+
 		return null;
 	}
 
@@ -1902,7 +1934,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		$dependentNote = '';
 		$dependentTable = new LiteralField('DependentNote', '<p></p>');
-		
+
 		// Create a table for showing pages linked to this one
 		$dependentPages = $this->DependentPages();
 		$dependentPagesCount = $dependentPages->Count();
@@ -1913,7 +1945,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				'DependentLinkType' => _t('SiteTree.DependtPageColumnLinkType', 'Link type'),
 			);
 			if(class_exists('Subsite')) $dependentColumns['Subsite.Title'] = singleton('Subsite')->i18n_singular_name();
-			
+
 			$dependentNote = new LiteralField('DependentNote', '<p>' . _t('SiteTree.DEPENDENT_NOTE', 'The following pages depend on this page. This includes virtual pages, redirector pages, and pages with content links.') . '</p>');
 			$dependentTable = GridField::create(
 				'DependentPages',
@@ -1939,12 +1971,12 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 					}
 				));
 		}
-		
+
 		$baseLink = Controller::join_links (
 			Director::absoluteBaseURL(),
 			(self::config()->nested_urls && $this->ParentID ? $this->Parent()->RelativeLink(true) : null)
 		);
-		
+
 		$urlsegment = SiteTreeURLSegmentField::create("URLSegment", $this->fieldLabel('URLSegment'))
 			->setURLPrefix($baseLink)
 			->setDefaultURL($this->generateURLSegment(_t(
@@ -1957,7 +1989,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$helpText .= _t('SiteTreeURLSegmentField.HelpChars', ' Special characters are automatically converted or removed.');
 		}
 		$urlsegment->setHelpText($helpText);
-		
+
 		$fields = new FieldList(
 			$rootTab = new TabSet("Root",
 				$tabMain = new Tab('Main',
@@ -1979,7 +2011,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			)
 		);
 		$htmlField->addExtraClass('stacked');
-		
+
 		// Help text for MetaData on page content editor
 		$metaFieldDesc
 			->setRightTitle(
@@ -2001,7 +2033,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		// Conditional dependent pages tab
 		if($dependentPagesCount) $tabDependent->setTitle(_t('SiteTree.TABDEPENDENT', "Dependent pages") . " ($dependentPagesCount)");
 		else $fields->removeFieldFromTab('Root', 'Dependent');
-		
+
 		$tabMain->setTitle(_t('SiteTree.TABCONTENT', "Main Content"));
 
 		if($this->ObsoleteClassName) {
@@ -2030,15 +2062,15 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			'/^Root\.Content\.Main$/' => 'Root.Main',
 			'/^Root\.Content\.([^.]+)$/' => 'Root.\\1',
 		));
-		
+
 		if(self::$runCMSFieldsExtensions) {
 			$this->extend('updateCMSFields', $fields);
 		}
 
 		return $fields;
 	}
-	
-	
+
+
 	/**
 	 * Returns fields related to configuration aspects on this record, e.g. access control. See {@link getCMSFields()}
 	 * for content-related fields.
@@ -2052,7 +2084,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$groupsMap[$group->ID] = $group->getBreadcrumbs(' > ');
 		}
 		asort($groupsMap);
-		
+
 		$fields = new FieldList(
 			$rootTab = new TabSet("Root",
 				$tabBehaviour = new Tab('Settings',
@@ -2097,17 +2129,17 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				)
 			)
 		);
-		
+
 		$visibility->setTitle($this->fieldLabel('Visibility'));
-		
+
 
 		// This filter ensures that the ParentID dropdown selection does not show this node,
 		// or its descendents, as this causes vanishing bugs
 		$parentIDField->setFilterFunction(create_function('$node', "return \$node->ID != {$this->ID};"));
 		$parentTypeSelector->addExtraClass('parentTypeSelector');
-		
+
 		$tabBehaviour->setTitle(_t('SiteTree.TABBEHAVIOUR', "Behavior"));
-		
+
 		// Make page location fields read-only if the user doesn't have the appropriate permission
 		if(!Permission::check("SITETREE_REORGANISE")) {
 			$fields->makeFieldReadonly('ParentType');
@@ -2117,14 +2149,14 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				$fields->makeFieldReadonly('ParentID');
 			}
 		}
-		
+
 		$viewersOptionsSource = array();
 		$viewersOptionsSource["Inherit"] = _t('SiteTree.INHERIT', "Inherit from parent page");
 		$viewersOptionsSource["Anyone"] = _t('SiteTree.ACCESSANYONE', "Anyone");
 		$viewersOptionsSource["LoggedInUsers"] = _t('SiteTree.ACCESSLOGGEDIN', "Logged-in users");
 		$viewersOptionsSource["OnlyTheseUsers"] = _t('SiteTree.ACCESSONLYTHESE', "Only these people (choose from list)");
 		$viewersOptionsField->setSource($viewersOptionsSource);
-		
+
 		$editorsOptionsSource = array();
 		$editorsOptionsSource["Inherit"] = _t('SiteTree.INHERIT', "Inherit from parent page");
 		$editorsOptionsSource["LoggedInUsers"] = _t('SiteTree.EDITANYONE', "Anyone who can log-in to the CMS");
@@ -2138,7 +2170,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			} else {
 				$fields->removeByName('ViewerGroups');
 			}
-			
+
 			$fields->makeFieldReadonly($editorsOptionsField);
 			if($this->CanEditType == 'OnlyTheseUsers') {
 				$fields->makeFieldReadonly($editorGroupsField);
@@ -2146,14 +2178,14 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				$fields->removeByName('EditorGroups');
 			}
 		}
-		
+
 		if(self::$runCMSFieldsExtensions) {
 			$this->extend('updateSettingsFields', $fields);
 		}
-		
+
 		return $fields;
 	}
-	
+
 	/**
 	 * @param bool $includerelations A boolean value to indicate if the labels returned should include relation fields
 	 * @return array
@@ -2183,7 +2215,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$labels['LinkChangeNote'] = _t (
 				'SiteTree.LINKCHANGENOTE', 'Changing this page\'s link will also affect the links of all child pages.'
 			);
-			
+
 			if($includerelations){
 				$labels['Parent'] = _t('SiteTree.has_one_Parent', 'Parent Page', 'The parent page in the site hierarchy');
 				$labels['LinkTracking'] = _t('SiteTree.many_many_LinkTracking', 'Link Tracking');
@@ -2288,7 +2320,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				} else {
 					// Determine if we should force a restore to root (where once it was a subpage)
 					$restoreToRoot = $this->isParentArchived();
-					
+
 					// "restore"
 					$title = $restoreToRoot
 						? _t('CMSMain.RESTORE_TO_ROOT','Restore draft at top level')
@@ -2327,7 +2359,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 							->addExtraClass('delete ss-ui-action-destructive')
 					);
 				}
-			
+
 				// "save", supports an alternate state that is still clickable, but notifies the user that the action is not needed.
 				$majorActions->push(
 					FormAction::create('save', _t('SiteTree.BUTTONSAVED', 'Saved'))
@@ -2352,15 +2384,15 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				$publish->addExtraClass('ss-ui-alternate');
 			}
 		}
-		
+
 		$actions = new FieldList(array($majorActions, $rootTabSet));
-		
+
 		// Hook for extensions to add/remove actions.
 		$this->extend('updateCMSActions', $actions);
-		
+
 		return $actions;
 	}
-	
+
 	/**
 	 * Publish this page.
 	 *
@@ -2370,7 +2402,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	public function doPublish() {
 		if (!$this->canPublish()) return false;
-		
+
 		$original = Versioned::get_one_by_stage("SiteTree", "Live", array(
 			'"SiteTree"."ID"' => $this->ID
 		));
@@ -2387,7 +2419,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			WHERE EXISTS (SELECT "SiteTree"."Sort" FROM "SiteTree" WHERE "SiteTree_Live"."ID" = "SiteTree"."ID") AND "ParentID" = ?',
 			array($this->ParentID)
 		);
-			
+
 		// Publish any virtual pages that might need publishing
 		$linkedPages = $this->VirtualPages();
 		if($linkedPages) foreach($linkedPages as $page) {
@@ -2395,7 +2427,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$page->write();
 			if($page->getExistsOnLive()) $page->doPublish();
 		}
-		
+
 		// Need to update pages linking to this one as no longer broken, on the live site
 		$origMode = Versioned::get_reading_mode();
 		Versioned::reading_stage('Live');
@@ -2404,13 +2436,13 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$page->write();
 		}
 		Versioned::set_reading_mode($origMode);
-		
+
 		// Handle activities undertaken by extensions
 		$this->invokeWithExtensions('onAfterPublish', $original);
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Unpublish this page - remove it from the live site
 	 *
@@ -2420,9 +2452,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function doUnpublish() {
 		if(!$this->canDeleteFromLive()) return false;
 		if(!$this->ID) return false;
-		
+
 		$this->invokeWithExtensions('onBeforeUnpublish', $this);
-		
+
 		$origStage = Versioned::current_stage();
 		Versioned::reading_stage('Live');
 
@@ -2455,7 +2487,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		return true;
 	}
-	
+
 	/**
 	 * Revert the draft changes: replace the draft content with the content on live
 	 */
@@ -2473,7 +2505,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			// $page->write() calls syncLinkTracking, which does all the hard work for us.
 			$page->write();
 		}
-		
+
 		$this->invokeWithExtensions('onAfterRevertToLive', $this);
 		return true;
 	}
@@ -2492,7 +2524,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 		return false;
 	}
-	
+
 	/**
 	 * Restore the content in the active copy of this SiteTree page to the stage site.
 	 *
@@ -2505,7 +2537,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if($this->isParentArchived()) {
 			$this->ParentID = 0;
 		}
-		
+
 		// if no record can be found on draft stage (meaning it has been "deleted from draft" before),
 		// create an empty record
 		if(!DB::prepared_query("SELECT \"ID\" FROM \"SiteTree\" WHERE \"ID\" = ?", array($this->ID))->value()) {
@@ -2514,12 +2546,12 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			DB::prepared_query("INSERT INTO \"SiteTree\" (\"ID\") VALUES (?)", array($this->ID));
 			if(method_exists($conn, 'allowPrimaryKeyEditing')) $conn->allowPrimaryKeyEditing('SiteTree', false);
 		}
-		
+
 		$oldStage = Versioned::current_stage();
 		Versioned::reading_stage('Stage');
 		$this->forceChange();
 		$this->write();
-		
+
 		$result = DataObject::get_by_id($this->class, $this->ID);
 
 		// Need to update pages linking to this one as no longer broken
@@ -2527,11 +2559,11 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			// $page->write() calls syncLinkTracking, which does all the hard work for us.
 			$page->write();
 		}
-		
+
 		Versioned::reading_stage($oldStage);
 
 		$this->invokeWithExtensions('onAfterRestoreToStage', $this);
-		
+
 		return $result;
 	}
 
@@ -2564,7 +2596,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if(!$member) {
             $member = Member::currentUser();
         }
-		
+
 		// Standard mechanism for accepting permission changes from extensions
 		$extended = $this->extendedCan('canArchive', $member);
 		if($extended !== null) {
@@ -2634,7 +2666,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$classes = self::page_type_classes();
 		$currentClass = null;
 		$result = array();
-		
+
 		$result = array();
 		foreach($classes as $class) {
 			$instance = singleton($class);
@@ -2644,7 +2676,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				if($instance instanceof HiddenClass) continue;
 				if(!$instance->canCreate(null, array('Parent' => $this->ParentID ? $this->Parent() : null))) continue;
 			}
-			
+
 			if($perms = $instance->stat('need_permission')) {
 				if(!$this->can($perms)) continue;
 			}
@@ -2661,7 +2693,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				$result[$class] = $result[$class] .  " ({$class})";
 			}
 		}
-		
+
 		// sort alphabetically, and put current on top
 		asort($result);
 		if($currentClass) {
@@ -2671,7 +2703,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$result[$currentClass] = $currentPageTypeName;
 			$result = array_reverse($result);
 		}
-		
+
 		return $result;
 	}
 
@@ -2697,7 +2729,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				}
 			}
 		}
-		
+
 		return $allowedChildren;
 	}
 
@@ -2752,7 +2784,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			$this->setField("MenuTitle", $value);
 		}
 	}
-	
+
 	/**
 	 * A flag provides the user with additional data about the current page status, for example a "removed from draft"
 	 * status. Each page can have more than one status flag. Returns a map of a unique key to a (localized) title for
@@ -2799,7 +2831,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 			$this->_cache_statusFlags = $flags;
 		}
-		
+
 		return $this->_cache_statusFlags;
 	}
 
@@ -2836,7 +2868,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				Convert::raw2xml($data['text'])
 			);
 		}
-		
+
 		return $treeTitle;
 	}
 
@@ -2896,7 +2928,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		if(!$this->ShowInMenus) {
 			$classes .= " notinmenu";
 		}
-			
+
 		//TODO: Add integration
 		/*
 		if($this->hasExtension('Translatable') && $controller->Locale != Translatable::default_locale() && !$this->isTranslation())
@@ -2906,7 +2938,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		return $classes;
 	}
-	
+
 	/**
 	 * Compares current draft with live version, and returns true if no draft version of this page exists  but the page
 	 * is still published (eg, after triggering "Delete from draft site" in the CMS).
@@ -2916,13 +2948,13 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function getIsDeletedFromStage() {
 		if(!$this->ID) return true;
 		if($this->isNew()) return false;
-		
+
 		$stageVersion = Versioned::get_versionnumber_by_stage('SiteTree', 'Stage', $this->ID);
 
 		// Return true for both completely deleted pages and for pages just deleted from stage
 		return !($stageVersion);
 	}
-	
+
 	/**
 	 * Return true if this page exists on the live site
 	 *
@@ -2941,16 +2973,16 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function getIsModifiedOnStage() {
 		// New unsaved pages could be never be published
 		if($this->isNew()) return false;
-		
+
 		$stageVersion = Versioned::get_versionnumber_by_stage('SiteTree', 'Stage', $this->ID);
 		$liveVersion =	Versioned::get_versionnumber_by_stage('SiteTree', 'Live', $this->ID);
-		
+
 		$isModified = ($stageVersion && $stageVersion != $liveVersion);
 		$this->extend('getIsModifiedOnStage', $isModified);
-		
+
 		return $isModified;
 	}
-	
+
 	/**
 	 * Compares current draft with live version, and returns true if no live version exists, meaning the page was never
 	 * published.
@@ -2960,13 +2992,13 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public function getIsAddedToStage() {
 		// New unsaved pages could be never be published
 		if($this->isNew()) return false;
-		
+
 		$stageVersion = Versioned::get_versionnumber_by_stage('SiteTree', 'Stage', $this->ID);
 		$liveVersion =	Versioned::get_versionnumber_by_stage('SiteTree', 'Live', $this->ID);
 
 		return ($stageVersion && !$liveVersion);
 	}
-	
+
 	/**
 	 * Stops extendCMSFields() being called on getCMSFields(). This is useful when you need access to fields added by
 	 * subclasses of SiteTree in a extension. Call before calling parent::getCMSFields(), and reenable afterwards.
@@ -2974,7 +3006,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	static public function disableCMSFieldsExtensions() {
 		self::$runCMSFieldsExtensions = false;
 	}
-	
+
 	/**
 	 * Reenables extendCMSFields() being called on getCMSFields() after it has been disabled by
 	 * disableCMSFieldsExtensions().
@@ -3017,7 +3049,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 			)
 		);
 	}
-	
+
 	/**
 	 * Return the translated Singular name.
 	 *
@@ -3028,7 +3060,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		$class = ($this->class == 'Page') ? 'SiteTree' : $this->class;
 		return _t($class.'.SINGULARNAME', $this->singular_name());
 	}
-	
+
 	/**
 	 * Overloaded to also provide entities for 'Page' class which is usually located in custom code, hence textcollector
 	 * picks it up for the wrong folder.
@@ -3037,9 +3069,9 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	public function provideI18nEntities() {
 		$entities = parent::provideI18nEntities();
-		
+
 		if(isset($entities['Page.SINGULARNAME'])) $entities['Page.SINGULARNAME'][3] = CMS_DIR;
-		if(isset($entities['Page.PLURALNAME'])) $entities['Page.PLURALNAME'][3] = CMS_DIR;		
+		if(isset($entities['Page.PLURALNAME'])) $entities['Page.PLURALNAME'][3] = CMS_DIR;
 
 		$entities[$this->class . '.DESCRIPTION'] = array(
 			$this->stat('description'),
@@ -3067,7 +3099,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	public static function reset() {
 		self::$cache_permissions = array();
 	}
-	
+
 	static public function on_db_reset() {
 		self::$cache_permissions = array();
 	}

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -4,13 +4,13 @@
  * @subpackage tests
  */
 class SiteTreeTest extends SapphireTest {
-	
+
 	protected static $fixture_file = 'SiteTreeTest.yml';
 
 	protected $illegalExtensions = array(
 		'SiteTree' => array('SiteTreeSubsites', 'Translatable')
 	);
-	
+
 	protected $extraDataObjects = array(
 		'SiteTreeTest_ClassA',
 		'SiteTreeTest_ClassB',
@@ -27,7 +27,7 @@ class SiteTreeTest extends SapphireTest {
 	public function logOut() {
 		if($member = Member::currentUser()) $member->logOut();
 	}
-	
+
 	public function testCreateDefaultpages() {
 			$remove = SiteTree::get();
 			if($remove) foreach($remove as $page) $page->delete();
@@ -513,7 +513,7 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertFalse(singleton('SiteTreeTest_ClassA')->canCreate(null, array('Parent' => $parentB)));
 		$this->assertTrue(singleton('SiteTreeTest_ClassC')->canCreate(null, array('Parent' => $parentB)));
 	}
-	
+
 	public function testEditPermissionsOnDraftVsLive() {
 		// Create an inherit-permission page
 		$page = new Page();
@@ -709,7 +709,7 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertEquals($sitetree->URLSegment, 'new-page',
 			'Sets based on default title on first save'
 		);
-		
+
 		$sitetree->Title = 'Changed';
 		$sitetree->write();
 		$this->assertEquals($sitetree->URLSegment, 'changed',
@@ -1075,7 +1075,7 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertEquals($breadcrumbs->first()->Title, "Breadcrumbs 4", "First item should be Breadrcumbs 4.");
 		$this->assertEquals($breadcrumbs->last()->Title, "Breadcrumbs 5", "Breadcrumbs 5 should be last.");
 	}
-	
+
 	/**
 	 * Tests SiteTree::MetaTags
 	 * Note that this test makes no assumption on the closing of tags (other than <title></title>)
@@ -1181,6 +1181,18 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertFalse($page->isPublished());
 	}
 
+	public function testCanNot() {
+		// Test that
+		$this->logInWithPermission('ADMIN');
+		$page = new SiteTreeTest_AdminDenied();
+		$this->assertFalse($page->canCreate());
+		$this->assertFalse($page->canEdit());
+		$this->assertFalse($page->canDelete());
+		$this->assertFalse($page->canAddChildren());
+		$this->assertFalse($page->canPublish());
+		$this->assertFalse($page->canView());
+	}
+
 }
 
 /**#@+
@@ -1193,11 +1205,11 @@ class SiteTreeTest_PageNode_Controller extends Page_Controller implements TestOn
 
 class SiteTreeTest_Conflicted extends Page implements TestOnly { }
 class SiteTreeTest_Conflicted_Controller extends Page_Controller implements TestOnly {
-	
+
 	private static $allowed_actions = array (
 		'conflicted-action'
 	);
-	
+
 	public function hasActionTemplate($template) {
 		if($template == 'conflicted-template') {
 			return true;
@@ -1205,7 +1217,7 @@ class SiteTreeTest_Conflicted_Controller extends Page_Controller implements Test
 			return parent::hasActionTemplate($template);
 		}
 	}
-	
+
 }
 
 class SiteTreeTest_NullHtmlCleaner extends HTMLCleaner {
@@ -1217,7 +1229,7 @@ class SiteTreeTest_NullHtmlCleaner extends HTMLCleaner {
 class SiteTreeTest_ClassA extends Page implements TestOnly {
 
 	private static $need_permission = array('ADMIN', 'CMS_ACCESS_CMSMain');
-	
+
 	private static $allowed_children = array('SiteTreeTest_ClassB');
 }
 
@@ -1258,4 +1270,23 @@ class SiteTreeTest_Extension extends DataExtension implements TestOnly {
 		return false;
 	}
 
+}
+
+class SiteTreeTest_AdminDenied extends Page implements TestOnly {
+	private static $extensions = array(
+		'SiteTreeTest_AdminDeniedExtension'
+	);
+}
+
+
+/**
+ * An extension that can even deny actions to admins
+ */
+class SiteTreeTest_AdminDeniedExtension extends DataExtension implements TestOnly {
+	public function canCreate($member) { return false; }
+	public function canEdit($member) { return false; }
+	public function canDelete($member) { return false; }
+	public function canPublish() { return false; }
+	public function canAddChildren() { return false; }
+	public function canView() { return false; }
 }


### PR DESCRIPTION
This is necessary in cases where extensions apply specific business logic. There is currently no way to make this logic apply to admins.