### PR TITLE
Remove extraneous gitignore declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,5 @@
-.sass-cache
-.DS_Store
 node_modules
-framework
-siteconfig
-reports
-testsession
 silverstripe-cache
 vendor
 /**/*.js.map
 /**/*.css.map
-


### PR DESCRIPTION
This was causing the https://github.com/silverstripe/silverstripe-cms/tree/master/code/Reports folder to appear as ignored (in some IDE). Modules aren't normally installed within CMS dir, so removing these from gitignore.