### PR TITLE
FIX History controller now shows right comparison versions

### DIFF
--- a/code/controllers/CMSPageHistoryController.php
+++ b/code/controllers/CMSPageHistoryController.php
@@ -394,7 +394,7 @@ class CMSPageHistoryController extends CMSMain {
 		}
 
 		if(isset($record)) {
-			$form = $this->getEditForm($id, null, null, true);
+			$form = $this->getEditForm($id, null, $fromVersion, $toVersion);
 			$form->setActions(new FieldList());
 			$form->addExtraClass('compare');
 			


### PR DESCRIPTION
When viewing history comparisons in the CMS the notice would say that you're comparing the current live version to `1` rather than the two versions you'd selected.