### PR TITLE
[WIP] Make CMS Compatible with Authentication Refactor work

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -922,7 +922,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         // Generate basic cache key. Too complex to encompass all variations
         $cache = Injector::inst()->get(CacheInterface::class . '.CMSMain_SiteTreeHints');
-        $cacheKey = md5(implode('_', array(Member::currentUserID(), implode(',', $cacheCanCreate), implode(',', $classes))));
+        $cacheKey = md5(implode('_', array(Security::getCurrentUser()->ID, implode(',', $cacheCanCreate), implode(',', $classes))));
         if ($this->getRequest()->getVar('flush')) {
             $cache->clear();
         }

--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -199,7 +199,7 @@ class CMSPageAddController extends CMSPageEditController
             $parentID = 0;
         }
 
-        if (!singleton($className)->canCreate(Member::currentUser(), array('Parent' => $parentObj))) {
+        if (!singleton($className)->canCreate(Security::getCurrentUser(), array('Parent' => $parentObj))) {
             return Security::permissionFailure($this);
         }
 

--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -20,8 +20,6 @@ use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\FieldType\DBVarchar;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Versioned\Versioned;
-use SilverStripe\Security\Member;
-use SilverStripe\Security\MemberAuthenticator;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\Security;
 use SilverStripe\SiteConfig\SiteConfig;
@@ -320,12 +318,12 @@ class ContentController extends Controller
      */
     public function LoginForm()
     {
-        return MemberAuthenticator::get_login_form($this);
+        return MemberAuthenticator::singleton()->loginForm($this);
     }
 
     public function SilverStripeNavigator()
     {
-        $member = Member::currentUser();
+        $member = Security::getCurrentUser();
         $items = '';
         $message = '';
 

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -52,6 +52,7 @@ use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\InheritedPermissions;
 use SilverStripe\Security\InheritedPermissionsExtension;
 use SilverStripe\Security\PermissionChecker;
+use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Security\Group;
 use SilverStripe\Security\Member;
@@ -922,7 +923,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     public function can($perm, $member = null, $context = array())
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         if ($member && Permission::checkMember($member, "ADMIN")) {
@@ -968,7 +969,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         }
 
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Standard mechanism for accepting permission changes from extensions
@@ -1004,7 +1005,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     public function canView($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Standard mechanism for accepting permission changes from extensions
@@ -1065,7 +1066,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     public function canPublish($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Check extension
@@ -1101,7 +1102,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     public function canDelete($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Standard mechanism for accepting permission changes from extensions
@@ -1145,7 +1146,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     public function canCreate($member = null, $context = array())
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Check parent (custom canCreate option for SiteTree)
@@ -1199,7 +1200,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     public function canEdit($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
 
         // Standard mechanism for accepting permission changes from extensions

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     "composer/installers": "*",
     "silverstripe/admin": "^1.0@dev",
     "silverstripe/campaign-admin": "^1@dev",
-    "silverstripe/framework": "^4.0@dev",
+    "silverstripe/framework": "4.0.x-dev",
     "silverstripe/reports": "^4.0@dev",
     "silverstripe/siteconfig": "^4.0@dev",
-    "silverstripe/versioned": "^1.0@dev"
+    "silverstripe/versioned": "1.0@dev"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7",

--- a/tests/controller/SilverStripeNavigatorTest.php
+++ b/tests/controller/SilverStripeNavigatorTest.php
@@ -7,6 +7,7 @@ use SilverStripe\CMS\Controllers\SilverStripeNavigator;
 use SilverStripe\CMS\Controllers\SilverStripeNavigatorItem;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\Security\Security;
 
 /**
  * @package cms
@@ -85,7 +86,7 @@ class SilverStripeNavigatorTest_ProtectedTestItem extends SilverStripeNavigatorI
     public function canView($member = null)
     {
         if (!$member) {
-            $member = Member::currentUser();
+            $member = Security::getCurrentUser();
         }
         return Permission::checkMember($member, 'ADMIN');
     }

--- a/tests/model/ErrorPageFileExtensionTest.php
+++ b/tests/model/ErrorPageFileExtensionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Assets\File;
 use SilverStripe\Control\Session;
@@ -46,7 +47,7 @@ class ErrorPageFileExtensionTest extends SapphireTest
         // Get stage version of file
         $file = File::get()->first();
         $fileLink = $file->Link();
-        Session::clear("loggedInAs");
+        Security::setCurrentUser(null);
 
         // Generate shortcode for a file which doesn't exist
         $shortcode = File::handle_shortcode(array('id' => 9999), null, new ShortcodeParser(), 'file_link');

--- a/tests/model/SiteTreeActionsTest.php
+++ b/tests/model/SiteTreeActionsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\ORM\DB;
 use SilverStripe\Security\Member;
@@ -40,7 +41,7 @@ class SiteTreeActionsTest extends FunctionalTest
 
         // Log in as another user
         $readonlyEditor = $this->objFromFixture(Member::class, 'cmsreadonlyeditor');
-        $this->session()->inst_set('loggedInAs', $readonlyEditor->ID);
+        Security::setCurrentUser($readonlyEditor);
 
         // Reload latest version
         $page = Page::get()->byID($page->ID);
@@ -76,7 +77,7 @@ class SiteTreeActionsTest extends FunctionalTest
 
         // Check that someone without the right permission can't delete the page
         $editor = $this->objFromFixture(Member::class, 'cmsnodeleteeditor');
-        $this->session()->inst_set('loggedInAs', $editor->ID);
+        Security::setCurrentUser($editor);
 
         $actions = $page->getCMSActions();
         $this->assertNull($actions->dataFieldByName('action_archive'));
@@ -84,7 +85,7 @@ class SiteTreeActionsTest extends FunctionalTest
         // Check that someone with the right permission can delete the page
         /** @var Member $member */
         $member = $this->objFromFixture(Member::class, 'cmseditor');
-        $member->logIn();
+        Security::setCurrentUser($member);
         $actions = $page->getCMSActions();
         $this->assertNotNull($actions->dataFieldByName('action_archive'));
     }
@@ -96,7 +97,7 @@ class SiteTreeActionsTest extends FunctionalTest
         }
 
         $author = $this->objFromFixture(Member::class, 'cmseditor');
-        $this->session()->inst_set('loggedInAs', $author->ID);
+        Security::setCurrentUser($author);
 
         /** @var Page $page */
         $page = new Page();
@@ -125,7 +126,7 @@ class SiteTreeActionsTest extends FunctionalTest
         }
 
         $author = $this->objFromFixture(Member::class, 'cmseditor');
-        $this->session()->inst_set('loggedInAs', $author->ID);
+        Security::setCurrentUser($author);
 
         $page = new Page();
         $page->CanEditType = 'LoggedInUsers';
@@ -158,7 +159,7 @@ class SiteTreeActionsTest extends FunctionalTest
         }
 
         $author = $this->objFromFixture(Member::class, 'cmseditor');
-        $this->session()->inst_set('loggedInAs', $author->ID);
+        Security::setCurrentUser($author);
 
         $page = new Page();
         $page->CanEditType = 'LoggedInUsers';

--- a/tests/search/SearchFormTest.php
+++ b/tests/search/SearchFormTest.php
@@ -6,6 +6,7 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\ORM\DB;
+use SilverStripe\Security\Security;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\MSSQL\MSSQLDatabase;
 use SilverStripe\PostgreSQL\PostgreSQLDatabase;
@@ -200,14 +201,14 @@ class ZZZSearchFormTest extends FunctionalTest
         );
 
         $member = $this->objFromFixture(Member::class, 'randomuser');
-        $member->logIn();
+        Security::setCurrentUser($member);
         $results = $sf->getResults();
         $this->assertContains(
             $page->ID,
             $results->column('ID'),
             'Page with "Restrict to logged in users" shows if login is present'
         );
-        $member->logOut();
+        Security::setCurrentUser(null);
     }
 
     public function testPagesRestrictedToSpecificGroupNotIncluded()
