### PR TITLE
Moved Backlink list/table to SS Template

### DIFF
--- a/code/Model/SiteTreeFileExtension.php
+++ b/code/Model/SiteTreeFileExtension.php
@@ -39,6 +39,10 @@ class SiteTreeFileExtension extends DataExtension {
 		'BackLinkTracking'
 	);
 
+	private static $casting = array(
+		'BackLinkHTMLList' => 'HTMLFragment'
+	);
+
 	public function updateCMSFields(FieldList $fields) {
 		$fields->insertAfter(
 			'LastEdited',
@@ -60,7 +64,7 @@ class SiteTreeFileExtension extends DataExtension {
 	public function BackLinkHTMLList() {
 		$viewer = new SSViewer(["type" => "Includes", __CLASS__ . "_description"]);
 
-		return $viewer->process($this->owner)->forTemplate();
+		return $viewer->process($this->owner);
 	}
 
 	/**

--- a/code/Model/SiteTreeFileExtension.php
+++ b/code/Model/SiteTreeFileExtension.php
@@ -10,6 +10,7 @@ use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ManyManyList;
 use SilverStripe\ORM\Versioning\Versioned;
+use SilverStripe\View\SSViewer;
 use Subsite;
 
 /**
@@ -57,25 +58,9 @@ class SiteTreeFileExtension extends DataExtension {
 	 * @return string
 	 */
 	public function BackLinkHTMLList() {
-		$html = '<em>' . _t(
-			'SiteTreeFileExtension.BACKLINK_LIST_DESCRIPTION',
-			'This list shows all pages where the file has been added through a WYSIWYG editor.'
-		) . '</em>';
+		$viewer = new SSViewer(["type" => "Includes", __CLASS__ . "_description"]);
 
-		$html .= '<ul>';
-		foreach ($this->BackLinkTracking() as $backLink) {
-			// Add the page link and CMS link
-			$html .= sprintf(
-				'<li><a href="%s" target="_blank">%s</a> &ndash; <a href="%s">%s</a></li>',
-				Convert::raw2att($backLink->Link()),
-				Convert::raw2xml($backLink->MenuTitle),
-				Convert::raw2att($backLink->CMSEditLink()),
-				_t('SiteTreeFileExtension.EDIT', 'Edit')
-			);
-		}
-		$html .= '</ul>';
-
-		return $html;
+		return $viewer->process($this->owner)->forTemplate();
 	}
 
 	/**

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -421,6 +421,9 @@ en:
     many_many_ImageTracking: 'Image Tracking'
     many_many_LinkTracking: 'Link Tracking'
   SiteTreeFileExtension:
+    TITLE_INDEX: '#'
+    TITLE_USED_ON: 'Used On'
+    TITLE_TYPE: 'Type'
     BACKLINK_LIST_DESCRIPTION: 'This list shows all pages where the file has been added through a WYSIWYG editor.'
     EDIT: Edit
   SiteTreeURLSegmentField:

--- a/templates/SilverStripe/CMS/Model/Includes/SiteTreeFileExtension_description.ss
+++ b/templates/SilverStripe/CMS/Model/Includes/SiteTreeFileExtension_description.ss
@@ -1,0 +1,27 @@
+<% if $BackLinkTracking %>
+	<table class="table">
+		<thead>
+		<tr>
+			<th><% _t('SiteTreeFileExtension.TITLE_INDEX', '#') %></th>
+			<th><% _t('SiteTreeFileExtension.TITLE_USED_ON', 'Used on') %></th>
+			<th><% _t('SiteTreeFileExtension.TITLE_TYPE', 'Type') %></th>
+		</tr>
+		</thead>
+		<tbody>
+		<% loop $BackLinkTracking %>
+			<tr>
+				<th>$Pos</th>
+				<td><a href="$CMSEditLink">$MenuTitle</a></td>
+				<td>
+					$i18n_singular_name
+					<% if $isPublished %>
+						<span class="label label-success">Published</span>
+					<% else %>
+						<span class="label label-info">Draft</span>
+					<% end_if %>
+				</td>
+			</tr>
+		<% end_loop %>
+		</tbody>
+	</table>
+<% end_if %>


### PR DESCRIPTION
This is a temporary work around to populate the Usage tab for Files and Images, until https://github.com/silverstripe/silverstripe-asset-admin/issues/251 is addressed
