### PR TITLE
API Rename services to match FQN of interface / classes

### DIFF
--- a/_config/adminpanels.yml
+++ b/_config/adminpanels.yml
@@ -1,2 +1,5 @@
+---
+Name: cmsdefaultadmin
+---
 SilverStripe\Admin\AdminRootController:
-  default_panel: 'SilverStripe\CMS\Controllers\CMSPagesController'
+  default_panel: SilverStripe\CMS\Controllers\CMSPagesController

--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -1,4 +1,5 @@
 ---
+Name: cmscache
 After:
   - '#corecache'
 ---

--- a/_config/cmslogging.yml
+++ b/_config/cmslogging.yml
@@ -1,9 +1,8 @@
 ---
 Name: cms-logging
-After: '#live-logging'
-Except:
-  environment: dev
+After:
+  - '#loggingformatters'
 ---
 SilverStripe\Core\Injector\Injector:
-  FriendlyErrorFormatter:
+  Monolog\Formatter\FormatterInterface.friendly:
     class: SilverStripe\CMS\Logging\ErrorPageErrorFormatter

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,3 +1,6 @@
+---
+Name: cmsextensions
+---
 SilverStripe\Admin\LeftAndMain:
   extensions:
     - SilverStripe\CMS\Controllers\LeftAndMainPageIconsExtension

--- a/_config/injector.yml
+++ b/_config/injector.yml
@@ -1,6 +1,0 @@
----
-Name: cmsinjector
----
-SilverStripe\Core\Injector\Injector:
-  SiteTreeLinkTracking_Parser:
-    class: SilverStripe\CMS\Model\SiteTreeLinkTracking_Parser

--- a/code/Model/ErrorPage.php
+++ b/code/Model/ErrorPage.php
@@ -390,6 +390,6 @@ class ErrorPage extends Page
      */
     protected static function get_asset_handler()
     {
-        return Injector::inst()->get('GeneratedAssetHandler');
+        return Injector::inst()->get(GeneratedAssetHandler::class);
     }
 }

--- a/code/Model/SiteTreeLinkTracking.php
+++ b/code/Model/SiteTreeLinkTracking.php
@@ -46,9 +46,9 @@ class SiteTreeLinkTracking extends DataExtension
      * @var array
      * @config
      */
-    private static $dependencies = array(
-        'Parser' => '%$SiteTreeLinkTracking_Parser'
-    );
+    private static $dependencies = [
+        'Parser' => '%$' . SiteTreeLinkTracking_Parser::class
+    ];
 
     /**
      * Parser for link tracking
@@ -64,7 +64,7 @@ class SiteTreeLinkTracking extends DataExtension
      * @param SiteTreeLinkTracking_Parser $parser
      * @return $this
      */
-    public function setParser($parser)
+    public function setParser(SiteTreeLinkTracking_Parser $parser = null)
     {
         $this->parser = $parser;
         return $this;
@@ -81,7 +81,7 @@ class SiteTreeLinkTracking extends DataExtension
     );
 
     private static $belongs_many_many = array(
-        "BackLinkTracking" => "SilverStripe\\CMS\\Model\\SiteTree.LinkTracking"
+        "BackLinkTracking" => SiteTree::class . '.LinkTracking',
     );
 
     /**

--- a/tests/model/ErrorPageTest.php
+++ b/tests/model/ErrorPageTest.php
@@ -14,7 +14,6 @@ use SilverStripe\Control\HTTPResponse_Exception;
  */
 class ErrorPageTest extends FunctionalTest
 {
-
     protected static $fixture_file = 'ErrorPageTest.yml';
 
     /**
@@ -29,8 +28,7 @@ class ErrorPageTest extends FunctionalTest
         parent::setUp();
         // Set temporary asset backend store
         TestAssetStore::activate('ErrorPageTest');
-        Config::inst()->update('SilverStripe\\CMS\\Model\\ErrorPage', 'enable_static_file', true);
-        Config::inst()->update('SilverStripe\\Control\\Director', 'environment_type', 'live');
+        Config::modify()->set(ErrorPage::class, 'enable_static_file', true);
         $this->logInWithPermission('ADMIN');
     }
 
@@ -42,7 +40,8 @@ class ErrorPageTest extends FunctionalTest
 
     public function test404ErrorPage()
     {
-        $page = $this->objFromFixture('SilverStripe\\CMS\\Model\\ErrorPage', '404');
+        /** @var ErrorPage $page */
+        $page = $this->objFromFixture(ErrorPage::class, '404');
         // ensure that the errorpage exists as a physical file
         $page->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
@@ -60,7 +59,7 @@ class ErrorPageTest extends FunctionalTest
 
     public function testBehaviourOfShowInMenuAndShowInSearchFlags()
     {
-        $page = $this->objFromFixture('SilverStripe\\CMS\\Model\\ErrorPage', '404');
+        $page = $this->objFromFixture(ErrorPage::class, '404');
 
         /* Don't show the error page in the menus */
         $this->assertEquals($page->ShowInMenus, 0, 'Don\'t show the error page in the menus');
@@ -71,7 +70,8 @@ class ErrorPageTest extends FunctionalTest
 
     public function testBehaviourOf403()
     {
-        $page = $this->objFromFixture('SilverStripe\\CMS\\Model\\ErrorPage', '403');
+        /** @var ErrorPage $page */
+        $page = $this->objFromFixture(ErrorPage::class, '403');
         $page->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
         try {
@@ -88,7 +88,8 @@ class ErrorPageTest extends FunctionalTest
     public function testSecurityError()
     {
         // Generate 404 page
-        $page = $this->objFromFixture('SilverStripe\\CMS\\Model\\ErrorPage', '404');
+        /** @var ErrorPage $page */
+        $page = $this->objFromFixture(ErrorPage::class, '404');
         $page->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
         // Test invalid action
@@ -101,7 +102,8 @@ class ErrorPageTest extends FunctionalTest
     public function testStaticCaching()
     {
         // Test new error code does not have static content
-        $this->assertEmpty(ErrorPage::get_content_for_errorcode('401'));
+        $error = ErrorPage::get_content_for_errorcode('401');
+        $this->assertEmpty($error);
         $expectedErrorPagePath = TestAssetStore::base_path() . '/error-401.html';
         $this->assertFileNotExists($expectedErrorPagePath, 'Error page is not automatically cached');
 
@@ -124,7 +126,7 @@ class ErrorPageTest extends FunctionalTest
      */
     public function testGeneratedFile()
     {
-        Config::inst()->update('SilverStripe\\CMS\\Model\\ErrorPage', 'enable_static_file', false);
+        Config::modify()->set(ErrorPage::class, 'enable_static_file', false);
         $this->logInWithPermission('ADMIN');
 
         $page = new ErrorPage();


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/6642

Requires certain framework changes to be merged first, especially the logging service name.

Includes some yml and ErrorPage cleanup.