### PR TITLE
Prevent installation from removing behat.yml

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
 docs/                 export-ignore
 javascript/src/       export-ignore
-behat.yml             export-ignore
 *.dist                export-ignore
 
 # Hide diffs


### PR DESCRIPTION
With the current export-ignore in place, behat.yml is deleted when installed within framework, breaking integration tests when framework runs BEHAT_TEST = cms.