### PR TITLE
add warning about child pages being unpublished

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2217,6 +2217,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 */
 	public function getCMSActions() {
 		$existsOnLive = $this->getExistsOnLive();
+		$numChildren = count($this->getDescendantIDList());
 
 		// Major actions appear as buttons immediately visible as page actions.
 		$majorActions = CompositeField::create()->setName('MajorActions')->setTag('fieldset')->addExtraClass('ss-ui-buttonset noborder');
@@ -2265,6 +2266,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				FormAction::create('unpublish', _t('SiteTree.BUTTONUNPUBLISH', 'Unpublish'), 'delete')
 					->setDescription(_t('SiteTree.BUTTONUNPUBLISHDESC', 'Remove this page from the published site'))
 					->addExtraClass('ss-ui-action-destructive')
+					->setAttribute('data-num-children', $numChildren)
 			);
 		}
 

--- a/javascript/CMSMain.EditForm.js
+++ b/javascript/CMSMain.EditForm.js
@@ -378,10 +378,18 @@
 			 */
 			onclick: function(e) {
 				var form = this.parents('form:first'), version = form.find(':input[name=Version]').val(), message = '';
-				message = ss.i18n.sprintf(
-					ss.i18n._t('CMSMain.Unpublish'),
-					version
-				);
+				numChildren = this.data('numChildren');
+				if (numChildren === 0) {
+					message = ss.i18n.sprintf(
+						ss.i18n._t('CMSMain.Unpublish'),
+						version
+					);
+				} else {
+					message = ss.i18n.sprintf(
+						ss.i18n._t('CMSMain.UnpublishWithChildren'),
+						numChildren
+					);
+				}
 				if(confirm(message)) {
 					return this._super(e);
 				} else {

--- a/javascript/lang/en.js
+++ b/javascript/lang/en.js
@@ -37,6 +37,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMain.RestoreToRoot": "Are you sure you want to restore this page from archive?\n\nBecause the parent page is not available this will be restored to the top level.",
     "CMSMain.RollbackToVersion": "Do you really want to roll back to version #%s of this page?",
     "CMSMain.Unpublish": "Are you sure you want to remove your page from the published site?\n\nThis page will still be available in the sitetree as draft.",
+    "CMSMain.UnpublishWithChildren": "Warning: removing this page from the published site will also unpublish %s child page(s). Are you sure you want to go ahead?\n\nThese pages will still be available in the sitetree as draft.",
     "Folder.Name": "Folder name",
     "Tree.AddSubPage": "Add new page here",
     "Tree.Duplicate": "Duplicate",


### PR DESCRIPTION
After multiple reports of content authors being unaware that unpublishing a page will unpublish all the children of that page also, this commit will offer a different warning to the user if there are children of the page.

Not sure if I've done the `lang` stuff correctly - any advice would be appreciated.