### PR TITLE
FIX: Fixes #1054 By preventing errors in the CMS _only_.

### DIFF
--- a/code/controllers/CMSPageHistoryController.php
+++ b/code/controllers/CMSPageHistoryController.php
@@ -358,7 +358,7 @@ class CMSPageHistoryController extends CMSMain {
 	/**
 	 * @param int $versionID
 	 * @param int $otherVersionID
-	 * @return Form
+	 * @return mixed
 	 */
 	public function CompareVersionsForm($versionID, $otherVersionID) {
 		if($versionID > $otherVersionID) {
@@ -369,16 +369,20 @@ class CMSPageHistoryController extends CMSMain {
 			$fromVersion = $versionID;
 		}
 
-		if(!$toVersion || !$toVersion) return false;
+		if(!$toVersion || !$toVersion) {
+			return false;
+		}
 		
 		$id = $this->currentPageID();
 		$page = DataObject::get_by_id("SiteTree", $id);
 		
-		if($page && !$page->canView()) {
-			return Security::permissionFailure($this);
-		}
+ 		if($page && $page->exists()) {
+			if(!$page->canView()) {
+				return Security::permissionFailure($this);
+			}
 
-		$record = $page->compareVersions($fromVersion, $toVersion);
+			$record = $page->compareVersions($fromVersion, $toVersion);
+		}
 
 		$fromVersionRecord = Versioned::get_version('SiteTree', $id, $fromVersion);
 		$toVersionRecord = Versioned::get_version('SiteTree', $id, $toVersion);
@@ -391,7 +395,7 @@ class CMSPageHistoryController extends CMSMain {
 			user_error("Can't find version $toVersion of page $id", E_USER_ERROR);
 		}
 
-		if($record) {
+		if(isset($record)) {
 			$form = $this->getEditForm($id, null, null, true);
 			$form->setActions(new FieldList());
 			$form->addExtraClass('compare');
@@ -414,6 +418,8 @@ class CMSPageHistoryController extends CMSMain {
 			
 			return $form;
 		}
+        
+        	return false;
 	}
 
 	public function Breadcrumbs($unlinked = false) {


### PR DESCRIPTION
MINOR Boyscouting: Addition of missing braces, default return and missing types in @return annotation.