### PR TITLE
API Cleanup inconsistent SiteTree::duplicate API

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -609,26 +609,13 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	}
 
 	/**
-	 * Create a duplicate of this node. Doesn't affect joined data - create a custom overloading of this if you need
-	 * such behaviour.
+	 * Reset Sort on duped page
 	 *
-	 * @param bool $doWrite Whether to write the new object before returning it
-	 * @return self The duplicated object
+	 * @param SiteTree $original
+	 * @param bool $doWrite
 	 */
-	 public function duplicate($doWrite = true) {
-
-		$page = parent::duplicate(false);
-		$page->Sort = 0;
-		$this->invokeWithExtensions('onBeforeDuplicate', $page);
-
-		if($doWrite) {
-			$page->write();
-
-			$page = $this->duplicateManyManyRelations($this, $page);
-		}
-		$this->invokeWithExtensions('onAfterDuplicate', $page);
-
-		return $page;
+	public function onBeforeDuplicate($original, $doWrite) {
+		$this->Sort = 0;
 	}
 
 	/**

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -368,6 +368,14 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertFalse(DataObject::get_by_id('Page', $pageStaffDuplicate->ID));
 	}
 
+	public function testDuplicate() {
+		$pageAbout = $this->objFromFixture('Page', 'about');
+		$dupe = $pageAbout->duplicate();
+		$this->assertEquals($pageAbout->Title, $dupe->Title);
+		$this->assertNotEquals($pageAbout->URLSegment, $dupe->URLSegment);
+		$this->assertNotEquals($pageAbout->Sort, $dupe->Sort);
+	}
+
 	public function testDeleteFromLiveOperatesRecursively() {
 		Config::inst()->update('SiteTree', 'enforce_strict_hierarchy', false);
 		$this->logInWithPermission('ADMIN');


### PR DESCRIPTION
Merge this before accepting https://github.com/silverstripe-australia/silverstripe-advancedworkflow/pull/261

At the moment onBeforeDuplicate is run on both the original and the duplicate.

This corrects the behaviour to run only on the duplicate, and have it pass in the original to the first parameter consistently.

dataobject implements as:

```php
public function duplicate($doWrite = true) {
		$className = $this->class;
		$clone = new $className( $this->toMap(), false, $this->model );
		$clone->ID = 0;

		$clone->invokeWithExtensions('onBeforeDuplicate', $this, $doWrite);
		if($doWrite) {
			$clone->write();
			$this->duplicateManyManyRelations($this, $clone);
		}
		$clone->invokeWithExtensions('onAfterDuplicate', $this, $doWrite);

		return $clone;
	}
```