### PR TITLE
Fix error when uploading file and ASSETS_DIR is a subdirectory

### DIFF
--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -73,7 +73,7 @@ class CMSFileAddController extends LeftAndMain {
 
 		if($folder->exists() && $folder->getFilename()) {
 			// The Upload class expects a folder relative *within* assets/
-			$path = preg_replace('/^' . ASSETS_DIR . '\//', '', $folder->getFilename());
+			$path = preg_replace('/^' . preg_quote(ASSETS_DIR, '/') . '\//', '', $folder->getFilename());
 			$uploadField->setFolderName($path);
 		} else {
 			$uploadField->setFolderName('/'); // root of the assets


### PR DESCRIPTION
When uploading files and the ASSETS_DIR directory is a subdirectory, for example `assets/site1`. The slash was being included as a part of the regex statement making it invalid. Adding a preg_quote command has escaped special characters as well as the forward slash.