### PR TITLE
Enforce JS var declaration with value

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "airbnb"
+	"extends": "airbnb",
+	"rules": {
+		"init-declarations": 1
+	}
 }


### PR DESCRIPTION
This caught us out recently where code did a strict type check for `myVar === undefined`.
The var was defined as `let myVar;`, without a value - so the check returned false (it's `null`).
To avoid this situation, we've decided to enforce declarations with values.
Note that preference should be given to single, immutable assignments via const where possible.

See http://eslint.org/docs/rules/init-declarations