### PR TITLE
API Add getFrontendControllerName - allows the controller to be configurable

### DIFF
--- a/code/Controllers/ModelAsController.php
+++ b/code/Controllers/ModelAsController.php
@@ -37,7 +37,7 @@ class ModelAsController extends Controller implements NestedController {
 	 * @return ContentController
 	 */
 	public static function controller_for(SiteTree $sitetree, $action = null) {
-		$controller = $sitetree->getControllerName();
+		$controller = $sitetree->getFrontendControllerName();
 
 		if ($action && class_exists($controller . '_' . ucfirst($action))) {
 			$controller = $controller . '_' . ucfirst($action);

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -242,6 +242,15 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 	private static $icon = null;
 
 	/**
+	 * Specify the fully qualfied class name for this model's controller. If not provided, the default behaviour
+	 * will be used (Fully\Qualified\PageController)
+	 *
+	 * @config
+	 * @var string
+	 */
+	private static $frontend_controller = null;
+
+	/**
 	 * @config
 	 * @var string Description of the class functionality, typically shown to a user
 	 * when selecting which page type to create. Translated through {@link provideI18nEntities()}.
@@ -2752,6 +2761,21 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 
 		return $controller;
+	}
+
+	/**
+	 * Find the frontend controller name, which can be the current fully qualified class name
+	 * with Controller or _Controller added to it within the same namespace, or a customised
+	 * filename as per the $frontend_controller configuration option.
+	 *
+	 * @return string
+	 */
+	public function getFrontendControllerName()
+	{
+		if ($customController = $this->config()->frontend_controller) {
+			return (string) $customController;
+		}
+		return $this->getControllerName();
 	}
 
 	/**

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -455,4 +455,16 @@ class VirtualPage extends Page {
 		return parent::getControllerName();
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getFrontendControllerName()
+	{
+		if ($copy = $this->CopyContentFrom()) {
+			return $copy->getFrontendControllerName();
+		}
+
+		return parent::getFrontendControllerName();
+	}
+
 }

--- a/tests/model/SiteTreeTest.php
+++ b/tests/model/SiteTreeTest.php
@@ -1351,6 +1351,21 @@ class SiteTreeTest extends SapphireTest {
 		$this->assertSame('SiteTreeTest_LegacyControllerName_Controller', $class->getControllerName());
 	}
 
+	/**
+	 * Test that the frontend controller name can be customised with configuration, or fall back to the default
+	 */
+	public function testGetFrontendControllerName()
+	{
+		Config::nest();
+
+		$customController = 'Vendor\\Package\\Controllers\\PageController';
+		Config::inst()->update(Page::class, 'frontend_controller', $customController);
+		$this->assertSame($customController, (new Page)->getFrontendControllerName());
+
+		Config::unnest();
+		$this->assertSame(PageController::class, (new Page)->getFrontendControllerName());
+	}
+
 }
 
 /**#@+


### PR DESCRIPTION
This change will allow developers to set a configuration value for `frontend_controller` on a `SiteTree` instance to tell it to use a custom controller class, e.g. `Whatever\You\Want`.

If will fall back to the default behaviour if the config static is not set.

Resolves silverstripe/silverstripe-framework#6549 and resolves #1721 