### PR TITLE
Removed dud Requirements breaking the RedirectorPage

### DIFF
--- a/code/Model/RedirectorPage.php
+++ b/code/Model/RedirectorPage.php
@@ -6,7 +6,6 @@ use SilverStripe\Forms\HeaderField;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\TreeDropdownField;
-use SilverStripe\View\Requirements;
 use Page;
 
 /**
@@ -139,8 +138,6 @@ class RedirectorPage extends Page {
 	}
 
 	public function getCMSFields() {
-		Requirements::javascript(CMS_DIR . '/client/dist/js/RedirectorPage.js');
-
 		$fields = parent::getCMSFields();
 		$fields->removeByName('Content', true);
 


### PR DESCRIPTION
RedirectorPage has a requirement on a JS file `cms/client/dist/js/RedirectorPage.js` which since has been moved over to `cms/client/dist/js/bundle.js` causing an `InvalidArgumentException`

Removing it fixes the exception, and causes no other issues:

![ss-cms-redirector](https://cloud.githubusercontent.com/assets/377860/20752223/147b0376-b6f8-11e6-9b42-b36e0060869b.gif)
