### PR TITLE
FIX do not show HiddenClass pages in allowed children

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2694,7 +2694,10 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				} else {
 					$subclasses = ClassInfo::subclassesFor($candidate);
 					foreach($subclasses as $subclass) {
-						if($subclass != "SiteTree_root") $allowedChildren[] = $subclass;
+						if ($subclass == 'SiteTree_root' || singleton($subclass) instanceof HiddenClass) {
+							continue;
+						}
+						$allowedChildren[] = $subclass;
 					}
 				}
 			}


### PR DESCRIPTION
* Resolves #1553

This change could probably be back merged into earlier 3.x versions too.