### PR TITLE
Count children time / memory issues fix

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -1956,7 +1956,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 				'CMSMain.NEWPAGE',
 				array('pagetype' => $this->i18n_singular_name())
 			)));
-		$helpText = (self::config()->nested_urls && count($this->Children())) ? $this->fieldLabel('LinkChangeNote') : '';
+		$helpText = (self::config()->nested_urls && $this->numChildren()) ? $this->fieldLabel('LinkChangeNote') : '';
 		if(!Config::inst()->get('URLSegmentFilter', 'default_allow_multibyte')) {
 			$helpText .= $helpText ? '<br />' : '';
 			$helpText .= _t('SiteTreeURLSegmentField.HelpChars', ' Special characters are automatically converted or removed.');


### PR DESCRIPTION
Children of the site tree are no longer listed only for the purpose of counting them. count($this->Children()) creates an array list of children which has serious performance consequences if there are lot of children present. On the other hand $this->numChildren() runs a count query which is much faster and eats less memory.