### PR TITLE
Add missing class to toolbar

### DIFF
--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSPagesController_ContentToolActions.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSPagesController_ContentToolActions.ss
@@ -1,5 +1,5 @@
 <div class="toolbar toolbar--content cms-content-toolbar">
-	<div class="cms-actions-buttons-row">
+	<div class="btn-toolbar cms-actions-buttons-row">
 		<a class="btn btn-primary cms-content-addpage-button tool-button font-icon-plus" href="$LinkPageAdd" data-url-addpage="{$LinkPageAdd('', 'ParentID=%s')}"><% _t('SilverStripe\CMS\Controllers\CMSMain.AddNewButton', 'Add new') %></a>
 
 		<% if $View == 'Tree' %>


### PR DESCRIPTION
Partial fix for https://github.com/silverstripe/silverstripe-admin/pull/28 which adds a missing class to toolbars.

Can be merged independently of https://github.com/silverstripe/silverstripe-admin/pull/28

