### PR TITLE
BUGFIX: Get rid of special dev webpack plugins

### DIFF
--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -5,6 +5,7 @@ if (Array.isArray(Config)) {
   const jsConfig = Config.find((item) => item.name === 'js');
 
   jsConfig.plugins = [
+  	...jsConfig.plugins,
     new webpack.ProvidePlugin({
       jQuery: 'jQuery',
       $: 'jQuery',

--- a/webpack-dev.config.js
+++ b/webpack-dev.config.js
@@ -2,22 +2,6 @@ const webpack = require('webpack');
 const Config = require('./webpack.config');
 
 if (Array.isArray(Config)) {
-  const jsConfig = Config.find((item) => item.name === 'js');
-
-  jsConfig.plugins = [
-  	...jsConfig.plugins,
-    new webpack.ProvidePlugin({
-      jQuery: 'jQuery',
-      $: 'jQuery',
-    }),
-    // Most vendor libs are loaded directly into the 'vendor' bundle (through require() calls in vendor.js).
-    // This ensures that any further require() calls in other bundles aren't duplicating libs.
-    new webpack.optimize.CommonsChunkPlugin({
-      name: 'vendor',
-      minChunks: Infinity,
-    }),
-  ];
-
   for (var i = 0; i < Config.length; i++) {
     Config[i].devtool = 'source-map';
   }


### PR DESCRIPTION
They're not being used and they're breaking things, e.g. `ExtractTextPlugin` and creating unused common chunks bundles e.g. `client/dist/js/vendor.js`