### PR TITLE
BUGFIX: Fixed issue on windows where the CMS_DIR constant would be set containing a backslash

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -11,7 +11,7 @@ use SilverStripe\Assets\File;
  */
 define('CMS_PATH', realpath(__DIR__));
 if(strpos(CMS_PATH, BASE_PATH) === 0) {
-	define('CMS_DIR', trim(substr(CMS_PATH, strlen(BASE_PATH)), '/'));
+	define('CMS_DIR', trim(substr(CMS_PATH, strlen(BASE_PATH)), DIRECTORY_SEPARATOR));
 } else {
 	throw new Exception("Path error: CMS_PATH " . CMS_PATH . " not within BASE_PATH " . BASE_PATH);
 }


### PR DESCRIPTION
This pull request fixes an issue found in SilverStripe 4 Alpha 3 where the cms would hard crash on windows because the CMS_DIR constant was being set containing a backslash. This seems to be caused by the trim call having a hard coded forward slash.