### PR TITLE
Fixes #1512

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and [installation from source](http://doc.silverstripe.org/framework/en/installa
 
 ## Bugtracker ##
 
-Bugs are tracked on [github.com](https://github.com/silverstripe/silverstripe-cms/issues). 
+Bugs are tracked on [github.com](https://github.com/silverstripe/silverstripe-cms/issues).
 Please read our [issue reporting guidelines](http://doc.silverstripe.org/framework/en/misc/contributing/issues).
 
 ## Development and Contribution ##
@@ -35,3 +35,8 @@ If you would like to make changes to the SilverStripe core codebase, we have an 
  * [Bugtracker: Installer](https://github.com/silverstripe/silverstripe-installer/issues)
  * [Forums](http://silverstripe.org/forums)
  * [Developer Mailinglist](https://groups.google.com/forum/#!forum/silverstripe-dev)
+
+## Archive warning message change ##
+
+Old archive message: 'Are you sure you want to archive this page and all of its children pages? This page and all of its children will be unpublished and sent to the archive.'
+New archive message: 'Are you sure you want to archive this page? This page will be unpublished and sent to the archive, any children will be orphaned.'

--- a/client/dist/styles/bundle.css
+++ b/client/dist/styles/bundle.css
@@ -64,7 +64,7 @@
 }
 
 .field.urlsegment.loading{
-  background:url(../images/loading.gif) no-repeat 162px 8px;
+  background:url(../images/loading.gif) no-repeat 154px 8px;
 }
 
 .field.urlsegment .URL-link{

--- a/client/lang/ar.js
+++ b/client/lang/ar.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "يرجى تحديد صفحة واحدة على الأقل.",
     "CMSMAIN.URLSEGMENTVALIDATION": "يمكن تكوين عناوين URL من أحرف وأرقام وواصلات فقط.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "يجب عليك حفظ إحدى الصفحات قبل إضافة أطفال تحته",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/bg.js
+++ b/client/lang/bg.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Please select at least 1 page.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs can only be made up of letters, digits and hyphens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "You have to save a page before adding children underneath it",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/en.js
+++ b/client/lang/en.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Please select at least 1 page.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs can only be made up of letters, digits and hyphens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "You have to save a page before adding children underneath it",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/fr.js
+++ b/client/lang/fr.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Veuillez sélectionner au moins une page.",
     "CMSMAIN.URLSEGMENTVALIDATION": "Les URL ne peuvent être composées que de lettres, chiffres ou tirets.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Vous devez sauvegarder la page avant d'y ajouter des enfants",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/hu.js
+++ b/client/lang/hu.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Válasszon legalább 1 oldalt!",
     "CMSMAIN.URLSEGMENTVALIDATION": "Az URL csak betüket, számokat illetve kötőjelet (\"-\") tartalmazhat",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Aloldalt csak a szülő-oldal mentését követően hozhat létre",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/id.js
+++ b/client/lang/id.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Mohon pilih minimal 1 laman.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL hanya boleh terdiri dari huruf, angka dan tanda sambung.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Anda harus menyimpan laman sebelum menambahkan laman turunan.",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/is.js
+++ b/client/lang/is.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Please select at least 1 page.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs can only be made up of letters, digits and hyphens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Þú verður að vista síðuna áður bætt er við einhverju undir hana",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/ja.js
+++ b/client/lang/ja.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "最低でも1ページ選択してください．",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLはアルファベットの文字か数値，及びハイフンのみから構成されます．",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "子ページを追加する前に，そのページを保存する必要があります．",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/ko.js
+++ b/client/lang/ko.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "최소한 1 페이지 선택하십시오.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL은 알파벳 문자나 숫자, 하이픈만으로 구성됩니다.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "하위 페이지를 추가하기 전에 페이지를 저장해야합니다.",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/mi.js
+++ b/client/lang/mi.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Kōwhiria kotahi whārangi i te iti rawa.",
     "CMSMAIN.URLSEGMENTVALIDATION": "Ka taea anake ngā pūāhua, ngā mati me ngā tohuhono i ngā PRO.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Me tiaki i te whārangi i mua i te tāpiri tamariki ki raro",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/nb.js
+++ b/client/lang/nb.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Vennligst velg minst én side.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs can only be made up of letters, digits and hyphens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Du må lagre siden før du kan legge til undersider.",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/nl.js
+++ b/client/lang/nl.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Selecteer minstens 1 pagina.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs kunnen alleen bestaan uit letters, cijfers en koppeltekens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "U moet de pagina opslaan voordat u onderliggende pagina's kan toevoegen",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/pl.js
+++ b/client/lang/pl.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Proszę wybrać przynajmniej jedną stronę",
     "CMSMAIN.URLSEGMENTVALIDATION": "Adres URL może składać się tylko z liter, cyfr i łączników.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Należy najpierw zapisać stronę, aby móc dodać strony podrzędne",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/ro.js
+++ b/client/lang/ro.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Vă rugăm să selectaţi cel puțin 1 pagină.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL-uri pot conţine doar litere, cifre și cratime.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Trebuie să salvați o pagină înainte de a adăuga copii sub aceasta",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/sl.js
+++ b/client/lang/sl.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Izberite vsaj 1 stran",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL-ji lahko vsebujejo le alfanumerične znake in pomišljaje.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Stran je potrebno shraniti pred dodajanjem otrok",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/sr.js
+++ b/client/lang/sr.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Молимо Вас да изаберете бар 1 страницу.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL-ови могу садржати само слова, бројеве и повлаке.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Морате снимити страницу пре него што јој можете додати подстранице",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/sr_RS@latin.js
+++ b/client/lang/sr_RS@latin.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "Molimo Vas da izaberete bar 1 stranicu.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL-ovi mogu sadržati samo slova, brojeve i povlake.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Morate snimiti stranicu pre nego što joj možete dodati podstranice",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/ar.js
+++ b/client/lang/src/ar.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "يرجى تحديد صفحة واحدة على الأقل.",
     "CMSMAIN.URLSEGMENTVALIDATION": "يمكن تكوين عناوين URL من أحرف وأرقام وواصلات فقط.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "يجب عليك حفظ إحدى الصفحات قبل إضافة أطفال تحته",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/bg.js
+++ b/client/lang/src/bg.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Please select at least 1 page.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs can only be made up of letters, digits and hyphens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "You have to save a page before adding children underneath it",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/en.js
+++ b/client/lang/src/en.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Please select at least 1 page.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs can only be made up of letters, digits and hyphens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "You have to save a page before adding children underneath it",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/fr.js
+++ b/client/lang/src/fr.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Veuillez sélectionner au moins une page.",
     "CMSMAIN.URLSEGMENTVALIDATION": "Les URL ne peuvent être composées que de lettres, chiffres ou tirets.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Vous devez sauvegarder la page avant d'y ajouter des enfants",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/hu.js
+++ b/client/lang/src/hu.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Válasszon legalább 1 oldalt!",
     "CMSMAIN.URLSEGMENTVALIDATION": "Az URL csak betüket, számokat illetve kötőjelet (\"-\") tartalmazhat",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Aloldalt csak a szülő-oldal mentését követően hozhat létre",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/id.js
+++ b/client/lang/src/id.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Mohon pilih minimal 1 laman.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL hanya boleh terdiri dari huruf, angka dan tanda sambung.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Anda harus menyimpan laman sebelum menambahkan laman turunan.",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/is.js
+++ b/client/lang/src/is.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Please select at least 1 page.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs can only be made up of letters, digits and hyphens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Þú verður að vista síðuna áður bætt er við einhverju undir hana",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/ja.js
+++ b/client/lang/src/ja.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "最低でも1ページ選択してください．",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLはアルファベットの文字か数値，及びハイフンのみから構成されます．",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "子ページを追加する前に，そのページを保存する必要があります．",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/ko.js
+++ b/client/lang/src/ko.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "최소한 1 페이지 선택하십시오.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL은 알파벳 문자나 숫자, 하이픈만으로 구성됩니다.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "하위 페이지를 추가하기 전에 페이지를 저장해야합니다.",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/mi.js
+++ b/client/lang/src/mi.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Kōwhiria kotahi whārangi i te iti rawa.",
     "CMSMAIN.URLSEGMENTVALIDATION": "Ka taea anake ngā pūāhua, ngā mati me ngā tohuhono i ngā PRO.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Me tiaki i te whārangi i mua i te tāpiri tamariki ki raro",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/nb.js
+++ b/client/lang/src/nb.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Vennligst velg minst én side.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs can only be made up of letters, digits and hyphens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Du må lagre siden før du kan legge til undersider.",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/nl.js
+++ b/client/lang/src/nl.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Selecteer minstens 1 pagina.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URLs kunnen alleen bestaan uit letters, cijfers en koppeltekens.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "U moet de pagina opslaan voordat u onderliggende pagina's kan toevoegen",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/pl.js
+++ b/client/lang/src/pl.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Proszę wybrać przynajmniej jedną stronę",
     "CMSMAIN.URLSEGMENTVALIDATION": "Adres URL może składać się tylko z liter, cyfr i łączników.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Należy najpierw zapisać stronę, aby móc dodać strony podrzędne",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/ro.js
+++ b/client/lang/src/ro.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Vă rugăm să selectaţi cel puțin 1 pagină.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL-uri pot conţine doar litere, cifre și cratime.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Trebuie să salvați o pagină înainte de a adăuga copii sub aceasta",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/sl.js
+++ b/client/lang/src/sl.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Izberite vsaj 1 stran",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL-ji lahko vsebujejo le alfanumerične znake in pomišljaje.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Stran je potrebno shraniti pred dodajanjem otrok",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/sr.js
+++ b/client/lang/src/sr.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Молимо Вас да изаберете бар 1 страницу.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL-ови могу садржати само слова, бројеве и повлаке.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Морате снимити страницу пре него што јој можете додати подстранице",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/sr_RS@latin.js
+++ b/client/lang/src/sr_RS@latin.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "Molimo Vas da izaberete bar 1 stranicu.",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL-ovi mogu sadržati samo slova, brojeve i povlake.",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "Morate snimiti stranicu pre nego što joj možete dodati podstranice",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/src/zh.js
+++ b/client/lang/src/zh.js
@@ -23,7 +23,7 @@
     "CMSMAIN.SELECTONEPAGE": "请至少选择 1 个页面。",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL 仅能由字母、数字和连字符组成。",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "将儿童添加在下面之前，您必须保存一个页面",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/lang/zh.js
+++ b/client/lang/zh.js
@@ -30,7 +30,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "CMSMAIN.SELECTONEPAGE": "请至少选择 1 个页面。",
     "CMSMAIN.URLSEGMENTVALIDATION": "URL 仅能由字母、数字和连字符组成。",
     "CMSMAIN.WARNINGSAVEPAGESBEFOREADDING": "将儿童添加在下面之前，您必须保存一个页面",
-    "CMSMain.Archive": "Are you sure you want to archive this page and all of its children pages?\n\nThis page and all of its children will be unpublished and sent to the archive.",
+    "CMSMain.Archive": "Are you sure you want to archive this page?\n\nThis page will be unpublished and sent to the archive, any children will be orphaned.",
     "CMSMain.ConfirmRestoreFromLive": "Are you sure you want to revert draft to when the page was last published?",
     "CMSMain.DeleteFromDraft": "Are you sure you want to remove your page from the draft site?\n\nThis page will remain on the published site.",
     "CMSMain.Restore": "Are you sure you want to restore this page from archive?",

--- a/client/src/styles/legacy/_CMSMain.scss
+++ b/client/src/styles/legacy/_CMSMain.scss
@@ -107,7 +107,7 @@
 .field.urlsegment {
 
 	&.loading {
-		background: url(../../images/loading.gif) no-repeat 162px 8px;
+		background: url(../../images/loading.gif) no-repeat 154px 8px;		
 	}
 
 	.URL-link {


### PR DESCRIPTION
This changes the archive warning message which previously didn't mention that archiving a page doesn't make any changes to the children when ```enforce_strict_hierarchy``` is set to false.