### PR TITLE
Fixes #980, broken SiteTree icons with namespaced classes

### DIFF
--- a/client/dist/js/bundle.js
+++ b/client/dist/js/bundle.js
@@ -118,7 +118,7 @@ action:function c(n){t(".cms-container").entwine(".ss").loadPanel(r["default"].s
 n.hasClass("nochildren")||(i.showaslist={label:r["default"]._t("Tree.ShowAsList"),action:function u(n){t(".cms-container").entwine(".ss").loadPanel(e.data("urlListview")+"&ParentID="+n.data("id"),null,{
 tabState:{"pages-controller-cms-content":{tabSelector:".content-listview"}}})}})
 var a=n.data("pagetype"),o=n.data("id"),s=n.find(">a .item").data("allowedchildren"),d={},l=!1
-return t.each(s,function(n,i){l=!0,d["allowedchildren-"+n]={label:'<span class="jstree-pageicon"></span>'+i,_class:"class-"+n,action:function a(i){t(".cms-container").entwine(".ss").loadPanel(t.path.addSearchParams(r["default"].sprintf(e.data("urlAddpage"),o,n),e.data("extraParams")))
+return t.each(s,function(n,i){l=!0,d["allowedchildren-"+n]={label:'<span class="jstree-pageicon"></span>'+i,_class:"class-"+n.replace(/\\/g,"-").toLowerCase(),action:function a(i){t(".cms-container").entwine(".ss").loadPanel(t.path.addSearchParams(r["default"].sprintf(e.data("urlAddpage"),o,n),e.data("extraParams")))
 
 }}}),l&&(i.addsubpage={label:r["default"]._t("Tree.AddSubPage","Add page under this page",100,"Used in the context menu when right-clicking on a page node in the CMS tree"),submenu:d}),n.hasClass("edit-disabled")||(i.duplicate={
 label:r["default"]._t("Tree.Duplicate"),submenu:[{label:r["default"]._t("Tree.ThisPageOnly"),action:function h(n){t(".cms-container").entwine(".ss").loadPanel(t.path.addSearchParams(r["default"].sprintf(e.data("urlDuplicate"),n.data("id")),e.data("extraParams")))

--- a/client/src/legacy/CMSMain.Tree.js
+++ b/client/src/legacy/CMSMain.Tree.js
@@ -80,7 +80,7 @@ $.entwine('ss.tree', function($){
 						hasAllowedChildren = true;
 						menuAllowedChildren["allowedchildren-" + klass ] = {
 							'label': '<span class="jstree-pageicon"></span>' + title,
-							'_class': 'class-' + klass,
+							'_class': 'class-' + klass.replace(/\\/g, '-').toLowerCase(),
 							'action': function(obj) {
 								$('.cms-container').entwine('.ss').loadPanel(
 									$.path.addSearchParams(

--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -6,6 +6,7 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Session;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Core\Convert;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
@@ -42,7 +43,7 @@ class CMSPageAddController extends CMSPageEditController {
 		$pageTypes = array();
 		foreach($this->PageTypes() as $type) {
 			$html = sprintf('<span class="page-icon class-%s"></span><span class="title">%s</span><span class="form__field-description">%s</span>',
-				$type->getField('ClassName'),
+				Convert::raw2htmlclass($type->getField('ClassName')),
 				$type->getField('AddAction'),
 				$type->getField('Description')
 			);

--- a/code/Controllers/LeftAndMainPageIconsExtension.php
+++ b/code/Controllers/LeftAndMainPageIconsExtension.php
@@ -4,6 +4,7 @@ namespace SilverStripe\CMS\Controllers;
 
 use SilverStripe\View\Requirements;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Convert;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Extension;
 
@@ -42,6 +43,7 @@ class LeftAndMainPageIconsExtension extends Extension {
 				$iconFile .= '-file.gif';
 			}
 
+			$class = Convert::raw2htmlclass($class);
 			$selector = ".page-icon.class-$class, li.class-$class > a .jstree-pageicon";
 
 			if(Director::fileExists($iconFile)) {

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2746,7 +2746,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	 * @return string
 	 */
 	public function CMSTreeClasses($numChildrenMethod="numChildren") {
-		$classes = sprintf('class-%s', static::class);
+		$classes = sprintf('class-%s', Convert::raw2htmlclass(static::class));
 		if($this->HasBrokenFile || $this->HasBrokenLink) {
 			$classes .= " BrokenLink";
 		}


### PR DESCRIPTION
This PR fixes issue #980 whereby namespaced `SiteTree` subclasses are not showing the icons defined within their `private static $icon`.  This was due to unescaped class names (with namespaces) being output into HTML.  CSS no likey the backslashes. 😉 

**NOTE:** a dependency for this PR was added to `SilverStripe\Core\Convert` within `silverstripe/silverstripe-framework`, please see PR silverstripe/silverstripe-framework#6462.