### PR TITLE
FIX reading mode can change during sitetree generation

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -4,29 +4,29 @@
  *
  * This class creates a 2-frame layout - left-tree and right-form - to sit beneath the main
  * admin menu.
- * 
+ *
  * @package cms
  * @subpackage controller
  * @todo Create some base classes to contain the generic functionality that will be replicated.
  */
 class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionProvider {
-	
+
 	private static $url_segment = 'pages';
-	
+
 	private static $url_rule = '/$Action/$ID/$OtherID';
-	
+
 	// Maintain a lower priority than other administration sections
 	// so that Director does not think they are actions of CMSMain
 	private static $url_priority = 39;
-	
+
 	private static $menu_title = 'Edit Page';
-	
+
 	private static $menu_priority = 10;
-	
+
 	private static $tree_class = "SiteTree";
-	
+
 	private static $subitem_class = "Member";
-	
+
 	/**
 	 * Amount of results showing on a single page.
 	 *
@@ -34,7 +34,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	 * @var int
 	 */
 	private static $page_length = 15;
-	
+
 	private static $allowed_actions = array(
 		'buildbrokenlinks',
 		'deleteitems',
@@ -56,20 +56,20 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		'ListViewForm',
 		'childfilter',
 	);
-	
+
 	public function init() {
 		// set reading lang
 		if(SiteTree::has_extension('Translatable') && !$this->request->isAjax()) {
 			Translatable::choose_site_locale(array_keys(Translatable::get_existing_content_languages('SiteTree')));
 		}
-		
+
 		parent::init();
 
 		Versioned::reading_stage("Stage");
-		
+
 		Requirements::css(CMS_DIR . '/css/screen.css');
 		Requirements::customCSS($this->generatePageIconsCss());
-		
+
 		Requirements::combine_files(
 			'cmsmain.js',
 			array_merge(
@@ -118,7 +118,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	public function ShowSwitchView() {
 		return true;
 	}
-	
+
 	/**
 	 * Overloads the LeftAndMain::ShowView. Allows to pass a page as a parameter, so we are able
 	 * to switch view also for archived versions.
@@ -127,7 +127,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		if(!$page) {
 			$page = $this->currentPage();
 		}
-		
+
 		if($page) {
 			$nav = SilverStripeNavigator::get_for_record($page);
 			return $nav['items'];
@@ -273,10 +273,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$this->extend('updateExtraTreeTools', $html);
 		return $html;
 	}
-	
+
 	/**
 	 * Returns a Form for page searching for use in templates.
-	 * 
+	 *
 	 * Can be modified from a decorator by a 'updateSearchForm' method
 	 *
 	 * @return Form
@@ -286,7 +286,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$content = new TextField('q[Term]', _t('CMSSearch.FILTERLABELTEXT', 'Content'));
 		$dateHeader = new HeaderField('q[Date]', _t('CMSSearch.FILTERDATEHEADING', 'Date'), 4);
 		$dateFrom = new DateField(
-			'q[LastEditedFrom]', 
+			'q[LastEditedFrom]',
 			_t('CMSSearch.FILTERDATEFROM', 'From')
 		);
 		$dateFrom->setConfig('showcalendar', true);
@@ -296,17 +296,17 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		);
 		$dateTo->setConfig('showcalendar', true);
 		$pageFilter = new DropdownField(
-			'q[FilterClass]', 
-			_t('CMSMain.PAGES', 'Pages'), 
+			'q[FilterClass]',
+			_t('CMSMain.PAGES', 'Pages'),
 			CMSSiteTreeFilter::get_all_filters()
 		);
 		$pageClasses = new DropdownField(
-			'q[ClassName]', 
-			_t('CMSMain.PAGETYPEOPT', 'Page Type', 'Dropdown for limiting search to a page type'), 
+			'q[ClassName]',
+			_t('CMSMain.PAGETYPEOPT', 'Page Type', 'Dropdown for limiting search to a page type'),
 			$this->getPageTypes()
 		);
 		$pageClasses->setEmptyString(_t('CMSMain.PAGETYPEANYOPT','Any'));
-		
+
 		// Group the Datefields
 		$dateGroup = new FieldGroup(
 			$dateHeader,
@@ -314,7 +314,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			$dateTo
 		);
 		$dateGroup->setFieldHolderTemplate('FieldGroup_DefaultFieldHolder')->addExtraClass('stacked');
-		
+
 		// Create the Field list
 		$fields = new FieldList(
 			$content,
@@ -322,7 +322,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			$pageFilter,
 			$pageClasses
 		);
-		
+
 		// Create the Search and Reset action
 		$actions = new FieldList(
 			FormAction::create('doSearch',  _t('CMSMain_left_ss.APPLY_FILTER', 'Apply Filter'))
@@ -334,7 +334,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		foreach($actions->dataFields() as $action) {
 			$action->setUseButtonTag(true);
 		}
-		
+
 		// Create the form
 		$form = Form::create($this, 'SearchForm', $fields, $actions)
 			->addExtraClass('cms-search-form')
@@ -342,19 +342,19 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			->setFormAction($this->Link())
 			->disableSecurityToken()
 			->unsetValidator();
-		
+
 		// Load the form with previously sent search data
 		$form->loadDataFrom($this->request->getVars());
 
 		// Allow decorators to modify the form
 		$this->extend('updateSearchForm', $form);
-		
+
 		return $form;
 	}
-	
+
 	/**
 	 * Returns a sorted array suitable for a dropdown with pagetypes and their translated name
-	 * 
+	 *
 	 * @return array
 	 */
 	protected function getPageTypes() {
@@ -365,7 +365,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		asort($pageTypes);
 		return $pageTypes;
 	}
-	
+
 	public function doSearch($data, $form) {
 		return $this->getsubtree($this->request);
 	}
@@ -389,7 +389,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	/**
 	 * Create serialized JSON string with site tree hints data to be injected into
 	 * 'data-hints' attribute of root node of jsTree.
-	 * 
+	 *
 	 * @return String Serialized JSON
 	 */
 	public function SiteTreeHints() {
@@ -474,18 +474,18 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			if($instance->stat('need_permission') && !$this->can(singleton($class)->stat('need_permission'))) continue;
 
 			$addAction = $instance->i18n_singular_name();
-			
+
 			// Get description (convert 'Page' to 'SiteTree' for correct localization lookups)
 			$description = _t((($class == 'Page') ? 'SiteTree' : $class) . '.DESCRIPTION');
 
 			if(!$description) {
 				$description = $instance->uninherited('description');
 			}
-			
+
 			if($class == 'Page' && !$description) {
 				$description = singleton('SiteTree')->uninherited('description');
 			}
-			
+
 			$result->push(new ArrayData(array(
 				'ClassName' => $class,
 				'AddAction' => $addAction,
@@ -495,9 +495,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				'Title' => singleton($class)->i18n_singular_name(),
 			)));
 		}
-		
+
 		$result = $result->sort('AddAction');
-		
+
 		return $result;
 	}
 
@@ -513,12 +513,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		if($id instanceof $treeClass) {
 			return $id;
-		} 
+		}
 		else if($id && is_numeric($id)) {
+			$currentStage = Versioned::current_stage();
+
 			if($this->request->getVar('Version')) {
 				$versionID = (int) $this->request->getVar('Version');
 			}
-			
+
 			if($versionID) {
 				$record = Versioned::get_version($treeClass, $id, $versionID);
 			} else {
@@ -532,9 +534,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				singleton($treeClass)->flushCache();
 
 				$record = DataObject::get_one( $treeClass, "\"$treeClass\".\"ID\" = $id");
-				if($record) Versioned::set_reading_mode('');
 			}
-			
+
 			// Then, try getting a deleted record
 			if(!$record) {
 				$record = Versioned::get_latest_version($treeClass, $id);
@@ -545,11 +546,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			 *  we should not check their locale matches the Translatable::get_current_locale,
 			 * 	here as long as we all the HTTPRequest is init with right locale.
 			 *	This bit breaks the all FileIFrameField functions if the field is used in CMS
-			 *  and its relevent ajax calles, like loading the tree dropdown for TreeSelectorField. 
+			 *  and its relevent ajax calles, like loading the tree dropdown for TreeSelectorField.
 			 */
 			/* if($record && SiteTree::has_extension('Translatable') && $record->Locale && $record->Locale != Translatable::get_current_locale()) {
 				$record = null;
 			}*/
+
+			// Set the reading mode back to what it was.
+			Versioned::reading_stage($currentStage);
 
 			return $record;
 
@@ -557,7 +561,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			return $this->getNewItem($id);
 		}
 	}
-	
+
 	/**
 	 * @param Int $id
 	 * @param FieldList $fields
@@ -567,7 +571,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		if(!$id) $id = $this->currentPageID();
 		$form = parent::getEditForm($id);
-		
+
 		// TODO Duplicate record fetching (see parent implementation)
 		$record = $this->getRecord($id);
 		if($record && !$record->canView()) return Security::permissionFailure($this);
@@ -594,14 +598,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 					if($stageLink) $stageLinkField->setValue($stageLink);
 				}
 			}
-			
+
 			// Added in-line to the form, but plucked into different view by LeftAndMain.Preview.js upon load
 			if(in_array('CMSPreviewable', class_implements($record)) && !$fields->fieldByName('SilverStripeNavigator')) {
 				$navField = new LiteralField('SilverStripeNavigator', $this->getSilverStripeNavigator());
 				$navField->setAllowHTML(true);
 				$fields->push($navField);
 			}
-			
+
 			// getAllCMSActions can be used to completely redefine the action list
 			if($record->hasMethod('getAllCMSActions')) {
 				$actions = $record->getAllCMSActions();
@@ -624,14 +628,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			// Use <button> to allow full jQuery UI styling
 			$actionsFlattened = $actions->dataFields();
 			if($actionsFlattened) foreach($actionsFlattened as $action) $action->setUseButtonTag(true);
-			
+
 			if($record->hasMethod('getCMSValidator')) {
 				$validator = $record->getCMSValidator();
 			} else {
 				$validator = new RequiredFields();
 			}
-			
-			$form = CMSForm::create( 
+
+			$form = CMSForm::create(
 				$this, "EditForm", $fields, $actions, $validator
 			)->setHTMLID('Form_EditForm');
 			$form->setResponseNegotiator($this->getResponseNegotiator());
@@ -715,7 +719,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			->addHeader('Content-Type', 'application/json; charset=utf-8')
 			->setBody(Convert::raw2json($disallowedChildren));
 	}
-	
+
 	/**
 	 * Safely reconstruct a selected filter from a given set of query parameters
 	 *
@@ -736,7 +740,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	 * Returns the pages meet a certain criteria as {@see CMSSiteTreeFilter} or the subpages of a parent page
 	 * defaulting to no filter and show all pages in first level.
 	 * Doubles as search results, if any search parameters are set through {@link SearchForm()}.
-	 * 
+	 *
 	 * @param array $params Search filter criteria
 	 * @param int $parentID Optional parent node to filter on (can't be combined with other search criteria)
 	 * @return SS_List
@@ -751,11 +755,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			return $list->filter("ParentID", $parentID);
 		}
 	}
-	
+
 	public function ListViewForm() {
 		$params = $this->request->requestVar('q');
 		$list = $this->getList($params, $parentID = $this->request->requestVar('ParentID'));
-		$gridFieldConfig = GridFieldConfig::create()->addComponents(			
+		$gridFieldConfig = GridFieldConfig::create()->addComponents(
 			new GridFieldSortableHeader(),
 			new GridFieldDataColumns(),
 			new GridFieldPaginator(self::config()->page_length)
@@ -798,7 +802,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 					return sprintf(
 						'<a class="cms-panel-link list-children-link" data-pjax-target="ListViewForm,Breadcrumbs" href="%s">%s</a>',
 						Controller::join_links(
-							$controller->Link(), 
+							$controller->Link(),
 							sprintf("?ParentID=%d&view=list", (int)$item->ID)
 						),
 						$num
@@ -816,8 +820,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				);
 			}
 		));
-		
-		$listview = CMSForm::create( 
+
+		$listview = CMSForm::create(
 			$this,
 			'ListViewForm',
 			new FieldList($gridField),
@@ -827,14 +831,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$listview->setResponseNegotiator($this->getResponseNegotiator());
 
 		$this->extend('updateListView', $listview);
-		
+
 		$listview->disableSecurityToken();
 		return $listview;
 	}
-	
+
 	public function currentPageID() {
 		$id = parent::currentPageID();
-		
+
 		$this->extend('updateCurrentPageID', $id);
 
 		// Fall back to homepage record
@@ -846,10 +850,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			));
 			if($homepageRecord) $id = $homepageRecord->ID;
 		}
-		
+
 		return $id;
 	}
-	
+
 	//------------------------------------------------------------------------------------------//
 	// Data saving handlers
 
@@ -869,7 +873,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			if(!singleton($this->stat('tree_class'))->canCreate()) return Security::permissionFailure($this);
 			$record = $this->getNewItem($SQL_id, false);
 		}
-		
+
 		// TODO Coupling to SiteTree
 		$record->HasBrokenLink = 0;
 		$record->HasBrokenFile = 0;
@@ -890,11 +894,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		// save form data into record
 		$form->saveInto($record);
 		$record->write();
-		
+
 		// If the 'Save & Publish' button was clicked, also publish the page
 		if (isset($data['publish']) && $data['publish'] == 1) {
 			$record->doPublish();
-		} 
+		}
 
 		return $this->getResponseNegotiator()->respond($this->request);
 	}
@@ -913,7 +917,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			}
 			throw new SS_HTTPResponse_Exception($response);
 		}
-		
+
 		$newItem = new $className();
 
 	    if( !$suffix ) {
@@ -946,25 +950,25 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		# Some modules like subsites add extra fields that need to be set when the new item is created
 		$this->extend('augmentNewSiteTreeItem', $newItem);
-		
+
 		return $newItem;
 	}
 
 	/**
 	 * Delete the page from live. This means a page in draft mode might still exist.
-	 * 
+	 *
 	 * @see delete()
 	 */
 	public function deletefromlive($data, $form) {
 		Versioned::reading_stage('Live');
 		$record = DataObject::get_by_id("SiteTree", $data['ID']);
 		if($record && !($record->canDelete() && $record->canDeleteFromLive())) return Security::permissionFailure($this);
-		
+
 		$descRemoved = '';
 		$descendantsRemoved = 0;
 		$recordTitle = $record->Title;
 		$recordID = $record->ID;
-		
+
 		// before deleting the records, get the descendants of this tree
 		if($record) {
 			$descendantIDs = $record->getDescendantIDList();
@@ -985,8 +989,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		if(isset($descendantsRemoved)) {
 			$descRemoved = ' ' . _t(
-				'CMSMain.DESCREMOVED', 
-				'and {count} descendants', 
+				'CMSMain.DESCREMOVED',
+				'and {count} descendants',
 				array('count' => $descendantsRemoved)
 			);
 		} else {
@@ -997,13 +1001,13 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			'X-Status',
 			rawurlencode(
 				_t(
-					'CMSMain.REMOVED', 
+					'CMSMain.REMOVED',
 					'Deleted \'{title}\'{description} from live site',
 					array('title' => $recordTitle, 'description' => $descRemoved)
 				)
 			)
 		);
-		
+
 		// Even if the record has been deleted from stage and live, it can be viewed in "archive mode"
 		return $this->getResponseNegotiator()->respond($this->request);
 	}
@@ -1013,7 +1017,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	 */
 	public function performPublish($record) {
 		if($record && !$record->canPublish()) return Security::permissionFailure($this);
-		
+
 		$record->doPublish();
 	}
 
@@ -1021,19 +1025,19 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
  	 * Reverts a page by publishing it to live.
  	 * Use {@link restorepage()} if you want to restore a page
  	 * which was deleted from draft without publishing.
- 	 * 
+ 	 *
  	 * @uses SiteTree->doRevertToLive()
 	 */
 	public function revert($data, $form) {
 		if(!isset($data['ID'])) return new SS_HTTPResponse("Please pass an ID in the form content", 400);
-		
+
 		$id = (int) $data['ID'];
 		$restoredPage = Versioned::get_latest_version("SiteTree", $id);
 		if(!$restoredPage) 	return new SS_HTTPResponse("SiteTree #$id not found", 400);
-		
+
 		$record = Versioned::get_one_by_stage(
-			'SiteTree', 
-			'Live', 
+			'SiteTree',
+			'Live',
 			sprintf("\"SiteTree_Live\".\"ID\" = '%d'", (int)$data['ID'])
 		);
 
@@ -1043,7 +1047,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		if(!$record || !$record->ID) throw new SS_HTTPResponse_Exception("Bad record ID #$id", 404);
 
 		$record->doRevertToLive();
-		
+
 		$this->response->addHeader(
 			'X-Status',
 			rawurlencode(_t(
@@ -1053,10 +1057,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				array('title' => $record->Title)
 			))
 		);
-		
+
 		return $this->getResponseNegotiator()->respond($this->request);
 	}
-	
+
 	/**
 	 * Delete the current page from draft stage.
 	 * @see deletefromlive()
@@ -1064,12 +1068,12 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	public function delete($data, $form) {
 		$id = Convert::raw2sql($data['ID']);
 		$record = DataObject::get_one(
-			"SiteTree", 
+			"SiteTree",
 			sprintf("\"SiteTree\".\"ID\" = %d", $id)
 		);
 		if($record && !$record->canDelete()) return Security::permissionFailure();
 		if(!$record || !$record->ID) throw new SS_HTTPResponse_Exception("Bad record ID #$id", 404);
-		
+
 		// save ID and delete record
 		$recordID = $record->ID;
 		$record->delete();
@@ -1078,31 +1082,31 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			'X-Status',
 			rawurlencode(sprintf(_t('CMSMain.REMOVEDPAGEFROMDRAFT',"Removed '%s' from the draft site"), $record->Title))
 		);
-		
+
 		// Even if the record has been deleted from stage and live, it can be viewed in "archive mode"
 		return $this->getResponseNegotiator()->respond($this->request);
 	}
 
 	public function publish($data, $form) {
 		$data['publish'] = '1';
-		
+
 		return $this->save($data, $form);
 	}
 
 	public function unpublish($data, $form) {
 		$className = $this->stat('tree_class');
 		$record = DataObject::get_by_id($className, $data['ID']);
-		
+
 		if($record && !$record->canDeleteFromLive()) return Security::permissionFailure($this);
 		if(!$record || !$record->ID) throw new SS_HTTPResponse_Exception("Bad record ID #" . (int)$data['ID'], 404);
-		
+
 		$record->doUnpublish();
-		
+
 		$this->response->addHeader(
 			'X-Status',
 			rawurlencode(_t('CMSMain.REMOVEDPAGE',"Removed '{title}' from the published site", array('title' => $record->Title)))
 		);
-		
+
 		return $this->getResponseNegotiator()->respond($this->request);
 	}
 
@@ -1126,13 +1130,13 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	 */
 	public function doRollback($data, $form) {
 		$this->extend('onBeforeRollback', $data['ID']);
-		
+
 		$id = (isset($data['ID'])) ? (int) $data['ID'] : null;
 		$version = (isset($data['Version'])) ? (int) $data['Version'] : null;
 
 		$record = DataObject::get_by_id($this->stat('tree_class'), $id);
 		if($record && !$record->canEdit()) return Security::permissionFailure($this);
-		
+
 		if($version) {
 			$record->doRollbackTo($version);
 			$message = _t(
@@ -1148,14 +1152,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		}
 
 		$this->response->addHeader('X-Status', rawurlencode($message));
-		
+
 		// Can be used in different contexts: In normal page edit view, in which case the redirect won't have any effect.
 		// Or in history view, in which case a revert causes the CMS to re-load the edit view.
 		// The X-Pjax header forces a "full" content refresh on redirect.
 		$url = Controller::join_links(singleton('CMSPageEditController')->Link('show'), $record->ID);
 		$this->response->addHeader('X-ControllerURL', $url);
-		$this->request->addHeader('X-Pjax', 'Content');  
-		$this->response->addHeader('X-Pjax', 'Content');  
+		$this->request->addHeader('X-Pjax', 'Content');
+		$this->response->addHeader('X-Pjax', 'Content');
 
 		return $this->getResponseNegotiator()->respond($this->request);
 	}
@@ -1166,7 +1170,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	public function batchactions() {
 		return new CMSBatchActionHandler($this, 'batchactions');
 	}
-	
+
 	public function BatchActionParameters() {
 		$batchActions = CMSBatchActionHandler::config()->batch_actions;
 
@@ -1184,7 +1188,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		$pageHtml = '';
 		foreach($forms as $urlSegment => $html) {
 			$pageHtml .= "<div class=\"params\" id=\"BatchActionParameters_$urlSegment\">$html</div>\n\n";
-		} 
+		}
 		return new LiteralField("BatchActionParameters", '<div id="BatchActionParameters" style="display:none">'.$pageHtml.'</div>');
 	}
 	/**
@@ -1193,14 +1197,14 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 	public function BatchActionList() {
 		return $this->batchactions()->batchActionList();
 	}
-	
+
 	public function buildbrokenlinks($request) {
 		// Protect against CSRF on destructive action
 		if(!SecurityToken::inst()->checkRequest($request)) return $this->httpError(400);
-		
+
 		increase_time_limit_to();
 		increase_memory_limit_to();
-		
+
 		if($this->urlParams['ID']) {
 			$newPageSet[] = DataObject::get_by_id("Page", $this->urlParams['ID']);
 		} else {
@@ -1235,20 +1239,20 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		increase_time_limit_to();
 		increase_memory_limit_to();
-		
+
 		$response = "";
 
 		if(isset($this->requestParams['confirm'])) {
 			// Protect against CSRF on destructive action
 			if(!SecurityToken::inst()->checkRequest($request)) return $this->httpError(400);
-			
+
 			$start = 0;
 			$pages = DataObject::get("SiteTree", "", "", "", "$start,30");
 			$count = 0;
 			while($pages) {
 				foreach($pages as $page) {
 					if($page && !$page->canPublish()) return Security::permissionFailure($this);
-					
+
 					$page->doPublish();
 					$page->destroy();
 					unset($page);
@@ -1280,10 +1284,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 					. $tokenHtml .
 				'</form>';
 		}
-		
+
 		return $response;
 	}
-	
+
 	/**
 	 * Restore a completely deleted page from the SiteTree_versions table.
 	 */
@@ -1291,29 +1295,29 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		if(!isset($data['ID']) || !is_numeric($data['ID'])) {
 			return new SS_HTTPResponse("Please pass an ID in the form content", 400);
 		}
-		
+
 		$id = (int)$data['ID'];
 		$restoredPage = Versioned::get_latest_version("SiteTree", $id);
 		if(!$restoredPage) 	return new SS_HTTPResponse("SiteTree #$id not found", 400);
-		
+
 		$restoredPage = $restoredPage->doRestoreToStage();
-		
+
 		$this->response->addHeader(
 			'X-Status',
 			rawurlencode(_t(
 				'CMSMain.RESTORED',
-				"Restored '{title}' successfully", 
+				"Restored '{title}' successfully",
 				array('title' => $restoredPage->Title)
 			))
 		);
-		
+
 		return $this->getResponseNegotiator()->respond($this->request);
 	}
 
 	public function duplicate($request) {
 		// Protect against CSRF on destructive action
 		if(!SecurityToken::inst()->checkRequest($request)) return $this->httpError(400);
-		
+
 		if(($id = $this->urlParams['ID']) && is_numeric($id)) {
 			$page = DataObject::get_by_id("SiteTree", $id);
 			if($page && (!$page->canEdit() || !$page->canCreate(null, array('Parent' => $page->Parent())))) {
@@ -1322,26 +1326,26 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			if(!$page || !$page->ID) throw new SS_HTTPResponse_Exception("Bad record ID #$id", 404);
 
 			$newPage = $page->duplicate();
-			
+
 			// ParentID can be hard-set in the URL.  This is useful for pages with multiple parents
 			if(isset($_GET['parentID']) && is_numeric($_GET['parentID'])) {
 				$newPage->ParentID = $_GET['parentID'];
 				$newPage->write();
 			}
-			
+
 			$this->response->addHeader(
 				'X-Status',
 				rawurlencode(_t(
 					'CMSMain.DUPLICATED',
-					"Duplicated '{title}' successfully", 
+					"Duplicated '{title}' successfully",
 					array('title' => $newPage->Title)
 				))
 			);
 			$url = Controller::join_links(singleton('CMSPageEditController')->Link('show'), $newPage->ID);
 			$this->response->addHeader('X-ControllerURL', $url);
-			$this->request->addHeader('X-Pjax', 'Content');  
-			$this->response->addHeader('X-Pjax', 'Content');  
-			
+			$this->request->addHeader('X-Pjax', 'Content');
+			$this->response->addHeader('X-Pjax', 'Content');
+
 			return $this->getResponseNegotiator()->respond($this->request);
 		} else {
 			return new SS_HTTPResponse("CMSMain::duplicate() Bad ID: '$id'", 400);
@@ -1365,21 +1369,21 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 				'X-Status',
 				rawurlencode(_t(
 					'CMSMain.DUPLICATEDWITHCHILDREN',
-					"Duplicated '{title}' and children successfully", 
+					"Duplicated '{title}' and children successfully",
 					array('title' => $newPage->Title)
 				))
 			);
 			$url = Controller::join_links(singleton('CMSPageEditController')->Link('show'), $newPage->ID);
 			$this->response->addHeader('X-ControllerURL', $url);
-			$this->request->addHeader('X-Pjax', 'Content');  
-			$this->response->addHeader('X-Pjax', 'Content');  
-			
+			$this->request->addHeader('X-Pjax', 'Content');
+			$this->response->addHeader('X-Pjax', 'Content');
+
 			return $this->getResponseNegotiator()->respond($this->request);
 		} else {
 			return new SS_HTTPResponse("CMSMain::duplicatewithchildren() Bad ID: '$id'", 400);
 		}
 	}
-	
+
 	public function providePermissions() {
 		$title = _t("CMSPagesController.MENUTITLE", LeftAndMain::menu_title_for_class('CMSPagesController'));
 		return array(


### PR DESCRIPTION
This causes a bug where the site tree incorrectly displays the structure (pages seem to be missing).

To reproduce the bug:
1. Create 3 pages (Parent page > Child page > Grandchild Page) and publish all 3
2. Move grandchild page to be under Parent page (same level as child page)
3. Click on child page
4. Unpublish child page
5. Delete child page
6. Refresh the page (still on the deleted child page)
(Notice that it doesn't show other children of Parent page)
7. Click onto another page (ie. Parent page) and refresh
(Notice that child pages display correctly)

This doesn't actually delete the page, but the site tree renders incorrectly.