### PR TITLE
FIX: Remove unnecessary tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,9 @@ env:
 matrix:
   include:
     - php: 5.5
-      env: DB=MYSQL PHPUNIT_TEST=1
-    - php: 5.5
       env: DB=PGSQL PHPUNIT_TEST=1
-    - php: 5.5
-      env: DB=SQLITE PHPUNIT_TEST=1
     - php: 5.6
-      env: DB=MYSQL PDO=1 PHPUNIT_TEST=1
+      env: DB=MYSQL PHPUNIT_TEST=1
     - php: 5.6
       env: DB=MYSQL BEHAT_TEST=1
     - php: 5.6


### PR DESCRIPTION
Removed two test combinations from our travis builds, to reduce the
testing blockages.
- SQLite isn’t recommended for production and isn’t necessary on every
  PR / build
- We don’t need two separate PDO test runs (php 7 and 5.5)
