### PR TITLE
BUG Ensure all CMS forms include full ID / VersionID in path

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -62,3 +62,4 @@ mappings:
   MigrateSiteTreeLinkingTask: SilverStripe\CMS\Tasks\MigrateSiteTreeLinkingTask
   RemoveOrphanedPagesTask: SilverStripe\CMS\Tasks\RemoveOrphanedPagesTask
   SiteTreeMaintenanceTask: SilverStripe\CMS\Tasks\SiteTreeMaintenanceTask
+  LeftAndMain_TreeNode: SilverStripe\CMS\Controllers\CMSTreeNode

--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -16,7 +16,6 @@ use SilverStripe\Forms\SelectionGroup_Item;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\ORM\ValidationException;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;

--- a/code/Controllers/CMSPageHistoryController.php
+++ b/code/Controllers/CMSPageHistoryController.php
@@ -2,20 +2,20 @@
 
 namespace SilverStripe\CMS\Controllers;
 
+use SilverStripe\Admin\LeftAndMainFormRequestHandler;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Forms\CheckboxField;
-use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\HTMLReadonlyField;
 use SilverStripe\Forms\LiteralField;
+use SilverStripe\Forms\Tab;
 use SilverStripe\ORM\FieldType\DBField;
-use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Security\Security;
 use SilverStripe\View\ArrayData;
@@ -35,6 +35,7 @@ class CMSPageHistoryController extends CMSMain
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 
     private static $allowed_actions = array(
+        'EditForm',
         'VersionsForm',
         'CompareVersionsForm',
         'show',
@@ -42,15 +43,23 @@ class CMSPageHistoryController extends CMSMain
     );
 
     private static $url_handlers = array(
-        '$Action/$ID/$VersionID/$OtherVersionID' => 'handleAction'
+        '$Action/$ID/$VersionID/$OtherVersionID' => 'handleAction',
+        'EditForm/$ID/$VersionID' => 'EditForm',
     );
