### PR TITLE
FIX Direct edit file by URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 
 env:
   global:
-    - CORE_RELEASE=3
+    - CORE_RELEASE=3.4
     - "ARTIFACTS_AWS_REGION=us-east-1"
     - "ARTIFACTS_S3_BUCKET=silverstripe-travis-artifacts"
     - secure: "7V20Qk3bIG2AlTJaA5D/uzB8vUVvRwQp+xjRYUxlahtj9FcuqEV3HIyjwwJe0T6Z1bnRYuu28ZnCT2CfP9BBZ3FE7AwSZbPase9c0/at2qDJNqkvIdC1xZ1H6Fcy2LSwNB9wLQPe613ItVdanitEuwE41iowxBPslxUUTnwx7eY="

--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -6,7 +6,7 @@ class CMSFileAddController extends LeftAndMain {
 	private static $required_permission_codes = 'CMS_ACCESS_AssetAdmin';
 	private static $menu_title = 'Files';
 	private static $tree_class = 'Folder';
-	
+
 //	public function upload($request) {
 //		$formHtml = $this->renderWith(array('AssetAdmin_UploadContent'));
 //		if($request->isAjax()) {
@@ -36,12 +36,11 @@ class CMSFileAddController extends LeftAndMain {
 	 * Return fake-ID "root" if no ID is found (needed to upload files into the root-folder)
 	 */
 	public function currentPageID() {
-		if(is_numeric($this->getRequest()->requestVar('ID')))	{
-			return $this->getRequest()->requestVar('ID');
-		} elseif (is_numeric($this->urlParams['ID'])) {
-			return $this->urlParams['ID'];
-		} elseif(Session::get("{$this->class}.currentPage")) {
-			return Session::get("{$this->class}.currentPage");
+		$request = $this->getRequest();
+		if (is_numeric($request->requestVar('ID')))	{
+			return $request->requestVar('ID');
+		} elseif (is_numeric($request->param('ID'))) {
+			return $request->param('ID');
 		} else {
 			return 0;
 		}
@@ -57,10 +56,6 @@ class CMSFileAddController extends LeftAndMain {
 		Requirements::javascript(FRAMEWORK_DIR . '/javascript/AssetUploadField.js');
 		Requirements::css(FRAMEWORK_DIR . '/css/AssetUploadField.css');
 
-		if($currentPageID = $this->currentPageID()){
-			Session::set("{$this->class}.currentPage", $currentPageID);	
-		}
-		
 		$folder = $this->currentPage();
 
 		$uploadField = UploadField::create('AssetUploadField', '');
@@ -87,7 +82,7 @@ class CMSFileAddController extends LeftAndMain {
 			$this,
 			'EditForm',
 			new FieldList(
-				$uploadField,				
+				$uploadField,
 				new HiddenField('ID')
 			),
 			new FieldList()
@@ -135,7 +130,7 @@ class CMSFileAddController extends LeftAndMain {
 			'Title' => _t('AssetAdmin.Upload', 'Upload'),
 			'Link' => $this->Link()
 		)));
-		
+
 		return $items;
 	}
 


### PR DESCRIPTION
Trying to navigate directly to the edit view of a file by URL would fail if a folder other than the file’s parent was held in session data, as it would take precedence over falsey but valid values such as 0 or null. Additionally, breadcrumbs would be missing if navigating directly to a file edit URL without navigating through the gridfield first. Storage of current folder ID in session retained for backwards compatibility, but reliance on it has been removed.

Behat test will fail without companion fix at https://github.com/silverstripe/silverstripe-framework/pull/5848