### PR TITLE
FIX Direct edit file by URL

### DIFF
--- a/code/controllers/AssetAdmin.php
+++ b/code/controllers/AssetAdmin.php
@@ -54,8 +54,6 @@ class AssetAdmin extends LeftAndMain implements PermissionProvider{
 			return $this->getRequest()->requestVar('ID');
 		} elseif (is_numeric($this->urlParams['ID'])) {
 			return $this->urlParams['ID'];
-		} elseif(Session::get("{$this->class}.currentPage")) {
-			return Session::get("{$this->class}.currentPage");
 		} else {
 			return 0;
 		}
@@ -517,13 +515,24 @@ JS
 	 * Custom currentPage() method to handle opening the 'root' folder
 	 */
 	public function currentPage() {
+		$folder = null;
 		$id = $this->currentPageID();
 		if($id && is_numeric($id) && $id > 0) {
-			$folder = DataObject::get_by_id('Folder', $id);
-			if($folder && $folder->isInDB()) {
-				return $folder;
+			$folder = Folder::get()->byID($id);
+		}
+		// Detect current folder in gridfield item edit view
+		if (!$folder) {
+			$paramID = $this->getRequest()->param('ID');
+			if (is_numeric($paramID) && $file = File::get()->byID($paramID)) {
+				$folder = $file->Parent();
 			}
 		}
+
+		if($folder && $folder->isInDB()) {
+			return $folder;
+		}
+
+		// Fallback to root
 		$this->setCurrentPageID(null);
 		return new Folder();
 	}

--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -40,8 +40,6 @@ class CMSFileAddController extends LeftAndMain {
 			return $this->getRequest()->requestVar('ID');
 		} elseif (is_numeric($this->urlParams['ID'])) {
 			return $this->urlParams['ID'];
-		} elseif(Session::get("{$this->class}.currentPage")) {
-			return Session::get("{$this->class}.currentPage");
 		} else {
 			return 0;
 		}
@@ -57,10 +55,6 @@ class CMSFileAddController extends LeftAndMain {
 		Requirements::javascript(FRAMEWORK_DIR . '/javascript/AssetUploadField.js');
 		Requirements::css(FRAMEWORK_DIR . '/css/AssetUploadField.css');
 
-		if($currentPageID = $this->currentPageID()){
-			Session::set("{$this->class}.currentPage", $currentPageID);	
-		}
-		
 		$folder = $this->currentPage();
 
 		$uploadField = UploadField::create('AssetUploadField', '');


### PR DESCRIPTION
Trying to navigate directly to the edit view of a file by URL would fail if a folder other than the file’s parent was held in session data. Removed redundant storage of current ID in session and added folder detection for edit view. This also fixes breadcrumbs when directly navigating to file edit URL.