### PR TITLE
Add dependency on admin module

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -4,7 +4,7 @@ namespace SilverStripe\CMS\Controllers;
 
 use SilverStripe\Admin\AdminRootController;
 use SilverStripe\Admin\CMSBatchActionHandler;
-use SilverStripe\Admin\CMSPreviewable;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\CMS\BatchActions\CMSBatchAction_Archive;
 use SilverStripe\CMS\BatchActions\CMSBatchAction_Publish;

--- a/code/Controllers/SilverStripeNavigator.php
+++ b/code/Controllers/SilverStripeNavigator.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\CMS\Controllers;
 
-use SilverStripe\Admin\CMSPreviewable;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
@@ -23,12 +23,12 @@ class SilverStripeNavigator extends ViewableData
 {
 
     /**
-     * @var DataObject|CMSPreviewable
+     * @var DataObject|\SilverStripe\ORM\CMSPreviewable
      */
     protected $record;
 
     /**
-     * @param DataObject|CMSPreviewable $record
+     * @param DataObject|\SilverStripe\ORM\CMSPreviewable $record
      */
     public function __construct(CMSPreviewable $record)
     {
@@ -71,7 +71,7 @@ class SilverStripeNavigator extends ViewableData
     }
 
     /**
-     * @return DataObject|CMSPreviewable
+     * @return DataObject|\SilverStripe\ORM\CMSPreviewable
      */
     public function getRecord()
     {

--- a/code/Controllers/SilverStripeNavigatorItem.php
+++ b/code/Controllers/SilverStripeNavigatorItem.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\CMS\Controllers;
 
-use SilverStripe\Admin\CMSPreviewable;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\Versioning\Versioned;
 use SilverStripe\Security\Member;

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -4,7 +4,7 @@ namespace SilverStripe\CMS\Model;
 
 use Page;
 use SilverStripe\Admin\AddToCampaignHandler_FormAction;
-use SilverStripe\Admin\CMSPreviewable;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
 use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\CMS\Controllers\ModelAsController;

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "php": ">=5.5.0",
     "composer/installers": "*",
     "silverstripe/framework": "^4.0@dev",
+    "silverstripe/admin": "^1.0@dev",
     "silverstripe/reports": "^4.0@dev",
     "silverstripe/siteconfig": "^4.0@dev"
   },


### PR DESCRIPTION
Requires https://github.com/silverstripe/silverstripe-framework/pull/6695

We had to move CMSPreviewable to framework module, as otherwise framework classes couldn't inherit it without directly requiring admin module (undesirable).