### PR TITLE
History panel forms markup add extra table header class

### DIFF
--- a/templates/CMSPageHistoryController_versions.ss
+++ b/templates/CMSPageHistoryController_versions.ss
@@ -2,9 +2,9 @@
 	<thead>
 		<tr>
 			<th class="ui-helper-hidden"></th>
-			<th><% _t('CMSPageHistoryController_versions_ss.WHEN','When') %></th>
+			<th class="first-column"><% _t('CMSPageHistoryController_versions_ss.WHEN','When') %></th>
 			<th><% _t('CMSPageHistoryController_versions_ss.AUTHOR','Author') %></th>
-			<th><% _t('CMSPageHistoryController_versions_ss.PUBLISHER','Publisher') %></th>
+			<th class="last-column"><% _t('CMSPageHistoryController_versions_ss.PUBLISHER','Publisher') %></th>
 		</tr>
 	</thead>
 


### PR DESCRIPTION
I've rebased this work against the new bootstrap form branch https://github.com/silverstripe/silverstripe-cms/pull/1530 so that PR should be accepted first.

Requires https://github.com/silverstripe/silverstripe-framework/pull/5724
Fixes https://github.com/silverstripe/silverstripe-cms/issues/1527

After:
![pasted_image_22_06_16__12_13_pm](https://cloud.githubusercontent.com/assets/555033/16250610/cafac708-3872-11e6-9310-d4d92c78358f.png)