### PR TITLE
Correcting an issue where page controller methods

### DIFF
--- a/code/model/ErrorPage.php
+++ b/code/model/ErrorPage.php
@@ -323,22 +323,5 @@ class ErrorPage extends Page {
  * @package cms
  */
 class ErrorPage_Controller extends Page_Controller {
-
-	/**
-	 * Overload the provided {@link Controller::handleRequest()} to append the
-	 * correct status code post request since otherwise permission related error
-	 * pages such as 401 and 403 pages won't be rendered due to
-	  * {@link SS_HTTPResponse::isFinished() ignoring the response body.
-	 *
-	 * @param SS_HTTPRequest $request
-	 * @param DataModel $model
-	 * @return SS_HTTPResponse
-	 */
-	public function handleRequest(SS_HTTPRequest $request, DataModel $model = NULL) {
-		$body = parent::handleRequest($request, $model);
-		$this->getResponse()->setStatusCode($this->ErrorCode);
-
-		return $this->getResponse();
-	}
 }
 

--- a/tests/model/ErrorPageTest.php
+++ b/tests/model/ErrorPageTest.php
@@ -64,13 +64,19 @@ class ErrorPageTest extends FunctionalTest {
 	public function testBehaviourOf403() {
 		$page = $this->objFromFixture('ErrorPage', '403');
 		$page->publish('Stage', 'Live');
-		
-		$response = $this->get($page->RelativeLink());
-		
-		$this->assertEquals($response->getStatusCode(), '403');
-		$this->assertNotNull($response->getBody(), 'We have body text from the error page');
+
+		try {
+			$controller = singleton('ContentController');
+			$controller->httpError(403);
+			$this->fail('Expected exception to be thrown');
+		}
+		catch(SS_HTTPResponse_Exception $e) {
+			$response = $e->getResponse();
+			$this->assertEquals($response->getStatusCode(), '403');
+			$this->assertNotNull($response->getBody(), 'We have body text from the error page');
+		}
 	}
-	
+
 	public function testSecurityError() {
 		// Generate 404 page
 		$page = $this->objFromFixture('ErrorPage', '404');


### PR DESCRIPTION
would end up with the error page response code, causing them to not work. This code only looks to be causing issues from what I can see.

An example is an autocomplete that is populated using a method on page controller. The moment you end up on a 404 error page, the autocomplete will attempt to populate and end up with a 404 response.

---

The only thing I noticed when removing this, is that hitting an error page **directly** ends up with a 200 response code (as opposed to the error page response code). Which is technically correct though, since this page **was** actually found. Hitting a URL that doesn't exist, however, continues to throw a 404.

The current state is quite nasty, and I've noticed it affecting a number of production sites, so it would be good to get this bug corrected across 3.X and 4.X moving forwards. Thoughts?