@@ -230,24 +231,24 @@ class ZZZSearchFormTest extends FunctionalTest
         );
 
         $member = $this->objFromFixture(Member::class, 'randomuser');
-        $member->logIn();
+        Security::setCurrentUser($member);
         $results = $sf->getResults();
         $this->assertNotContains(
             $page->ID,
             $results->column('ID'),
             'Page with "Restrict to these users" doesnt show if logged in user is not in the right group'
         );
-        $member->logOut();
+        Security::setCurrentUser(null);
 
         $member = $this->objFromFixture(Member::class, 'websiteuser');
-        $member->logIn();
+        Security::setCurrentUser($member);
         $results = $sf->getResults();
         $this->assertContains(
             $page->ID,
             $results->column('ID'),
             'Page with "Restrict to these users" shows if user in this group is logged in'
         );
-        $member->logOut();
+        Security::setCurrentUser(null);
     }
 
     public function testInheritedRestrictedPagesNotIncluded()
@@ -269,14 +270,14 @@ class ZZZSearchFormTest extends FunctionalTest
         );
 
         $member = $this->objFromFixture(Member::class, 'websiteuser');
-        $member->logIn();
+        Security::setCurrentUser($member);
         $results = $sf->getResults();
         $this->assertContains(
             $page->ID,
             $results->column('ID'),
             'Page inheriting "Restrict to loggedin users" shows if user in this group is logged in'
         );
-        $member->logOut();
+        Security::setCurrentUser(null);
     }
 
     public function testDisabledShowInSearchFlagNotIncludedForSiteTree()


### PR DESCRIPTION
- Move Member::currentUser() to Security::getCurrentUser()

Composer.json temporarily changed for tests to run