### PR TITLE
API: Add checker for Ajax calls so error page is not returned

### DIFF
--- a/code/Controllers/ErrorPageControllerExtension.php
+++ b/code/Controllers/ErrorPageControllerExtension.php
@@ -24,6 +24,9 @@ class ErrorPageControllerExtension extends Extension {
 	 * @throws SS_HTTPResponse_Exception
 	 */
 	public function onBeforeHTTPError($statusCode, $request) {
+		if (\Director::is_ajax()) {
+			return;
+		}
 		$response = ErrorPage::response_for($statusCode);
 		if($response) {
 			throw new SS_HTTPResponse_Exception($response, $statusCode);


### PR DESCRIPTION
This would allow for error messages to passed easily when an ajax call is made instead of a full form submit.