+
+    /**
+     * Current version ID for this request. Can be 0 for latest version
+     *
+     * @var int
+     */
+    protected $versionID = null;
 
     public function getResponseNegotiator()
     {
         $negotiator = parent::getResponseNegotiator();
         $controller = $this;
         $negotiator->setCallback('CurrentForm', function () use (&$controller) {
-            $form = $controller->ShowVersionForm($controller->getRequest()->param('VersionID'));
+            $form = $controller->getEditForm();
             if ($form) {
                 return $form->forTemplate();
             } else {
@@ -65,19 +74,30 @@ class CMSPageHistoryController extends CMSMain
 
     /**
      * @param HTTPRequest $request
-     * @return array
+     * @return HTTPResponse
      */
     public function show($request)
     {
-        $form = $this->ShowVersionForm($request->param('VersionID'));
+        // Record id and version for this request
+        $id = $request->param('ID');
+        $this->setCurrentPageID($id);
+        $versionID = $request->param('VersionID');
+        $this->setVersionID($versionID);
+
+        // Show id
+        $form = $this->getEditForm();
 
         $negotiator = $this->getResponseNegotiator();
         $controller = $this;
         $negotiator->setCallback('CurrentForm', function () use (&$controller, &$form) {
-            return $form ? $form->forTemplate() : $controller->renderWith($controller->getTemplatesWithSuffix('_Content'));
+            return $form
+                ? $form->forTemplate()
+                : $controller->renderWith($controller->getTemplatesWithSuffix('_Content'));
         });
         $negotiator->setCallback('default', function () use (&$controller, &$form) {
-            return $controller->customise(array('EditForm' => $form))->renderWith($controller->getViewer('show'));
+            return $controller
+                ->customise(array('EditForm' => $form))
+                ->renderWith($controller->getViewer('show'));
         });
 
         return $negotiator->respond($request);
@@ -85,7 +105,7 @@ class CMSPageHistoryController extends CMSMain
 
     /**
      * @param HTTPRequest $request
-     * @return array
+     * @return HTTPResponse
      */
     public function compare($request)
     {
@@ -118,6 +138,24 @@ class CMSPageHistoryController extends CMSMain
     }
 
     /**
+     * @param HTTPRequest $request
+     * @return Form
+     */
+    public function EditForm($request = null)
+    {
+        if ($request) {
+            // Validate VersionID is present
+            $versionID = $request->param('VersionID');
+            if (!isset($versionID)) {
+                $this->httpError(400);
+                return null;
+            }
+            $this->setVersionID($versionID);
+        }
+        return parent::EditForm($request);
+    }
+
+    /**
      * Returns the read only version of the edit form. Detaches all {@link FormAction}
      * instances attached since only action relates to revert.
      *
@@ -135,11 +173,21 @@ class CMSPageHistoryController extends CMSMain
         if (!$id) {
             $id = $this->currentPageID();
         }
+        if (!$versionID) {
+            $versionID = $this->getVersionID();
+        }
 
         $record = $this->getRecord($id, $versionID);
-        $versionID = ($record) ? $record->Version : $versionID;
+        if (!$record) {
+            return $this->EmptyForm();
+        }
 
-        $form = parent::getEditForm($record, ($record) ? $record->getCMSFields() : null);
+        // Refresh version ID
+        $versionID = $record->Version;
+        $this->setVersionID($versionID);
+
+        // Get edit form
+        $form = parent::getEditForm($record, $record->getCMSFields());
         // Respect permission failures from parent implementation
         if (!($form instanceof Form)) {
             return $form;
@@ -148,9 +196,14 @@ class CMSPageHistoryController extends CMSMain
         // TODO: move to the SilverStripeNavigator structure so the new preview can pick it up.
         //$nav = new SilverStripeNavigatorItem_ArchiveLink($record);
 
-        $form->setActions(new FieldList(
-            $revert = FormAction::create('doRollback', _t('CMSPageHistoryController.REVERTTOTHISVERSION', 'Revert to this version'))->setUseButtonTag(true)
-        ));
+        $actions = new FieldList(
+            $revert = FormAction::create(
+                'doRollback',
+                _t('CMSPageHistoryController.REVERTTOTHISVERSION', 'Revert to this version')
+            )->setUseButtonTag(true)
+        );
+        $actions->setForm($form);
+        $form->setActions($actions);
 
         $fields = $form->Fields();
         $fields->removeByName("Status");
@@ -189,7 +242,9 @@ class CMSPageHistoryController extends CMSMain
             }
         }
 
-        $fields->fieldByName('Root.Main')->unshift(
+        /** @var Tab $mainTab */
+        $mainTab = $fields->fieldByName('Root.Main');
+        $mainTab->unshift(
             new LiteralField('CurrentlyViewingMessage', ArrayData::create(array(
                 'Content' => DBField::create_field('HTMLFragment', $message),
                 'Classes' => 'notice'
@@ -202,11 +257,16 @@ class CMSPageHistoryController extends CMSMain
             "Version" => $versionID,
         ));
 
-        if (($record && $record->isLatestVersion())) {
+        if ($record->isLatestVersion()) {
             $revert->setReadonly(true);
         }
 
         $form->removeExtraClass('cms-content');
+
+        // History form has both ID and VersionID as suffixes
+        $form->setRequestHandler(
+            LeftAndMainFormRequestHandler::create($form, [$id, $versionID])
+        );
 
         return $form;
     }
@@ -276,28 +336,11 @@ class CMSPageHistoryController extends CMSMain
             $hiddenID = new HiddenField('ID', false, "")
         );
 
-        $actions = new FieldList(
-            new FormAction(
-                'doCompare',
-                _t('CMSPageHistoryController.COMPAREVERSIONS', 'Compare Versions')
-            ),
-            new FormAction(
-                'doShowVersion',
-                _t('CMSPageHistoryController.SHOWVERSION', 'Show Version')
-            )
-        );
-
-        // Use <button> to allow full jQuery UI styling
-        foreach ($actions->dataFields() as $action) {
-            /** @var FormAction $action */
-            $action->setUseButtonTag(true);
-        }
-
         $form = Form::create(
             $this,
             'VersionsForm',
             $fields,
-            $actions
+            new FieldList()
         )->setHTMLID('Form_VersionsForm');
         $form->loadDataFrom($this->getRequest()->requestVars());
         $hiddenID->setValue($id);
@@ -307,97 +350,6 @@ class CMSPageHistoryController extends CMSMain
             ->addExtraClass('cms-versions-form') // placeholder, necessary for $.metadata() to work
             ->setAttribute('data-link-tmpl-compare', Controller::join_links($this->Link('compare'), '%s', '%s', '%s'))
             ->setAttribute('data-link-tmpl-show', Controller::join_links($this->Link('show'), '%s', '%s'));
-
-        return $form;
-    }
-
-    /**
-     * Process the {@link VersionsForm} compare function between two pages.
-     *
-     * @param array $data
-     * @param Form $form
-     * @return HTTPResponse|DBHTMLText
-     */
-    public function doCompare($data, $form)
-    {
-        $versions = $data['Versions'];
-        if (count($versions) < 2) {
-            return null;
-        }
-
-        $version1 = array_shift($versions);
-        $version2 = array_shift($versions);
-
-        $form = $this->CompareVersionsForm($version1, $version2);
-
-        // javascript solution, render into template
-        if ($this->getRequest()->isAjax()) {
-            return $this->customise(array(
-                "EditForm" => $form
-            ))->renderWith(array(
-                static::class . '_EditForm',
-                'LeftAndMain_Content'
-            ));
-        }
-
-        // non javascript, redirect the user to the page
-        return $this->redirect(Controller::join_links(
-            $this->Link('compare'),
-            $version1,
-            $version2
-        ));
-    }
-
-    /**
-     * Process the {@link VersionsForm} show version function. Only requires
-     * one page to be selected.
-     *
-     * @param array
-     * @param Form
-     *
-     * @return DBHTMLText|HTTPResponse
-     */
-    public function doShowVersion($data, $form)
-    {
-        $versionID = null;
-
-        if (isset($data['Versions']) && is_array($data['Versions'])) {
-            $versionID  = array_shift($data['Versions']);
-        }
-
-        if (!$versionID) {
-            return null;
-        }
-
-        $request = $this->getRequest();
-        if ($request->isAjax()) {
-            return $this->customise(array(
-                "EditForm" => $this->ShowVersionForm($versionID)
-            ))->renderWith(array(
-                static::class . '_EditForm',
-                'LeftAndMain_Content'
-            ));
-        }
-
-        // non javascript, redirect the user to the page
-        return $this->redirect(Controller::join_links(
-            $this->Link('version'),
-            $versionID
-        ));
-    }
-
-    /**
-     * @param int|null $versionID
-     * @return Form
-     */
-    public function ShowVersionForm($versionID = null)
-    {
-        if (!$versionID) {
-            return null;
-        }
-
-        $id = $this->currentPageID();
-        $form = $this->getEditForm($id, null, $versionID);
 
         return $form;
     }
@@ -434,8 +386,8 @@ class CMSPageHistoryController extends CMSMain
             $record = $page->compareVersions($fromVersion, $toVersion);
         }
 
-        $fromVersionRecord = Versioned::get_version('SilverStripe\\CMS\\Model\\SiteTree', $id, $fromVersion);
-        $toVersionRecord = Versioned::get_version('SilverStripe\\CMS\\Model\\SiteTree', $id, $toVersion);
+        $fromVersionRecord = Versioned::get_version(SiteTree::class, $id, $fromVersion);
+        $toVersionRecord = Versioned::get_version(SiteTree::class, $id, $toVersion);
 
         if (!$fromVersionRecord) {
             user_error("Can't find version $fromVersion of page $id", E_USER_ERROR);
@@ -489,5 +441,27 @@ class CMSPageHistoryController extends CMSMain
             $fields->replaceField($field->getName(), $newField);
         }
         return $fields;
+    }
+
+    /**
+     * Set current version ID
+     *
+     * @param int $versionID
+     * @return $this
+     */
+    public function setVersionID($versionID)
+    {
+        $this->versionID = $versionID;
+        return $this;
+    }
+
+    /**
+     * Get current version ID
+     *
+     * @return int
+     */
+    public function getVersionID()
+    {
+        return $this->versionID;
     }
 }

--- a/code/Controllers/CMSSiteTreeFilter.php
+++ b/code/Controllers/CMSSiteTreeFilter.php
@@ -5,9 +5,9 @@ namespace SilverStripe\CMS\Controllers;
 use SilverStripe\Admin\LeftAndMain_SearchFilter;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Forms\DateField;
 use SilverStripe\ORM\DataList;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Versioned\Versioned;
 
@@ -24,8 +24,7 @@ use SilverStripe\Versioned\Versioned;
  */
 abstract class CMSSiteTreeFilter implements LeftAndMain_SearchFilter
 {
-
-    use \SilverStripe\Core\Injector\Injectable;
+    use Injectable;
 
     /**
      * Search parameters, mostly properties on {@link SiteTree}.

--- a/code/Controllers/CMSTreeNode.php
+++ b/code/Controllers/CMSTreeNode.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace SilverStripe\CMS\Controllers;
+
+use SilverStripe\Admin\LeftAndMain_SearchFilter;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\View\SSViewer;
+use SilverStripe\View\ViewableData;
+
+/**
+ * Wrapper around objects being displayed in a tree.
+ * Caution: Volatile API.
+ *
+ * @todo Implement recursive tree node rendering.
+ */
+class CMSTreeNode extends ViewableData
+{
+
+    /**
+     * Object represented by this node
+     *
+     * @var SiteTree
+     */
+    protected $obj;
+
+    /**
+     * Edit link to the current record in the CMS
+     *
+     * @var string
+     */
+    protected $link;
+
+    /**
+     * True if this is the currently selected node in the tree
+     *
+     * @var bool
+     */
+    protected $isCurrent;
+
+    /**
+     * Name of method to count the number of children
+     *
+     * @var string
+     */
+    protected $numChildrenMethod;
+
+    /**
+     *
+     * @var LeftAndMain_SearchFilter
+     */
+    protected $filter;
+
+    /**
+     * @param Object $obj
+     * @param string $link
+     * @param bool $isCurrent
+     * @param string $numChildrenMethod
+     * @param LeftAndMain_SearchFilter $filter
+     */
+    public function __construct(
+        $obj,
+        $link = null,
+        $isCurrent = false,
+        $numChildrenMethod = 'numChildren',
+        $filter = null
+    ) {
+        parent::__construct();
+        $this->obj = $obj;
+        $this->link = $link;
+        $this->isCurrent = $isCurrent;
+        $this->numChildrenMethod = $numChildrenMethod;
+        $this->filter = $filter;
+    }
+
+    /**
+     * Returns template, for further processing by {@link Hierarchy->getChildrenAsUL()}.
+     * Does not include closing tag to allow this method to inject its own children.
+     *
+     * @todo Remove hardcoded assumptions around returning an <li>, by implementing recursive tree node rendering
+     *
+     * @return string
+     */
+    public function forTemplate()
+    {
+        $obj = $this->obj;
+
+        return (string)SSViewer::execute_template(
+            [ 'type' => 'Includes', self::class ],
+            $obj,
+            array(
+                'Classes' => $this->getClasses(),
+                'Link' => $this->getLink(),
+                'Title' => sprintf(
+                    '(%s: %s) %s',
+                    trim(_t('LeftAndMain.PAGETYPE', 'Page type'), " :"),
+                    $obj->i18n_singular_name(),
+                    $obj->Title
+                ),
+            )
+        );
+    }
+
+    /**
+     * Determine the CSS classes to apply to this node
+     *
+     * @return string
+     */
+    public function getClasses()
+    {
+        // Get classes from object
+        $classes = $this->obj->CMSTreeClasses($this->numChildrenMethod);
+        if ($this->isCurrent) {
+            $classes .= ' current';
+        }
+        // Get status flag classes
+        $flags = $this->obj->hasMethod('getStatusFlags')
+            ? $this->obj->getStatusFlags()
+            : false;
+        if ($flags) {
+            $statuses = array_keys($flags);
+            foreach ($statuses as $s) {
+                $classes .= ' status-' . $s;
+            }
+        }
+        // Get additional filter classes
+        if ($this->filter && ($filterClasses = $this->filter->getPageClasses($this->obj))) {
+            if (is_array($filterClasses)) {
+                $filterClasses = implode(' ', $filterClasses);
+            }
+            $classes .= ' ' . $filterClasses;
+        }
+        return $classes ?: '';
+    }
+
+    /**
+     * Get page backing this node
+     *
+     * @return SiteTree
+     */
+    public function getObj()
+    {
+        return $this->obj;
+    }
+
+    /**
+     * Set object backing this node
+     *
+     * @param SiteTree $obj
+     * @return $this
+     */
+    public function setObj($obj)
+    {
+        $this->obj = $obj;
+        return $this;
+    }
+
+    /**
+     * Get link to this node
+     *
+     * @return string
+     */
+    public function getLink()
+    {
+        return $this->link;
+    }
+
+    /**
+     * Set link to this node
+     *
+     * @param string $link
+     * @return $this
+     */
+    public function setLink($link)
+    {
+        $this->link = $link;
+        return $this;
+    }
+
+    /**
+     * Check if this is the currently selected node
+     *
+     * @return bool
+     */
+    public function getIsCurrent()
+    {
+        return $this->isCurrent;
+    }
+
+    /**
+     * Set this node to current, or not current
+     *
+     * @param bool $bool
+     * @return $this
+     */
+    public function setIsCurrent($bool)
+    {
+        $this->isCurrent = $bool;
+        return $this;
+    }
+}

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -314,6 +314,8 @@ de:
     SINGULARNAME: Weiterleitungsseite
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: 'Allgemeine Inhaltsseite'
+    SINGULARNAME: Seite
+    PLURALNAME: Seiten
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: 'Zeigt den Inhalt einer anderen Seite an'
     PLURALNAME: 'Virtuelle Seiten'

--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSTreeNode.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSTreeNode.ss
@@ -1,0 +1,4 @@
+<li id="record-$ID" data-id="$ID" data-pagetype="$ClassName" class="$Classes"><ins class="jstree-icon">&nbsp;</ins>
+	<a href="$Link" title="$Title.ATT"><ins class="jstree-icon">&nbsp;</ins>
+		<span class="text">$TreeTitle</span>
+	</a>

--- a/tests/controller/CMSTreeTest.php
+++ b/tests/controller/CMSTreeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Tests for tree-operations refactored out of LeftAndMain
+ */
+class CMSTreeTest extends FunctionalTest
+{
+    protected static $fixture_file = 'CMSTreeTest.yml';
+
+    public function testSaveTreeNodeSorting()
+    {
+        $this->logInWithPermission('ADMIN');
+
+        // forcing sorting for non-MySQL
+        $rootPages = SiteTree::get()
+            ->filter("ParentID", 0)
+            ->sort('"ID"');
+        $siblingIDs = $rootPages->column('ID');
+        $page1 = $rootPages->offsetGet(0);
+        $page2 = $rootPages->offsetGet(1);
+        $page3 = $rootPages->offsetGet(2);
+
+        // Move page2 before page1
+        $siblingIDs[0] = $page2->ID;
+        $siblingIDs[1] = $page1->ID;
+        $data = array(
+            'SiblingIDs' => $siblingIDs,
+            'ID' => $page2->ID,
+            'ParentID' => 0
+        );
+
+        $response = $this->post('admin/pages/edit/savetreenode', $data);
+        $this->assertEquals(200, $response->getStatusCode());
+        /** @var SiteTree $page1 */
+        $page1 = SiteTree::get()->byID($page1->ID);
+        /** @var SiteTree $page2 */
+        $page2 = SiteTree::get()->byID($page2->ID);
+        /** @var SiteTree $page3 */
+        $page3 = SiteTree::get()->byID($page3->ID);
+
+        $this->assertEquals(2, $page1->Sort, 'Page1 is sorted after Page2');
+        $this->assertEquals(1, $page2->Sort, 'Page2 is sorted before Page1');
+        $this->assertEquals(3, $page3->Sort, 'Sort order for other pages is unaffected');
+    }
+
+    public function testSaveTreeNodeParentID()
+    {
+        $this->logInWithPermission('ADMIN');
+
+        $page2 = $this->objFromFixture(SiteTree::class, 'page2');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
+        $page31 = $this->objFromFixture(SiteTree::class, 'page31');
+        $page32 = $this->objFromFixture(SiteTree::class, 'page32');
+
+        // Move page2 into page3, between page3.1 and page 3.2
+        $siblingIDs = array(
+            $page31->ID,
+            $page2->ID,
+            $page32->ID
+        );
+        $data = array(
+            'SiblingIDs' => $siblingIDs,
+            'ID' => $page2->ID,
+            'ParentID' => $page3->ID
+        );
+        $response = $this->post('admin/pages/edit/savetreenode', $data);
+        $this->assertEquals(200, $response->getStatusCode());
+        $page2 = DataObject::get_by_id(SiteTree::class, $page2->ID, false);
+        $page31 = DataObject::get_by_id(SiteTree::class, $page31->ID, false);
+        $page32 = DataObject::get_by_id(SiteTree::class, $page32->ID, false);
+
+        $this->assertEquals($page3->ID, $page2->ParentID, 'Moved page gets new parent');
+        $this->assertEquals(1, $page31->Sort, 'Children pages before insertaion are unaffected');
+        $this->assertEquals(2, $page2->Sort, 'Moved page is correctly sorted');
+        $this->assertEquals(3, $page32->Sort, 'Children pages after insertion are resorted');
+    }
+
+
+    /**
+     * Test {@see CMSMain::updatetreenodes}
+     */
+    public function testUpdateTreeNodes()
+    {
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
+        $page2 = $this->objFromFixture(SiteTree::class, 'page2');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
+        $page31 = $this->objFromFixture(SiteTree::class, 'page31');
+        $page32 = $this->objFromFixture(SiteTree::class, 'page32');
+        $this->logInWithPermission('ADMIN');
+
+        // Check page
+        $result = $this->get('admin/pages/edit/updatetreenodes?ids='.$page1->ID);
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertEquals('application/json', $result->getHeader('Content-Type'));
+        $data = json_decode($result->getBody(), true);
+        $pageData = $data[$page1->ID];
+        $this->assertEquals(0, $pageData['ParentID']);
+        $this->assertEquals($page2->ID, $pageData['NextID']);
+        $this->assertEmpty($pageData['PrevID']);
+
+        // check subpage
+        $result = $this->get('admin/pages/edit/updatetreenodes?ids='.$page31->ID);
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertEquals('application/json', $result->getHeader('Content-Type'));
+        $data = json_decode($result->getBody(), true);
+        $pageData = $data[$page31->ID];
+        $this->assertEquals($page3->ID, $pageData['ParentID']);
+        $this->assertEquals($page32->ID, $pageData['NextID']);
+        $this->assertEmpty($pageData['PrevID']);
+
+        // Multiple pages
+        $result = $this->get('admin/pages/edit/updatetreenodes?ids='.$page1->ID.','.$page2->ID);
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertEquals('application/json', $result->getHeader('Content-Type'));
+        $data = json_decode($result->getBody(), true);
+        $this->assertEquals(2, count($data));
+
+        // Invalid IDs
+        $result = $this->get('admin/pages/edit/updatetreenodes?ids=-3');
+        $this->assertEquals(200, $result->getStatusCode());
+        $this->assertEquals('application/json', $result->getHeader('Content-Type'));
+        $data = json_decode($result->getBody(), true);
+        $this->assertEquals(0, count($data));
+    }
+
+}

--- a/tests/controller/CMSTreeTest.yml
+++ b/tests/controller/CMSTreeTest.yml
@@ -1,0 +1,91 @@
+SilverStripe\CMS\Model\SiteTree:
+  page1:
+    Title: Page 1
+    Sort: 1
+  page2:
+    Title: Page 2
+    Sort: 2
+  page3:
+    Title: Page 3
+    Sort: 3
+  page31:
+    Title: Page 3.1
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page3
+    Sort: 1
+  page32:
+    Title: Page 3.2
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page3
+    Sort: 2
+  page4:
+    Title: Page 4
+    Sort: 4
+  page5:
+    Title: Page 5
+    Sort: 5
+  page6:
+    Title: Page 6
+    Sort: 6
+  page7:
+    Title: Page 7
+    Sort: 7
+  page8:
+    Title: Page 8
+    Sort: 8
+  page9:
+    Title: Page 9
+    Sort: 9
+  page10:
+    Title: Page 10
+    Sort: 10
+  page11:
+    Title: Page 11
+    Sort: 11
+  page12:
+    Title: Page 12
+    Sort: 12
+  page13:
+    Title: Page 13
+    Sort: 13
+  page14:
+    Title: Page 14
+    Sort: 14
+  page15:
+    Title: Page 15
+    Sort: 15
+  page16:
+    Title: Page 16
+    Sort: 16
+  page17:
+    Title: Page 17
+    Sort: 17
+  page18:
+    Title: Page 18
+    Sort: 18
+  page19:
+    Title: Page 19
+    Sort: 19
+  page20:
+    Title: Page 20
+    Sort: 20
+  page21:
+    Title: Page 21
+    Sort: 21
+  page22:
+    Title: Page 22
+    Sort: 22
+  page23:
+    Title: Page 23
+    Sort: 23
+  page24:
+    Title: Page 24
+    Sort: 24
+  page25:
+    Title: Page 25
+    Sort: 25
+  page26:
+    Title: Page 26
+    Sort: 26
+  home:
+    Title: Home
+    URLSegment: home
+    Sort: 0


### PR DESCRIPTION
Fixes #1510, meaning that we can now use formfield-actions in react sections.

Refactor tree operations into CMSMain; Increases complexity of CMSMain (unfortunately), but simplifies LeftAndMain by removing all tree-handling logic.

Cleanup of getEditForm() and various other aging code blocks.

Note: @timkung has been working on a 3.x version at https://github.com/silverstripe/silverstripe-cms/pull/1784