### PR TITLE
FIX allowedChildren only filters direct implementors of HiddenPage

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2695,7 +2695,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				} else {
 					$subclasses = ClassInfo::subclassesFor($candidate);
 					foreach($subclasses as $subclass) {
-						if ($subclass == 'SiteTree_root' || singleton($subclass) instanceof HiddenClass) {
+						if ($subclass == 'SiteTree_root' || ClassInfo::classImplements($subclass, 'HiddenPage')) {
 							continue;
 						}
 						$allowedChildren[] = $subclass;


### PR DESCRIPTION
Only direct implementors of `HiddenPage` should be hidden.