### PR TITLE
Code Coverage via CodeCov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     - php: 5.6
       env: NPM_TEST=1
     - php: 7.0
-      env: DB=MYSQL PDO=1 PHPUNIT_TEST=1
+      env: DB=MYSQL PDO=1 PHPUNIT_COVERAGE_TEST=1
 
 before_script:
  - composer self-update || true
@@ -56,6 +56,8 @@ script:
  - "if [ \"$PHPUNIT_TEST\" = \"1\" ]; then vendor/bin/phpunit tests flush=1; fi"
  - "if [ \"$BEHAT_TEST\" = \"1\" ]; then vendor/bin/behat .; fi"
  - "if [ \"$NPM_TEST\" = \"1\" ]; then (nvm use 4 && npm run lint); fi"
+ - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ]; then phpdbg -qrr vendor/bin/phpunit tests flush=1 --coverage-clover=coverage.xml; fi"
+ - "if [ \"$PHPUNIT_COVERAGE_TEST\" = \"1\" ]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi"
 
 after_failure:
  - php ~/travis-support/travis_upload_artifacts.php --if-env BEHAT_TEST,ARTIFACTS_BUCKET,ARTIFACTS_KEY,ARTIFACTS_SECRET --target-path $TRAVIS_REPO_SLUG/$TRAVIS_BUILD_ID/$TRAVIS_JOB_ID --artifacts-base-url https://s3.amazonaws.com/$ARTIFACTS_BUCKET/

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_script:
  - composer self-update || true
  - phpenv rehash
  - phpenv config-rm xdebug.ini
+ - echo 'memory_limit = 2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
  - composer install --prefer-dist
  - "if [ \"$DB\" = \"PGSQL\" ]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi"
  - "if [ \"$DB\" = \"SQLITE\" ]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,3 @@
-<!--
-	PHPUnit configuration for SilverStripe
-
-	Requires PHPUnit 3.5+
-
-	Usage:
-	 - "phpunit": Runs all tests in all folders
-	 - "phpunit framework/tests/": Run all tests of the framework module
-	 - "phpunit framework/tests/filesystem": Run all filesystem tests within the framework module
-	 - "phpunit framework/tests/filesystem/FolderTest.php": Run a single test
-	 - "phpunit <dash><dash>coverage-html assets/": Generate coverage report (replace <dash> with "-", requires xdebug)
-
-	More information:
-	- http://www.phpunit.de/manual/current/en/textui.html
-	- http://doc.silverstripe.org/framework/en/topics/testing/#configuration
-
-	It is safe to remove this file for normal website operation.
--->
 <phpunit bootstrap="tests/bootstrap.php" colors="true">
 
 	<testsuite name="Default">
@@ -25,12 +7,6 @@
 	<listeners>
 		<listener class="SilverStripe\Dev\TestListener" />
 	</listeners>
-
-	<groups>
-		<exclude>
-			<group>sanitychecks</group>
-		</exclude>
-	</groups>
 
 	<filter>
 		<whitelist addUncoveredFilesFromWhitelist="true">

--- a/tests/controller/ContentControllerTest.php
+++ b/tests/controller/ContentControllerTest.php
@@ -145,7 +145,7 @@ class ContentControllerTest extends FunctionalTest {
 	/**
 	 * Tests that {@link ContentController::getViewer()} chooses the correct templates.
 	 *
-	 * @covers ContentController::getViewer()
+	 * @covers SilverStripe\CMS\Controllers\ContentController::getViewer()
 	**/
 	public function testGetViewer() {
 

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -838,7 +838,7 @@ class SiteTreeTest extends SapphireTest {
 	}
 
 	/**
-	 * @covers SiteTree::validURLSegment
+	 * @covers SilverStripe\CMS\Model\SiteTree::validURLSegment
 	 */
 	public function testValidURLSegmentURLSegmentConflicts() {
 		$sitetree = new SiteTree();
@@ -869,7 +869,7 @@ class SiteTreeTest extends SapphireTest {
 	}
 
 	/**
-	 * @covers SiteTree::validURLSegment
+	 * @covers SilverStripe\CMS\Model\SiteTree::validURLSegment
 	 */
 	public function testValidURLSegmentClassNameConflicts() {
 		$sitetree = new SiteTree();
@@ -879,7 +879,7 @@ class SiteTreeTest extends SapphireTest {
 	}
 
 	/**
-	 * @covers SiteTree::validURLSegment
+	 * @covers SilverStripe\CMS\Model\SiteTree::validURLSegment
 	 */
 	public function testValidURLSegmentControllerConflicts() {
 		Config::inst()->update('SilverStripe\\CMS\\Model\\SiteTree', 'nested_urls', true);


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/pull/6089

Note that the `phpunit.xml.dist` won't apply until we make builds run without `travis-support` (out of scope for this PR). Once that's resolved it'll automatically pick up the PHPUnit defaults set here.
