### PR TITLE
Changed init() visibility to protected

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -141,7 +141,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 		'SiteTreeAsUL' => 'HTMLFragment',
 	);
 
-	public function init() {
+	protected function init() {
 		// set reading lang
 		if(SiteTree::has_extension('Translatable') && !$this->getRequest()->isAjax()) {
 			Translatable::choose_site_locale(array_keys(Translatable::get_existing_content_languages('SilverStripe\\CMS\\Model\\SiteTree')));

--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -122,7 +122,7 @@ class ContentController extends Controller {
 		return SiteTree::get_by_link($link);
 	}
 
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		// If we've accessed the homepage as /home/, then we should redirect to /.

--- a/code/Controllers/ModelAsController.php
+++ b/code/Controllers/ModelAsController.php
@@ -46,7 +46,7 @@ class ModelAsController extends Controller implements NestedController {
 		return Injector::inst()->create($controller, $sitetree);
 	}
 
-	public function init() {
+	protected function init() {
 		singleton('SilverStripe\\CMS\\Model\\SiteTree')->extend('modelascontrollerInit', $this);
 		parent::init();
 	}

--- a/code/Model/RedirectorPageController.php
+++ b/code/Model/RedirectorPageController.php
@@ -9,7 +9,7 @@ use PageController;
 class RedirectorPageController extends PageController
 {
 
-	public function init()
+	protected function init()
 	{
 		parent::init();
 

--- a/code/Tasks/RemoveOrphanedPagesTask.php
+++ b/code/Tasks/RemoveOrphanedPagesTask.php
@@ -64,7 +64,7 @@ in the other stage:<br />
 
 	protected $orphanedSearchClass = 'SilverStripe\\CMS\\Model\\SiteTree';
 
-	public function init() {
+	protected function init() {
 		parent::init();
 
 		if(!Permission::check('ADMIN')) {


### PR DESCRIPTION
`Controller` has had it's `init()` method changed to `protected`, updating `Controller` subclasses in CMS to follow suit.