### PR TITLE
API Move preview template to cms section

### DIFF
--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_PreviewPanel.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_PreviewPanel.ss
@@ -1,0 +1,11 @@
+<div class="cms-preview east" data-layout-type="border">
+	<div class="preview-note"><span><!-- --></span><%t CMSPageHistoryController_versions_ss.PREVIEW 'Website preview' %></div>
+	<div class="panel-scrollable panel-scrollable--single-toolbar">
+		<div class="preview-device-outer">
+			<div class="preview-device-inner">
+				<iframe src="about:blank" class="center" name="cms-preview-iframe"></iframe>
+			</div>
+		</div>
+	</div>
+	<div class="cms-content-controls cms-preview-controls south"></div>
+</div>


### PR DESCRIPTION
Ensures that preview area is only loaded for sections which support preview. Originally it was designed as a CMS-wide feature, but it was never utilised outside of CMSMain.

Merge this first, and then https://github.com/silverstripe/silverstripe-framework/pull/5994.