### PR TITLE
FIX allow custom query params when archiving a page (resolves #1557)

### DIFF
--- a/code/controllers/SilverStripeNavigator.php
+++ b/code/controllers/SilverStripeNavigator.php
@@ -386,9 +386,12 @@ class SilverStripeNavigatorItem_ArchiveLink extends SilverStripeNavigatorItem {
 			return "<div id=\"SilverStripeNavigatorMessage\" title=\"". _t('ContentControl.NOTEWONTBESHOWN', 'Note: this message will not be shown to your visitors') ."\">". _t('ContentController.ARCHIVEDSITEFROM', 'Archived site from') ."<br>" . $dateObj->Nice() . "</div>";
 		}
 	}
-	
+
 	public function getLink() {
-		return $this->record->PreviewLink() . '?archiveDate=' . urlencode($this->record->LastEdited);
+		return Controller::join_links(
+			$this->record->PreviewLink(),
+			'?archiveDate=' . urlencode($this->record->LastEdited)
+		);
 	}
 	
 	public function canView($member = null) {


### PR DESCRIPTION
The original code doesn't use `Controller::join_links()` so if the `PreviewLink()` already contains query string parameters, it may end up resulting in a link looking like this:

```
/path/to/preview?my=query&string=here?archiveDate=1234...
```

This resolves the issue by using the `join_links()` method as used elsewhere in the same file.