### PR TITLE
Revert "Update translations"

### DIFF
--- a/javascript/lang/es.js
+++ b/javascript/lang/es.js
@@ -44,7 +44,7 @@ if (typeof(ss) === 'undefined' || typeof(ss.i18n) === 'undefined') {
     "Tree.ShowAsList": "Mostrar hijos como lista",
     "Tree.ThisPageAndSubpages": "Esta página y subpáginas",
     "Tree.ThisPageOnly": "Sólo en esta página",
-    "Tree.ViewPage": "Ver",
+    "Tree.ViewPage": "View",
     "URLSEGMENT.Cancel": "Cancelar",
     "URLSEGMENT.Edit": "Editar",
     "URLSEGMENT.OK": "Ok",

--- a/javascript/lang/src/es.js
+++ b/javascript/lang/src/es.js
@@ -37,7 +37,7 @@
     "Tree.ShowAsList": "Mostrar hijos como lista",
     "Tree.ThisPageAndSubpages": "Esta página y subpáginas",
     "Tree.ThisPageOnly": "Sólo en esta página",
-    "Tree.ViewPage": "Ver",
+    "Tree.ViewPage": "View",
     "URLSEGMENT.Cancel": "Cancelar",
     "URLSEGMENT.Edit": "Editar",
     "URLSEGMENT.OK": "Ok",

--- a/lang/af.yml
+++ b/lang/af.yml
@@ -1,7 +1,41 @@
 af:
+  AssetAdmin:
+    ADDFILES: "Voeg lêers by"
+    ActionAdd: "Voeg dossier by"
+    AppCategoryArchive: "Stoor in argiewe"
+    AppCategoryAudio: Klank
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Prentjie
+    AppCategoryVideo: Video
+    BackToFolder: "Terug na dossier"
+    CREATED: Datum
+    CurrentFolderOnly: "Beperrk tot die huidige dossier"
+    DetailsView: Besonderhede
+    FILES: Lêers
+    FILESYSTEMSYNC: "Sinchroniseer lêers"
+    FILESYSTEMSYNCTITLE: "Bring die CMS op datum met die nuutse lêers wat in die lêersisteem lê. Dit is voordelig om te doen wanneer lêers buite die CMS opgelaai was bv deur midel van FTP"
+    FROMTHEINTERNET: "Van die indernet af"
+    FROMYOURCOMPUTER: "Van jou rekenaar af"
+    Filetype: "Lêer tipe"
+    ListView: "Lys aansig"
+    MENUTITLE: Lêers
+    NEWFOLDER: "Nuwe Dossier"
+    SIZE: Groote
+    THUMBSDELETED: "{count} ongebruikte duimnaelsketse was verwyder"
+    TreeView: "Boom aansig"
+    Upload: "Laai op"
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Verwyder dossiere"
+  AssetAdmin_Tools:
+    FILTER: Filtreer
+  AssetAdmin_left_ss:
+    GO: "Gaan voort"
   AssetTableField:
     BACKLINKCOUNT: "Gebruik op:"
     PAGES: bladsy(e)
+  BackLink_Button_ss:
+    Back: Terug
   BrokenLinksReport:
     Any: Enige
     BROKENLINKS: "Gebreekte skakels verslag"
@@ -16,19 +50,34 @@ af:
     502: "502 - Slegte Deurgang"
     503: "503 - Diens Nie Beskikbaar"
     505: "505 - HTTP Weergawe Nie Ondersteun"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Verwyder ongebruikte miniatuur prente"
+    UNUSEDFILESTITLE: "Ongebruikte lêers"
+    UNUSEDTHUMBNAILSTITLE: "Ongebruikte miniatuur prente"
+  Permission:
+    CMS_ACCESS_CATEGORY: "IBS Toegang"
   Permissions:
     CONTENT_CATEGORY: "Inhoud permissies"
     PERMISSIONS_CATEGORY: "Rolle en toegang permissies"
   SideReport:
     BROKENFILES: "Bladsye met gebreekte lêers"
+    BROKENLINKS: "Bladsye met gebreekte skakels"
     BrokenLinksGroupTitle: "Gebreekte skakels verslae"
     ContentGroupTitle: "Inhoud verslae"
+    OtherGroupTitle: Ander
     ParameterLiveCheckbox: "Kies lewendige werf"
+  SilverStripeNavigatorLink:
+    ShareLink: "Deel skakel"
+  SilverStripeNavigatorLinkl:
+    CloseLink: "Maak toe"
+  SiteConfig:
+    DEFAULTTHEME: "(Gebruik verstek tema)"
   SiteTree:
     ACCESSANYONE: "Enige iemand"
     ACCESSHEADER: "Wie mag hierdie bladsy sien?"
     ACCESSLOGGEDIN: "Ingetekende gebruikers"
     ACCESSONLYTHESE: "Slegs hierdie mense (kies uit lys)"
+    ALLOWCOMMENTS: "Laat aanmerkings toe op hierdie bladsy?"
     BUTTONUNPUBLISH: Onpubliseer
     BUTTONUNPUBLISHDESC: "Verwyder hierdie bladsy van die gepubliseerde werf"
     Content: Inhoud
@@ -53,3 +102,4 @@ af:
     HAVEASKED: "U het gevra om die inhoud van ons werf te sien op"
   VirtualPage:
     HEADER: "Hierdie is 'n virtuele bladsy"
+    SINGULARNAME: "Virtuele Bladsy"

--- a/lang/ar.yml
+++ b/lang/ar.yml
@@ -1,7 +1,41 @@
 ar:
+  AssetAdmin:
+    ADDFILES: "أضف الملفات"
+    ActionAdd: "أضف مجلد"
+    AppCategoryArchive: الأرشيف
+    AppCategoryAudio: سمعي
+    AppCategoryDocument: وثيقة
+    AppCategoryFlash: "أخبار خاطفة"
+    AppCategoryImage: صورة
+    AppCategoryVideo: فيديو
+    BackToFolder: "العودة الى المجلد"
+    CREATED: التاريخ
+    CurrentFolderOnly: "الحصر للمجلد الحالي؟"
+    DetailsView: التفاصيل
+    FILES: الملفات
+    FILESYSTEMSYNC: "مزامنة الملفات"
+    FILESYSTEMSYNCTITLE: "تحديث إدخالات الملفات لقاعدة بيانات CMS على نظام الملفات. مفيد عندما يكون قد تم تحميل ملفات جديدة من خارج  نظام إدارة المحتوى CMS، على سبيل المثال من خلال FTP."
+    FROMTHEINTERNET: "من الإنترنت"
+    FROMYOURCOMPUTER: "من حاسوبك"
+    Filetype: "نوع الملف"
+    ListView: "عرض القائمة"
+    MENUTITLE: الملفات
+    NEWFOLDER: "مجلد جديد"
+    SIZE: الحجم
+    THUMBSDELETED: "تم حذف {count} صور مصغرة غير المستخدمة"
+    TreeView: "عرض الشجرة"
+    Upload: تحميل
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "احذف المجلدات"
+  AssetAdmin_Tools:
+    FILTER: مصفاة
+  AssetAdmin_left_ss:
+    GO: اذهب
   AssetTableField:
     BACKLINKCOUNT: "مستعمل في:"
     PAGES: "صفحة (صفحات)"
+  BackLink_Button_ss:
+    Back: الرجوع
   BrokenLinksReport:
     Any: أي
     BROKENLINKS: "تقرير الروابط المكسورة"
@@ -27,8 +61,14 @@ ar:
   CMSAddPageController:
     Title: "أضف صفحة"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "حذفت %d صفحات من مسودة الموقع، %d من الإخفاقات"
+    DELETED_PAGES: "قد تم مسح d% من الصفحات من الموقع المنشور, d% من الإخفاقات"
+    DELETE_DRAFT_PAGES: "حذف من مسودة الموقع"
+    DELETE_PAGES: "حذف من الصفحة المنشورة"
     PUBLISHED_PAGES: "%d من الصفحات المنشورة"
     PUBLISH_PAGES: النشر
+  CMSFileAddController:
+    MENUTITLE: ملفات
   CMSMain:
     ACCESS: "النفاذ إلى القسم '{title}'"
     ACCESS_HELP: "سماح بعرض لقسم يحتوي على صفحة الشجرة والمحتوى. يمكن التعامل معها عرض وتحرير الأذونات من خلال القائمه المنسدله للروابط محددة صفحة، فضلا عن فصل \"أذونات المحتوى\"."
@@ -38,8 +78,13 @@ ar:
     ChoosePageParentMode: "اختر مكان إنشاء هذه الصفحة"
     ChoosePageType: "اختر نوع الصفحة"
     Create: خلق
+    DELETE: "حذف من مسودة الموقع"
+    DELETEFP: "حذف من الموقع المنشور"
+    DESCREMOVED: "و {count} منحدر منه"
     DUPLICATED: "تكرار '{title}' بنجاح"
     DUPLICATEDWITHCHILDREN: "تكرار '{title}' والتوابع بنجاح"
+    EditTree: "تعديل الهيكل"
+    MENUTITLE: "حرر الصفحة"
     NEWPAGE: "{pagetype} جديد"
     PAGENOTEXISTS: "هذه الصفحة غير موجودة"
     PAGETYPEANYOPT: أي
@@ -47,22 +92,31 @@ ar:
     PUBALLFUN: "\"نشر الجميع\"خاصية "
     PUBPAGES: "تمّ: نشر {count} صفحات"
     PageAdded: "تم إنشاء الصفحة بنجاح"
+    REMOVED: "حذف '{title}'{description} من الموقع الحي"
     REMOVEDPAGE: "أزيل '{title}' من الموقع المنشور"
     REMOVEDPAGEFROMDRAFT: "'%s' محذوف من مسودة الموقع"
     RESTORED: "استعادة '{title}' بنجاح"
     ROLLBACK: "عودة إلى هذا الإصدار"
     ROLLEDBACKPUBv2: "التراجع إلى النسخة المنشورة."
     ROLLEDBACKVERSIONv2: "التراجع إلى النسخة #%d."
+    SAVE: حفظ
     SAVEDRAFT: "احفظ المسودة"
     TabContent: المحتوى
     TabHistory: السوابق
     TabSettings: الإعدادات
+  CMSMain_left_ss:
+    RESET: "إعادة الوضع الأصلي"
   CMSPageAddController:
+    MENUTITLE: "أضف صفحة"
     ParentMode_child: "تحت صفحة أخرى"
     ParentMode_top: "أعلى مستوى"
+  CMSPageEditController:
+    MENUTITLE: "تحرير الصفحة"
   CMSPageHistoryController:
     COMPAREMODE: "وضع المقارنة (حدد اثنين)"
     COMPAREVERSIONS: "قارن الإصدارات"
+    COMPARINGVERSION: "مقارنة الإصدارين {version1} و {version2}."
+    MENUTITLE: السجل
     REVERTTOTHISVERSION: "العودة إلى هذا الإصدار"
     SHOWUNPUBLISHED: "عرض الإصدارات الغير منشورة"
     SHOWVERSION: "اعرض الإصدار"
@@ -75,7 +129,10 @@ ar:
     PUBLISHER: الناشر
     UNKNOWN: "غير معروف"
     WHEN: متى
+  CMSPageSettingsController:
+    MENUTITLE: "تحرير صفحة"
   CMSPagesController:
+    GalleryView: "مشاهدة المعرض"
     ListView: "عرض القائمة"
     MENUTITLE: الصفحات
     TreeView: "عرض الشجرة"
@@ -83,7 +140,10 @@ ar:
     FILTER: مصفاة
   CMSSearch:
     FILTERDATEFROM: من
+    FILTERDATEHEADING: موعد
     FILTERDATETO: إلى
+  CMSSettingsController:
+    MENUTITLE: الإعدادات
   CMSSiteTreeFilter_Search:
     Title: "كل الصفحات"
   ContentControl:
@@ -94,6 +154,7 @@ ar:
     CMS: "نظام إدارة المحتوى"
     DRAFT: المسودّة
     DRAFTSITE: "موقع في المسودة"
+    DRAFT_SITE_ACCESS_RESTRICTION: "يجب عليك تسجيل الدخول باستخدام كلمة مرور CMS الخاصة بك من أجل عرض مشاريع المحتوى أو المحتوى المؤرشف. <a href=\"%s\">انقر هنا للرجوع إلى الموقع المنشور.</a>"
     Email: "البريد الإلكتروني"
     INSTALL_SUCCESS: "تم التثبيت بنجاح!"
     InstallFilesDeleted: "تم حذف ملفات التثبيت بنجاح."
@@ -139,17 +200,40 @@ ar:
     DEFAULTERRORPAGETITLE: "الصفحة غير موجودة"
     DEFAULTSERVERERRORPAGECONTENT: "<p>عذرا، كانت هناك مشكلة في التعامل مع طلبك.</p>"
     DEFAULTSERVERERRORPAGETITLE: "خطأ في الملقم"
+    DESCRIPTION: "محتوى مخصص للحالات المختلفة من الأخطاء (على سبيل المثال \"الصفحة غير موجودة\")"
+    ERRORFILEPROBLEM: "خطأ في فتح الملف \"{filename}\" للكتابة. يرجى التحقق من تراخيص ملف."
+    SINGULARNAME: "صفحة الأخطاء"
+  Folder:
+    AddFolderButton: "أضف مجلد"
+    DELETEUNUSEDTHUMBNAILS: "حذف المصغرات غير المستخدمة"
+    UNUSEDFILESTITLE: "الملفات غير المستخدمة"
+    UNUSEDTHUMBNAILSTITLE: "المصغرات غير المستخدمة"
+    UploadFilesButton: تحميل
+  LeftAndMain:
+    DELETED: حذفت.
+    PreviewButton: "عرض مسبق"
+    SAVEDUP: "تم الحفظ."
+    SearchResults: "نتائج البحث"
+  Permission:
+    CMS_ACCESS_CATEGORY: "الوصل لنظام إدارة المحتوى"
   Permissions:
     CONTENT_CATEGORY: "تصاريح المحتوى"
     PERMISSIONS_CATEGORY: "تصريح الدخول والقواعد"
   RedirectorPage:
+    DESCRIPTION: "إعادة التوجيه إلى صفحة داخلية مختلفة"
     HASBEENSETUP: "صفحة التحويل تم تهيئتها بدون تحديد وجهة التحويل"
     HEADER: "هذه الصفحة سوف تقوم بتحويل الأعضاء إلى صفحة أخرى"
     OTHERURL: "رابط موقع آخر"
     REDIRECTTO: "تحويل إلى"
     REDIRECTTOEXTERNAL: "موقع آخر"
     REDIRECTTOPAGE: "صفحة في موقعك الشخصي"
+    SINGULARNAME: "معيد توجيه الصفحة"
     YOURPAGE: "صفحة في موقعك الشخصي"
+  ReportAdmin:
+    MENUTITLE: التقارير
+    ReportTitle: العنوان
+  ReportAdminForm:
+    FILTERBY: "فرز عبر"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "يرجى نشر الصفحة المرتبطة من أجل نشر الصفحة الافتراضية"
     VIRTUALPAGEWARNING: "يرجى اختيار صفحة مرتبطة وقم بالحفظ أولا من أجل نشر هذه الصفحة"
@@ -160,15 +244,38 @@ ar:
     SearchResults: "نتائج البحث"
   SideReport:
     BROKENFILES: "صفحات مع ملفات مكسورة"
+    BROKENLINKS: "صفحات مع روباط مكسورة"
     BROKENREDIRECTORPAGES: "معيد التوجيه الصفحات يشير إلى صفحات محذوفة"
     BROKENVIRTUALPAGES: "الصفحات الظاهرية تشير إالى صفحات محذوفة"
     BrokenLinksGroupTitle: "تقارير الروابط المكسورة"
     ContentGroupTitle: "تقارير المحتوى"
     EMPTYPAGES: "صفحات فارغة"
     LAST2WEEKS: "صفحات تم تعديلها في آخر أسبوعين"
+    OtherGroupTitle: أخرى
     ParameterLiveCheckbox: "التأكد من حيوية الموقع"
+    REPEMPTY: "التقرير {title} فارغ."
   SilverStripeNavigator:
     ARCHIVED: المؤرشف
+  SilverStripeNavigatorLink:
+    ShareLink: "رابط مشترك"
+  SilverStripeNavigatorLinkl:
+    CloseLink: إغلاق
+  SiteConfig:
+    DEFAULTTHEME: "( استخدام الثيم الافتراضي )"
+    EDITHEADER: "من يستطيع تحرير الصفحات الموجودة على هذا الموقع؟"
+    EDIT_PERMISSION: "إدارة إعدادات الموقع"
+    EDIT_PERMISSION_HELP: "القدرة على تحرير إعدادات الوصول العالمي / أذونات صفحة المستوى الأعلى."
+    PLURALNAME: "تكوينات الموقع"
+    SINGULARNAME: "تهيئة الموقع"
+    SITENAMEDEFAULT: "اسم عنوان موقعك"
+    SITETAGLINE: "علامة / شعار الموقع"
+    SITETITLE: "عنوان الموقع"
+    TABACCESS: الوصول
+    TABMAIN: الرئيسي
+    TAGLINEDEFAULT: "علامتك هنا"
+    THEME: الثيم
+    TOPLEVELCREATE: "من يستطيع إنشاء صفحات في جذر الموقع؟"
+    VIEWHEADER: "من يستطيع عرض الصفحات على هذا الموقع؟..."
   SiteTree:
     ACCESSANYONE: الجميع
     ACCESSHEADER: "من يستطيع مشاهدة هذه الصفحة ؟"
@@ -176,6 +283,7 @@ ar:
     ACCESSONLYTHESE: "فقط هؤلاء الأشخاص ( اختر من القائمة)"
     ADDEDTODRAFTHELP: "لم تنشر الصفحة بعد"
     ADDEDTODRAFTSHORT: المسودة
+    ALLOWCOMMENTS: "السماح بالتعليقات في هذه الصفحة ؟"
     APPEARSVIRTUALPAGES: "يظهر هذا المحتوى أيضا على الصفحات الافتراضية في أقسام {title}."
     BUTTONCANCELDRAFT: "إلغاء التغييرات في المسودة"
     BUTTONCANCELDRAFTDESC: "إلغاء المسودة و العودة إلى الموقع المنشور حالياً"
@@ -189,7 +297,10 @@ ar:
     DEFAULTABOUTTITLE: حول
     DEFAULTCONTACTTITLE: "اتصل بنا"
     DEFAULTHOMETITLE: الرئيسة
+    DELETEDPAGEHELP: "لم تعد الصفحة المنشورة"
+    DELETEDPAGESHORT: المحذوف
     DEPENDENT_NOTE: "الصفحات التالية تعتمد على هذه الصفحة. وهذا يشمل صفحات الظاهري، وصفحات معيد التوجيه، والصفحات التي تحتوي على روابط المحتوى."
+    DESCRIPTION: "صفحة المحتوى العام"
     DependtPageColumnLinkType: "نوع الرابط"
     DependtPageColumnURL: رابط
     EDITANYONE: "أي شخص "
@@ -227,17 +338,22 @@ ar:
     PARENTTYPE_SUBPAGE: "صفحة فرعية أسفل صفحة رئيسية (اختر أدناه)"
     PERMISSION_GRANTACCESS_DESCRIPTION: "التحكم في المجموعات التي لها صلاحية الدخول أو التعديل على صفحات محددة"
     PERMISSION_GRANTACCESS_HELP: "السماح بضع القيود على الوصول صفحة محددة في قسم \"الصفحات\"."
+    PLURALNAME: الصفحات
     PageTypNotAllowedOnRoot: "نوع الصفحة \"{type}\" غير مسموح به على مستوى الجذر"
     PageTypeNotAllowed: "نوع الصفحة  \"{type}\" لا يسمح به كتابع لهذه الصفحة الرئيسية"
+    REMOVEDFROMDRAFTHELP: "تم نشر الصفحة، ولكن تم حذفها من المسودة"
+    REMOVEDFROMDRAFTSHORT: "حذف من المسودّة"
     REMOVE_INSTALL_WARNING: "تحذير: يجب إزالة install.php من هذا التثبيت SilverStripe وذلك لأسباب أمنية."
     REORGANISE_DESCRIPTION: "Can reorganise the site tree"
     REORGANISE_HELP: "إعادة ترتيب الصفحات في  شجرة الموقع من خلال السحب والإسقاط."
     SHOWINMENUS: "عرض في قوائم ؟"
     SHOWINSEARCH: "عرض في البحث ؟"
+    SINGULARNAME: الصفحة
     TABBEHAVIOUR: الشسلوك
     TABCONTENT: المحتوى
     TABDEPENDENT: "الصفحات المعتدة"
     TOPLEVEL: "محتوى الموقع ( مستوى أعلى )"
+    TOPLEVELCREATORGROUPS: "منشيء المستوى الأعلى"
     URLSegment: "جزء رابط الموقع"
     VIEWERGROUPS: "مجموعات الزوار"
     VIEW_ALL_DESCRIPTION: "Can view any page on the site, bypassing page specific security"
@@ -262,7 +378,9 @@ ar:
     HAVEASKED: "تم طلب مشاهدة محتوى الموقع في"
   VirtualPage:
     CHOOSE: "الصفحة المرتبطة"
+    DESCRIPTION: "يعرض محتوى صفحة أخرى"
     EditLink: حرر
     HEADER: "هذه صفحة افتراضية"
     HEADERWITHLINK: "هذه صفحة افتراضية تنسخ المحتوى من \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "نوع الصفحة الأصلية \"{type}\"غير مسموح به على مستوى الجذر لهذه الصفحة الافتراضية"
+    SINGULARNAME: "الصفحة الافتراضية"

--- a/lang/az.yml
+++ b/lang/az.yml
@@ -1,4 +1,8 @@
 az:
+  CMSMain:
+    DELETE: "Qaralama saytdan sil"
+    DELETEFP: "Dərc olunmuş saytdan sil"
+    SAVE: "Yadda saxla"
   ContentControl:
     NOTEWONTBESHOWN: "Qeyd: Bu mesaj ziyarətçilər üçün görünməyəcək"
   ContentController:
@@ -15,6 +19,10 @@ az:
     CODE: "Səhv kodu"
     DEFAULTERRORPAGECONTENT: "<P> Üzr istəyirik, görünür siz mövcud olan səhifəyə giriş əldə etməyə cəhd edirdiniz. </p><p>Xahiş sizin giriş əldə etməyə və bir daha sınaqdan keçirməyə cəhd etdiyiniz URL-i yoxlayasınız </p>"
     DEFAULTERRORPAGETITLE: "Səhifə tapılmadı"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "İşlənməyən şəkilləri sil"
+    UNUSEDFILESTITLE: "İstifadəsiz fayllar"
+    UNUSEDTHUMBNAILSTITLE: "İşlənməyən şəkillər"
   Permissions:
     CONTENT_CATEGORY: "Məzmun səlahiyyətləri"
     PERMISSIONS_CATEGORY: İcazələr
@@ -30,11 +38,29 @@ az:
     GO: Göndər
     SEARCH: Axtar
     SearchResults: "Axtarış nəticələri"
+  SilverStripeNavigatorLink:
+    ShareLink: "Linki Paylaş"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Bağla
+  SiteConfig:
+    DEFAULTTHEME: "(Susmaya görə olan şablon)"
+    EDITHEADER: "Bu saytda səhifələri kim redaktə edə bilər?"
+    EDIT_PERMISSION: "Sayt konfigurasiyasını sazla"
+    SITENAMEDEFAULT: "Saytın adı"
+    SITETAGLINE: "Saytın sloqanı"
+    SITETITLE: "Saytın başlığı"
+    TABACCESS: İcazə
+    TABMAIN: Əsas
+    TAGLINEDEFAULT: "Sizin sloganınız burda"
+    THEME: Şablon
+    TOPLEVELCREATE: "Saytın kəlləsində kim səhifə yarada bilər?"
+    VIEWHEADER: "Bu saytda səhifələri kim görə bilir?"
   SiteTree:
     ACCESSANYONE: "Hər kəs"
     ACCESSHEADER: "Bu səhifəyə kimlər baxa bilər?"
     ACCESSLOGGEDIN: "Daxil olmuş istifadəçilər"
     ACCESSONLYTHESE: "Yalnız aşağıdakılar(siyahıdan seçin)"
+    ALLOWCOMMENTS: "Bu səhifədə şərhlərə icazə verilsin?"
     BUTTONCANCELDRAFT: "Qaralama dəyişiklikləri imtina et"
     BUTTONCANCELDRAFTDESC: "Qaralamanı sil və cari dərc olunmuş versiyaya qaytar"
     BUTTONUNPUBLISH: "Dərci ləğv et"
@@ -69,6 +95,7 @@ az:
     TABCONTENT: Məzmun
     TABDEPENDENT: "Asılı səhifələr"
     TOPLEVEL: "Saytın məzmunu (yuxarı səviyyə)"
+    TOPLEVELCREATORGROUPS: "Yuxarı səviyyə yaradıcıları"
     URLSegment: "URL seqmenti"
     VIEW_ALL_DESCRIPTION: "İstənilən səhifəyə bax"
     VIEW_DRAFT_CONTENT: "Qaralama məzmuna bax"
@@ -77,3 +104,4 @@ az:
     many_many_LinkTracking: "Keçidin izlənməsi"
   VirtualPage:
     HEADER: "Bu virtual səhifədir"
+    SINGULARNAME: "Virtual səhifə"

--- a/lang/bg.yml
+++ b/lang/bg.yml
@@ -1,7 +1,41 @@
 bg:
+  AssetAdmin:
+    ADDFILES: "Добави файлове"
+    ActionAdd: "Добави директория"
+    AppCategoryArchive: Архив
+    AppCategoryAudio: Аудио
+    AppCategoryDocument: Документ
+    AppCategoryFlash: Флаш
+    AppCategoryImage: Изображение
+    AppCategoryVideo: Видео
+    BackToFolder: "Обратно към директорията"
+    CMSMENU_OLD: "Файлове (стара версия)"
+    CREATED: "Дата на създаване"
+    CurrentFolderOnly: "Ограничи в текущата директория?"
+    DetailsView: Детайли
+    FILES: Файлове
+    FILESYSTEMSYNC: "Синхронизирай файловете"
+    FILESYSTEMSYNCTITLE: "Актуализира базата данни с файловете от файловата система. Полезно когато файлове са били качени не през системата, а например през FTP."
+    FROMTHEINTERNET: "От интернет"
+    FROMYOURCOMPUTER: "От компютъра"
+    Filetype: "Тип на файла"
+    ListView: "Изглед в списък"
+    MENUTITLE: Файлове
+    NEWFOLDER: "Нова директория"
+    SIZE: Размер
+    TreeView: "Дървовиден изглед"
+    Upload: Качване
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Изтрити папки"
+  AssetAdmin_Tools:
+    FILTER: Филтър
+  AssetAdmin_left_ss:
+    GO: Давай
   AssetTableField:
     BACKLINKCOUNT: "Използвано от:"
     PAGES: Страница/и
+  BackLink_Button_ss:
+    Back: Назад
   BrokenLinksReport:
     Any: Всички
     BROKENLINKS: "Списък на развалени линкове"
@@ -27,10 +61,18 @@ bg:
   CMSAddPageController:
     Title: "Добави страница"
   CMSBatchActions:
+    ARCHIVE: Архив
+    ARCHIVED_PAGES: "Бяха архивирани %d страници"
+    DELETED_DRAFT_PAGES: "Публикувани %d страници от черновата на сайта, %d грешки"
+    DELETED_PAGES: "Публикувани %d страници, %d грешки"
+    DELETE_DRAFT_PAGES: "Изтрий от черновите"
+    DELETE_PAGES: "Изтрий от публикуваните страници"
     PUBLISHED_PAGES: "Публикувани %d страници, %d грешки"
     PUBLISH_PAGES: Публикувай
     RESTORE: Възстанови
     RESTORED_PAGES: "Бяха възстановени %d страници"
+  CMSFileAddController:
+    MENUTITLE: Файлове
   CMSMain:
     ACCESS: "Достъп до '{title}' секция"
     ACCESS_HELP: "Разреши излгед на раздела съдържащ структурното дърво и съдържанието. Правата за достъп и редактиране могат да бъдат променени през падащи менюта (dropdowns), както и чрез отделни права на съдържанието"
@@ -43,8 +85,12 @@ bg:
     ChoosePageParentMode: "Избери къде да създадеш тази страница"
     ChoosePageType: "Избери тип на страницата"
     Create: Създай
+    DELETE: "Изтрий черновата и отиди на текущата публикувана страница"
+    DELETEFP: Изтрии
     DUPLICATED: "'{title}' беше успешно дублирана"
     DUPLICATEDWITHCHILDREN: "'{title}' и под-страниците бяха успешно дублирани"
+    EditTree: "Редактиране на дървото"
+    MENUTITLE: "Редактиране на страницата"
     NEWPAGE: "Нова страница {pagetype}"
     PAGENOTEXISTS: "Тази страница не съществува"
     PAGETYPEANYOPT: Всички
@@ -62,17 +108,25 @@ bg:
     ROLLBACK: "Върни към тази версия"
     ROLLEDBACKPUBv2: "Беше върнато до публикуваната версия"
     ROLLEDBACKVERSIONv2: "Беше върната версия #%d."
+    SAVE: Запис
     SAVED: "Страница '{title}' беше записана успешно."
     SAVEDRAFT: "Запиши чернова"
     TabContent: Съдържание
     TabHistory: История
     TabSettings: Настройки
+  CMSMain_left_ss:
+    RESET: Нулирай
   CMSPageAddController:
+    MENUTITLE: "Добави страница"
     ParentMode_child: "Под друга страница"
     ParentMode_top: "Най-високо ниво"
+  CMSPageEditController:
+    MENUTITLE: "Редактиране на страницата"
   CMSPageHistoryController:
     COMPAREMODE: "Режим на сравнение (Избери два)"
     COMPAREVERSIONS: "Сравни версиите"
+    COMPARINGVERSION: "Сравняване на версии {version1} и {version2}."
+    MENUTITLE: История
     REVERTTOTHISVERSION: "Върни към тази версия"
     SHOWUNPUBLISHED: "Покажи непублекуваната версия"
     SHOWVERSION: "Покажи версията"
@@ -85,7 +139,10 @@ bg:
     PUBLISHER: "Публикувана от"
     UNKNOWN: Неизвестно
     WHEN: Кога
+  CMSPageSettingsController:
+    MENUTITLE: "Редактиране на страницата"
   CMSPagesController:
+    GalleryView: "Изглед в галерия"
     ListView: "Изглед в списък"
     MENUTITLE: Страници
     TreeView: "Дървовиден изглед"
@@ -95,8 +152,11 @@ bg:
     Title: "Публикувани страници"
   CMSSearch:
     FILTERDATEFROM: От
+    FILTERDATEHEADING: Дата
     FILTERDATETO: До
     PAGEFILTERDATEHEADING: "Последна редакция"
+  CMSSettingsController:
+    MENUTITLE: Настройки
   CMSSiteTreeFilter_Search:
     Title: "Всички страници"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -109,6 +169,7 @@ bg:
     CMS: "СУС (CMS)"
     DRAFT: Чернова
     DRAFTSITE: Чернови
+    DRAFT_SITE_ACCESS_RESTRICTION: "Трябва да влезете с вашата CMS парола, за да видите черновата или архивираното съдържание. <a href=\"%s\">Натиснете тук, за да се върнете обратно към публикувания сайт.</a>"
     Email: "Ел. поща"
     INSTALL_SUCCESS: "Инсталацията премина успешно."
     InstallFilesDeleted: "Инсталационните файлове са успешно изтрити."
@@ -154,17 +215,43 @@ bg:
     DEFAULTERRORPAGETITLE: "Страницата не беше намерена"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Проблем при изпълнението на заявката.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Сървърна грешка"
+    DESCRIPTION: "Специално съдържание при различни грешки (напр. \"Страницата не съществува\")"
+    PLURALNAME: "Страници от тип грешка"
+    SINGULARNAME: "Страница от тип грешка"
+  File:
+    Title: Име
+  Folder:
+    AddFolderButton: "Добави папка"
+    DELETEUNUSEDTHUMBNAILS: "Изтрий неизползвани миниатури"
+    UNUSEDFILESTITLE: "Неизползвани файлове"
+    UNUSEDTHUMBNAILSTITLE: "Неизползвани миниатури"
+    UploadFilesButton: "Качи "
+  LeftAndMain:
+    DELETED: Изтрит
+    PreviewButton: Изглед
+    SAVEDUP: Записано
+    SearchResults: "Резултати от търсенето"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Достъп до CMS"
   Permissions:
     CONTENT_CATEGORY: "Права по съдържанието"
     PERMISSIONS_CATEGORY: "Роли и права за достъп"
   RedirectorPage:
+    DESCRIPTION: "Препрати към друга вътрешна за сайта, страница"
     HASBEENSETUP: "Създадена е страница за пренасочване без да има накъде да се пренасочи."
     HEADER: "Тази страница ще пренасочи потребители към друга страница"
     OTHERURL: "Друг уебсайт URL"
+    PLURALNAME: "Страница за пренасочване"
     REDIRECTTO: "Пренасочи към"
     REDIRECTTOEXTERNAL: "Друг уебсайт"
     REDIRECTTOPAGE: "Страница на вашият уебсайт"
+    SINGULARNAME: "Пренасочваща страница"
     YOURPAGE: "Страница на вашият уебсайт"
+  ReportAdmin:
+    MENUTITLE: "Отчети за съдържание"
+    ReportTitle: Заглавие
+  ReportAdminForm:
+    FILTERBY: "Филтрирай по"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Моля, публикувайте свързаните страници, за да бъдат публикувани и виртуалните."
     VIRTUALPAGEWARNING: "Моля, първо изберете свързана страница и запишете, за да можете да публикувате тази страница."
@@ -174,15 +261,38 @@ bg:
     SearchResults: "Резултати от търсенето"
   SideReport:
     BROKENFILES: "Страници с несъществуващи файлове"
+    BROKENLINKS: "Страници съдържащи невалидни препратки."
     BROKENREDIRECTORPAGES: "Пренасочващи страници, които сочат към изтрити страници"
     BROKENVIRTUALPAGES: "Виртуални страници, които сочат към изтрити страници"
     BrokenLinksGroupTitle: "Отчет за страници съдържащи невалидни препратки."
     ContentGroupTitle: "Отчети за съдържание"
     EMPTYPAGES: "Страници без съдържание"
     LAST2WEEKS: "Страници редактирани през последните 2 седмици"
+    OtherGroupTitle: собственник
     ParameterLiveCheckbox: "Провери реалния сайт"
+    REPEMPTY: "Отчетът {title}  е празен"
   SilverStripeNavigator:
     ARCHIVED: Архивирани
+  SilverStripeNavigatorLink:
+    ShareLink: "Препратка за споделяне"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Затвори
+  SiteConfig:
+    DEFAULTTHEME: "(използвай тема по подразбиране)"
+    EDITHEADER: "Кой може да редактира страници по сайта?"
+    EDIT_PERMISSION: "Промяна на конфигурацията на сайта"
+    EDIT_PERMISSION_HELP: "Възможност за редакция на глобалните правила за достъп / правата на страниците, най-високо в йерархията"
+    PLURALNAME: "Конфигурации на сайта"
+    SINGULARNAME: "Конфигурация на сайта"
+    SITENAMEDEFAULT: "Име на сайта"
+    SITETAGLINE: "Подзаглавие на сайта"
+    SITETITLE: "Заглавие на сайта"
+    TABACCESS: Достъп
+    TABMAIN: Съдържание
+    TAGLINEDEFAULT: Подзаглавие
+    THEME: Тема
+    TOPLEVELCREATE: "Кой може да създава най-високо ниво страници?"
+    VIEWHEADER: "Кой може да достъпи страницата?"
   SiteTree:
     ACCESSANYONE: Всеки
     ACCESSHEADER: "Кой има достъп до тази страница на моят сайт?"
@@ -190,9 +300,11 @@ bg:
     ACCESSONLYTHESE: "Само тези хора (изберете от списъка)"
     ADDEDTODRAFTHELP: "Страници, които не са публикувани"
     ADDEDTODRAFTSHORT: Чернова
+    ALLOWCOMMENTS: "Разрешавате ли коментари на тази страница?"
     APPEARSVIRTUALPAGES: "Съдържанието присъства във виртуалните страници в секция {title}."
     ARCHIVEDPAGEHELP: "Страницата е премахната от сайта и от черновите"
     ARCHIVEDPAGESHORT: Архивирани
+    BUTTONARCHIVEDESC: "Премахни от публикация и запиши в архива"
     BUTTONCANCELDRAFT: "Отмени промените в черновата"
     BUTTONCANCELDRAFTDESC: "Изтрий черновата и отиди на текущата публикувана страница"
     BUTTONPUBLISHED: Публикувана
@@ -206,7 +318,10 @@ bg:
     DEFAULTCONTACTTITLE: "За контакт"
     DEFAULTHOMECONTENT: "<p>Това е съдържанието по подразбиране на началната страница. Можете да редактирате тази страница като влезете в <a href=\"admin/\">СУС (CMS)</a>.</p><p>Също така можете да разгледате <a href=\"http://docs.silverstripe.org\">документацията за разработчици</a> или да започнете с <a href=\"http://www.silverstripe.org/learn/lessons\">уроците по SilverStripe</a>.</p>"
     DEFAULTHOMETITLE: Начало
+    DELETEDPAGEHELP: "Страницата вече не е публикувана"
+    DELETEDPAGESHORT: Изтрита
     DEPENDENT_NOTE: "Следните страници зависят от тази страница. Това включва виртуални страници, пренасочващи страници и страници с препратки в съдържанието към тази страница."
+    DESCRIPTION: "Обща страница със съдържание"
     DependtPageColumnLinkType: "Тип на връзката"
     DependtPageColumnURL: URL
     EDITANYONE: "Всеки, който може да влезе в CMS"
@@ -244,17 +359,22 @@ bg:
     PARENTTYPE_SUBPAGE: Подстраница
     PERMISSION_GRANTACCESS_DESCRIPTION: "Управление на правата за достъп до съдържанието"
     PERMISSION_GRANTACCESS_HELP: "Разреши настройката на специфични ограничения за достъп в раздела \"Страници\""
+    PLURALNAME: Страници
     PageTypNotAllowedOnRoot: "Страница от тип \"{type}\" не може да бъде създадена в основното ниво на дървото"
     PageTypeNotAllowed: "Страница от тип \"{type}\" не може да е подстраница на тази страница"
+    REMOVEDFROMDRAFTHELP: "Страницата  е публикувана, но е изтрита от черновата"
+    REMOVEDFROMDRAFTSHORT: "Изтрии от чернова"
     REMOVE_INSTALL_WARNING: "Внимание: Трябва да изтриете install.php от тази Silverstripe инсталация от съображения за сигурност."
     REORGANISE_DESCRIPTION: "Промени структурата на сайта"
     REORGANISE_HELP: "Реорганизирай страниците в дървото чрез \"drag&drop\" (теглене и пускане)"
     SHOWINMENUS: "Покажи в менютата?"
     SHOWINSEARCH: "Покажи в търсене?"
+    SINGULARNAME: Страница
     TABBEHAVIOUR: Поведение
     TABCONTENT: Съдържание
     TABDEPENDENT: "Зависими страници"
     TOPLEVEL: "Съдържание на сайта (Top level)"
+    TOPLEVELCREATORGROUPS: "Автори на страници от най-високо ниво"
     URLSegment: "URL - Сегмент"
     VIEWERGROUPS: "Групи потребители"
     VIEW_ALL_DESCRIPTION: "Достъп до всяка страница"
@@ -271,3 +391,4 @@ bg:
     CANACCESS: "Можете да достигнете архивирания сайт, чрез тази връзка"
   VirtualPage:
     HEADER: "Това е виртуална страница"
+    SINGULARNAME: "Виртуална страница"

--- a/lang/bs.yml
+++ b/lang/bs.yml
@@ -1,16 +1,46 @@
 bs:
+  AssetAdmin:
+    ADDFILES: "Dodaj datoteke"
+    ActionAdd: "Kreiraj direktorij"
+    AppCategoryArchive: Arhiva
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Dokument
+    BackToFolder: "Nazad na direktorij"
+    CREATED: Datum
+    CurrentFolderOnly: "Limitiraj na trenutni direktorij?"
+    DetailsView: Detalji
+    FILES: Datoteke
+    FILESYSTEMSYNC: "Sinhroniziraj datoteke"
+    FROMTHEINTERNET: "Sa interneta"
+    FROMYOURCOMPUTER: "Sa Vašeg kompijutera"
+    Filetype: "Tip datoteke"
+    MENUTITLE: Datoteke
+    NEWFOLDER: NoviDirektorij
+    SIZE: Veličina
+    THUMBSDELETED: "{count} nekorištenih je obrisano"
+    Upload: Upload
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Izbriši direktorije"
+  AssetAdmin_Tools:
+    FILTER: Filter
+  AssetAdmin_left_ss:
+    GO: Idi
   AssetTableField:
     BACKLINKCOUNT: "Korišteno ovdje:"
     PAGES: strana(ice)
+  BackLink_Button_ss:
+    Back: Nazad
   BrokenLinksReport:
     Any: "Bilo koji"
   CMSMain:
     Create: Kreiraj
+    DELETE: "Izbriši sa privremenog nacrta stranice"
     PAGENOTEXISTS: "Ova stranica ne postoji"
     PUBALLCONFIRM: "Molimo, objavite svaku stavku na ovoj stranici, kopiranjem sadržaja na aktivnu stranicu"
     PUBALLFUN: "Funkcija \"Objavi sve\""
     REMOVEDPAGEFROMDRAFT: "Uklonjeno '%s' sa privremenog nacrta stranice"
     ROLLBACK: "Vrati na ovo izdanje"
+    SAVE: Snimi
   ErrorPage:
     400: "400 - Pogrešan zahtjev"
     401: "401 - Neovlašteno"
@@ -38,6 +68,10 @@ bs:
     CODE: "Kod greške"
     DEFAULTERRORPAGECONTENT: "<p>Žao nam je, pokušali ste pristupiti stranici koja ne postoji.</p><p>Molimo provjerite da li ste ispravno ukucali URL kojem ste pokušali pristupiti i pokušajte ponovo.</p>"
     DEFAULTERRORPAGETITLE: "Stranica nije pronađena"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Izbriši neiskorištene sličice"
+    UNUSEDFILESTITLE: "Neiskorištene datoteke"
+    UNUSEDTHUMBNAILSTITLE: "Neiskorištene sličice"
   RedirectorPage:
     HASBEENSETUP: "Stranica za preusmjeravanje je podešena bez odredišta."
     HEADER: "Ova stranica će preusmjeriti korisnike na drugu stranicu"
@@ -57,6 +91,7 @@ bs:
     ACCESSHEADER: "Ko može pregledati ovu stavku na mojoj stranici?"
     ACCESSLOGGEDIN: "Prijavljeni korisnici"
     ACCESSONLYTHESE: "Samo ovi korisnici (izaberite sa popisa)"
+    ALLOWCOMMENTS: "Dozvoli komentare na ovoj stranici?"
     BUTTONCANCELDRAFT: "Poništi promjene privremenog nacrta stranice"
     BUTTONCANCELDRAFTDESC: "Izbrišite Vaš privremeni nacrt stranice i vratite se na trenutno objavljenu stranicu"
     BUTTONUNPUBLISH: "Opozovi objavljivanje"

--- a/lang/ca.yml
+++ b/lang/ca.yml
@@ -1,10 +1,17 @@
 ca:
+  AssetAdmin:
+    NEWFOLDER: NovaCarpeta
+  AssetAdmin_left_ss:
+    GO: Vés
   CMSMain:
+    DELETE: "Suprimeix del lloc esborrany"
+    DELETEFP: "Suprimeix del lloc publicat"
     PAGENOTEXISTS: "Aquesta pàgina no existeix"
     PUBALLCONFIRM: "Publica cada pàgina del lloc web, copiant el contingut cap a la versió publicada"
     PUBALLFUN: "Funcionalitat de \"Publica-ho tot\""
     REMOVEDPAGEFROMDRAFT: "S'ha suprimit  '%s' del lloc esborrany"
     ROLLBACK: "Torna a aquesta versió"
+    SAVE: Desa
   ErrorPage:
     400: "400 - Mala petició"
     401: "401 - Sense autorització"
@@ -32,6 +39,10 @@ ca:
     CODE: "Codi d'error"
     DEFAULTERRORPAGECONTENT: "<p>Sembla que intenteu accedir a una pàgina que no existeix.</p><p>Si us plau, reviseu com heu escrit la URL que intenteu accedir i proveu-ho de nou.</p>"
     DEFAULTERRORPAGETITLE: "Pàgina no trobada"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Suprimeix les miniatures no usades"
+    UNUSEDFILESTITLE: "Fitxers no usats"
+    UNUSEDTHUMBNAILSTITLE: "Miniatures no usades"
   RedirectorPage:
     HASBEENSETUP: "S'ha definit una pàgina redirectora sense cap lloc on redirigir."
     HEADER: "Aquesta pàgina redirigirà usuaris a una altra pàgina"
@@ -51,6 +62,7 @@ ca:
     ACCESSHEADER: "Qui pot veure aquesta pàgina al meu lloc web?"
     ACCESSLOGGEDIN: "Usuaris connectats"
     ACCESSONLYTHESE: "Només aquesta gent (trieu de la llista)"
+    ALLOWCOMMENTS: "Permet comentaris en aquesta pàgina?"
     BUTTONCANCELDRAFT: "Cancel·la els canvis de l'esborrany"
     BUTTONCANCELDRAFTDESC: "Suprimeix el vostre esborrany i reverteix a la pàgina actualment publicada"
     BUTTONUNPUBLISH: Despublica
@@ -89,3 +101,4 @@ ca:
     HAVEASKED: "Heu demanat de veure el contingut del nostre lloc el"
   VirtualPage:
     HEADER: "Aquesta és una pàgina virtual"
+    SINGULARNAME: "Pàgina virtual"

--- a/lang/cs.yml
+++ b/lang/cs.yml
@@ -1,7 +1,42 @@
 cs:
+  AssetAdmin:
+    ADDFILES: "Přidat soubory"
+    ActionAdd: "Přidat složku"
+    AppCategoryArchive: Archív
+    AppCategoryAudio: Zvuk
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Obrázek
+    AppCategoryVideo: Video
+    BackToFolder: "Zpět na složku"
+    CMSMENU_OLD: "Soubory (staré)"
+    CREATED: Datum
+    CurrentFolderOnly: "Omezit na aktuální složku?"
+    DetailsView: Podrobnosti
+    FILES: Soubory
+    FILESYSTEMSYNC: "Synchronizovat soubory"
+    FILESYSTEMSYNCTITLE: "Aktualizace záznamů souborů databáze CMS na souborovém systému. Užitečné, když byly nové soubory nahrány mimo CMS, např. přes FTP."
+    FROMTHEINTERNET: "Z internetu"
+    FROMYOURCOMPUTER: "Z vašeho počítače"
+    Filetype: "Typ souboru"
+    ListView: Seznam
+    MENUTITLE: Soubory
+    NEWFOLDER: "Nová složka"
+    SIZE: Velikost
+    THUMBSDELETED: "{count} nepoužitých miniatur bylo smazáno"
+    TreeView: "Zobrazit strom"
+    Upload: Nahrát
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Smazat složky"
+  AssetAdmin_Tools:
+    FILTER: Filtr
+  AssetAdmin_left_ss:
+    GO: Proveď
   AssetTableField:
     BACKLINKCOUNT: "Použito na:"
     PAGES: stránka(y)
+  BackLink_Button_ss:
+    Back: Zpět
   BrokenLinksReport:
     Any: Jakékoliv
     BROKENLINKS: "Výkaz porušených odkazů"
@@ -27,10 +62,18 @@ cs:
   CMSAddPageController:
     Title: "Přidat stránku"
   CMSBatchActions:
+    ARCHIVE: Archivovat
+    ARCHIVED_PAGES: "Archivovaných %d stránek"
+    DELETED_DRAFT_PAGES: "Smazáno %d stránek z konceptu webu, %d selhání"
+    DELETED_PAGES: "Odstraněno %d stránek z veřejného webu, %d selhání"
+    DELETE_DRAFT_PAGES: "Smazat z konceptu webu"
+    DELETE_PAGES: "Smazat ze zveřejněného webu"
     PUBLISHED_PAGES: "Zveřejněných %d stránek, %d selhání"
     PUBLISH_PAGES: Zveřejnit
     RESTORE: Obnovit
     RESTORED_PAGES: "Obnoveno %d stránek"
+  CMSFileAddController:
+    MENUTITLE: Soubory
   CMSMain:
     ACCESS: "Přístup k '{title}' sekci"
     ACCESS_HELP: "Povolit prohlížení sekce obsahující strukturu a obsah webu. Oprávnění na prohlížení a úpravu mohou být nastavena skrze menu pro samostatnou stránku, také jako jednotlivé oprávnění pro obsah."
@@ -43,8 +86,13 @@ cs:
     ChoosePageParentMode: "Vyberte, kde vytvořit tuto stránku"
     ChoosePageType: "Vyberte typ stránky"
     Create: Vytvořit
+    DELETE: "Smazat koncept"
+    DELETEFP: "Smazat z publikovaných stránek"
+    DESCREMOVED: "a {count} potomků"
     DUPLICATED: "Duplikováno '{title}' úspěšně"
     DUPLICATEDWITHCHILDREN: "Duplikováno '{title}' a potomci úspěšně"
+    EditTree: "Upravit strom"
+    MENUTITLE: "Upravit stránku"
     NEWPAGE: "Nová {pagetype}"
     PAGENOTEXISTS: "Tato stránka neexistuje"
     PAGETYPEANYOPT: Jakékoliv
@@ -53,6 +101,7 @@ cs:
     PUBLISHED: "Publikováno '{title}' úspěšně"
     PUBPAGES: "Hotovo: Zveřejněno {count} stránek"
     PageAdded: "Stránka vytvořena úspěšně"
+    REMOVED: "Smazáno '{title}'{description} z webu"
     REMOVEDPAGE: "Odstraněno '{title}' ze zveřejněného webu"
     REMOVEDPAGEFROMDRAFT: "Odstraněno '%s' z konceptu webu"
     RESTORED: "Obnoveno '{title}' úspěšně"
@@ -62,17 +111,25 @@ cs:
     ROLLBACK: "Vrátit se zpět na tuto verzi"
     ROLLEDBACKPUBv2: "Vráceno zpět na zveřejněnou verzi."
     ROLLEDBACKVERSIONv2: "Vráceno zpět na verzi #%d."
+    SAVE: Uložit
     SAVED: "Uloženo '{title}' úspěšně"
     SAVEDRAFT: "Uložit koncept"
     TabContent: Obsah
     TabHistory: Historie
     TabSettings: Nastavení
+  CMSMain_left_ss:
+    RESET: Resetovat
   CMSPageAddController:
+    MENUTITLE: "Přidat stránku"
     ParentMode_child: "Pod jinou stránku"
     ParentMode_top: "Nejvyšší úroveň"
+  CMSPageEditController:
+    MENUTITLE: "Upravit stránku"
   CMSPageHistoryController:
     COMPAREMODE: "Porovnávací mód (vyberte dva)"
     COMPAREVERSIONS: "Porovnat verze"
+    COMPARINGVERSION: "Porovnání verzí {version1} a {version2}."
+    MENUTITLE: Historie
     REVERTTOTHISVERSION: "Zpět na tuto verzi"
     SHOWUNPUBLISHED: "Zobrazit nezveřejněné verze"
     SHOWVERSION: "Zobrazit verzi"
@@ -86,7 +143,10 @@ cs:
     PUBLISHER: Vydavatel
     UNKNOWN: Neznámý
     WHEN: Když
+  CMSPageSettingsController:
+    MENUTITLE: "Editovat stránku"
   CMSPagesController:
+    GalleryView: "Pohled galerie"
     ListView: "Pohled seznam"
     MENUTITLE: Stránky
     TreeView: "Pohled strom"
@@ -96,8 +156,11 @@ cs:
     Title: "Zveřejněné stránky"
   CMSSearch:
     FILTERDATEFROM: Od
+    FILTERDATEHEADING: Datum
     FILTERDATETO: Do
     PAGEFILTERDATEHEADING: "Poslední změna"
+  CMSSettingsController:
+    MENUTITLE: Možnosti
   CMSSiteTreeFilter_Search:
     Title: "Všechny stránky"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -110,6 +173,7 @@ cs:
     CMS: CMS
     DRAFT: Koncept
     DRAFTSITE: "Koncept webu"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Abyste mohli prohlížet archiv nebo koncepty, musíte být přihlášeni se svým CMS heslem. <a href=\"%s\">Klikněte sem pro návrat na zveřejněné stránky.</a>"
     Email: E-mail
     INSTALL_SUCCESS: "Instalace úspěšná!"
     InstallFilesDeleted: "Instalační soubory byly odstraněny úspěšně."
@@ -157,16 +221,38 @@ cs:
     DEFAULTERRORPAGETITLE: "Stránka nenelazena"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Promiňte, nastal problém s obsloužením vaší žádosti.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Chyba serveru"
+    DESCRIPTION: "Vlastní obsah pro různé případy chyb (např. \"Stránka nenalezena\")"
+    ERRORFILEPROBLEM: "Chyba otevření souboru \"{filename}\" pro zápis. Zkontrolujte oprávnění souboru, prosím."
+    PLURALNAME: "Chybová stránky"
+    SINGULARNAME: "Chybová stránka"
+  File:
+    Title: Název
+  Folder:
+    AddFolderButton: "Přidat složku"
+    DELETEUNUSEDTHUMBNAILS: "Smazat nepoužité miniatury"
+    UNUSEDFILESTITLE: "Nepoužité soubory"
+    UNUSEDTHUMBNAILSTITLE: "Nepoužité miniatury"
+    UploadFilesButton: Nahrát
+  LeftAndMain:
+    DELETED: Smazáno.
+    PreviewButton: Náhled
+    SAVEDUP: Uloženo.
+    SearchResults: "Výsledky hledání"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Přístup CMS"
   Permissions:
     CONTENT_CATEGORY: "Oprávnění obsahu"
     PERMISSIONS_CATEGORY: "Role a přístupová práva"
   RedirectorPage:
+    DESCRIPTION: "Přesměruje na jinou interní stránku"
     HASBEENSETUP: "Přesměrovací stránka byla nastavena bez cíle."
     HEADER: "Tato stránka přesměruje uživatele na jinou stránku"
     OTHERURL: "Jiná web adresa"
+    PLURALNAME: "Přesměrovací stránky"
     REDIRECTTO: "Přesměrovat na"
     REDIRECTTOEXTERNAL: "Jiná web stránka"
     REDIRECTTOPAGE: "Stránka na vašem webu"
+    SINGULARNAME: "Přesměrovací stránka"
     YOURPAGE: "Stránka na vašem webu"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Běž
@@ -178,6 +264,11 @@ cs:
     OPERATION_REMOVE: "Odstranit označené ze všech konceptů (Upozornění: Budou zničeny všechny označené stránky z obou koncept a živé)"
     SELECTALL: "označit vše"
     UNSELECTALL: "odznačit vše"
+  ReportAdmin:
+    MENUTITLE: Výkazy
+    ReportTitle: Titulek
+  ReportAdminForm:
+    FILTERBY: "Filtrovat dle"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Zveřejněte prosím odkazovanou stránku pro zveřejnění virtuální stránky"
     VIRTUALPAGEWARNING: "Zvolte prosím odkazovanou stránku a předem uložte před zveřejněním této stránky"
@@ -188,15 +279,22 @@ cs:
     SearchResults: "Výsledky hledání"
   SideReport:
     BROKENFILES: "Stránky s porušenými soubory"
+    BROKENLINKS: "Stránky s porušenými odkazy"
     BROKENREDIRECTORPAGES: "Přesměrovací stránky ukazují na smazané stránky"
     BROKENVIRTUALPAGES: "VirualPages ukazuje na smazané stránky"
     BrokenLinksGroupTitle: "Výkazy porušených odkazů"
     ContentGroupTitle: "Výkazy obsahu"
     EMPTYPAGES: "Stránky bez obsahu"
     LAST2WEEKS: "Stránky upravené během posledních 2 týdnů"
+    OtherGroupTitle: Jiné
     ParameterLiveCheckbox: "Zkontrolovat web"
+    REPEMPTY: "{title} výkaz je prázdný."
   SilverStripeNavigator:
     ARCHIVED: Archivováno
+  SilverStripeNavigatorLink:
+    ShareLink: "Sdílet odkaz"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Zavřít
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Přidat stránku"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -217,10 +315,28 @@ cs:
     SINGULARNAME: "Přesměrovací stránka"
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: "Obecný obsah stránky"
+    PLURALNAME: "Struktury webu"
+    SINGULARNAME: "Struktura webu"
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: "Zobrazí obsah jiné stránky"
     PLURALNAME: "Virtuální stránky"
     SINGULARNAME: "Virtuální stránka"
+  SiteConfig:
+    DEFAULTTHEME: "(Použít implicitní tému)"
+    EDITHEADER: "Kdo může editovat stránky tohoto webu?"
+    EDIT_PERMISSION: "Správa konfigurace webu"
+    EDIT_PERMISSION_HELP: "Možnost měnit globální přístupové nastavení/oprávnění pro hlavní stránky."
+    PLURALNAME: "Konfigurace webu"
+    SINGULARNAME: "Konfigurace webu"
+    SITENAMEDEFAULT: "Název tvého webu"
+    SITETAGLINE: "Štítek/Slogan webu"
+    SITETITLE: "Titulek webu"
+    TABACCESS: Přístup
+    TABMAIN: Hlavní
+    TAGLINEDEFAULT: "Slogan Vašeho webu"
+    THEME: Téma
+    TOPLEVELCREATE: "Kdo může vytvářet stránky v kořenu webu?"
+    VIEWHEADER: "Kdo může vidět stránky na tomto webu?"
   SiteTree:
     ACCESSANYONE: Kdokoliv
     ACCESSHEADER: "Kdo může tuto stránku prohlížet?"
@@ -228,9 +344,11 @@ cs:
     ACCESSONLYTHESE: "Jenom tito lidé (vyberte ze seznamu)"
     ADDEDTODRAFTHELP: "Stránka nebyla dosud zveřejněna"
     ADDEDTODRAFTSHORT: Koncept
+    ALLOWCOMMENTS: "Povolit pro tuto stránku komentáře?"
     APPEARSVIRTUALPAGES: "Tento obsah se také zobrazí na virtuálních stránkáchy v sekcích {title}."
     ARCHIVEDPAGEHELP: "Stránka je odstraněná z konceptu i z webu"
     ARCHIVEDPAGESHORT: Archivováno
+    BUTTONARCHIVEDESC: "Nezveřejnit a odeslat do archívu"
     BUTTONCANCELDRAFT: "Zrušit změny v konceptu"
     BUTTONCANCELDRAFTDESC: "Odstranit koncept a vrátit se k aktuálně zveřejněné stránce"
     BUTTONPUBLISHED: Zveřejněno
@@ -244,7 +362,10 @@ cs:
     DEFAULTCONTACTTITLE: "Kontaktujte nás"
     DEFAULTHOMECONTENT: "<p>Vítejte v SilverStripe! Toto je základní domácí stránka. Můžete ji upravit otevřením <a href=\"admin/\">CMS</a>.</p><p>Můžete také nyní vstoupit  do <a href=\"http://docs.silverstripe.org\">dokumentace vývojáře</a>, nebo se přiučit na <a href=\"http://www.silverstripe.org/learn/lessons\">SilverStripe lekcích</a>.</p>"
     DEFAULTHOMETITLE: "Úvodní strana"
+    DELETEDPAGEHELP: "Stránka už není více zveřejněna"
+    DELETEDPAGESHORT: Smazáno
     DEPENDENT_NOTE: "Následující stránky závisí na této stránce. Tyto obsahují virtuální stránky, přesměrovací stránky a stránky s odkazy obsahu."
+    DESCRIPTION: "Obecný obsah stránky"
     DependtPageColumnLinkType: "Typ odkazu"
     DependtPageColumnURL: URL
     EDITANYONE: "Kdokoliv, kdo se do CMS může přihlásit"
@@ -284,17 +405,22 @@ cs:
     PARENTTYPE_SUBPAGE: "Pod-stránka pod nadřazenou stránkou (vyberte dole)"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Správa přístupových práv pro obsah stránek"
     PERMISSION_GRANTACCESS_HELP: "Povolit nastavení omezení na specifické stránky v sekci \"Stránky\"."
+    PLURALNAME: Stránky
     PageTypNotAllowedOnRoot: "Stránka typu \"{type}\" není povolena na nejvyšší úrovni"
     PageTypeNotAllowed: "Stránka typu \"{type}\" není povolena jako potomek této nadřízené stránky"
+    REMOVEDFROMDRAFTHELP: "Stránka je zveřejněna, ale byla odstraněna z konceptu"
+    REMOVEDFROMDRAFTSHORT: "Odstraněno z konceptu"
     REMOVE_INSTALL_WARNING: "Upozornění: Měli by jste odstranit soubor install.php z této instalace SilverStripe z bezpečnostních důvodů."
     REORGANISE_DESCRIPTION: "Změna struktury webu"
     REORGANISE_HELP: "Reorganizace stránek webu pomocí  \"táhni a pusť\"."
     SHOWINMENUS: "Zobrazovat v menu?"
     SHOWINSEARCH: "Zobrazovat ve vyhledávání?"
+    SINGULARNAME: Stránka
     TABBEHAVIOUR: Chování
     TABCONTENT: Obsah
     TABDEPENDENT: "Závislé stránky"
     TOPLEVEL: "Obsah Webu (Nejvyšší úroveň)"
+    TOPLEVELCREATORGROUPS: "Tvůrci nejvyšší úrovně"
     URLSegment: "Segment URL"
     VIEWERGROUPS: "Prohlížeč skupin"
     VIEW_ALL_DESCRIPTION: "Může vidět jakoukoli stránku webu, obcházeje bezpečnostní specifikaci stránky"
@@ -308,6 +434,8 @@ cs:
     many_many_ImageTracking: "Stopování obrázku"
     many_many_LinkTracking: "Stopování odkazu"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Seznam zobrazuje všechny stránky, kde byl soubor přidán pomocí WYSIWYG editoru."
+    EDIT: Editovat
     TITLE_INDEX: "#"
     TITLE_TYPE: Typ
     TITLE_USED_ON: "Použito na"
@@ -323,7 +451,10 @@ cs:
     HAVEASKED: "Požadovali jste prohlížet obsah našich stránek během"
   VirtualPage:
     CHOOSE: "Odkazovaná stránka"
+    DESCRIPTION: "Zobrazit obsah jiné stránky"
     EditLink: editovat
     HEADER: "Toto je virtuální stránka"
     HEADERWITHLINK: "Toto je virtuální stránka, kopíruje se obsah z \"{title}\" ({link})"
+    PLURALNAME: "Virtuální stránky"
     PageTypNotAllowedOnRoot: "Původní stránka typu \"{type}\" není povolena na nejvyšší úrovni pro tuto virtuální stránku"
+    SINGULARNAME: "Virtuální stránka"

--- a/lang/da.yml
+++ b/lang/da.yml
@@ -1,7 +1,39 @@
 da:
+  AssetAdmin:
+    ADDFILES: "Tilføj filer"
+    ActionAdd: "Tilføj mappe"
+    AppCategoryArchive: Arkiv
+    AppCategoryAudio: Lyd
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Billeder
+    AppCategoryVideo: Video
+    BackToFolder: "Tilbage til mappen"
+    CREATED: Dato
+    CurrentFolderOnly: "Begræns til den nuværende mappe"
+    DetailsView: Detaljer
+    FILES: Filer
+    FILESYSTEMSYNC: "Synkronisér filer"
+    FILESYSTEMSYNCTITLE: "Opdater poster over filer i filsystemet i CMS-databasen. Dette kan være nyttigt når nye filer er blevet overført uden for CMS, f.eks. via FTP."
+    FROMTHEINTERNET: "Fra internettet"
+    FROMYOURCOMPUTER: "Fra din computer"
+    Filetype: Filtype
+    ListView: Listevisning
+    MENUTITLE: Filer
+    NEWFOLDER: "Ny mappe"
+    SIZE: Størrelse
+    THUMBSDELETED: "{count} ubrugte miniaturer er blevet slettet"
+    TreeView: Trævisning
+    Upload: Overfør
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Slet mapper"
+  AssetAdmin_Tools:
+    FILTER: Filter
   AssetTableField:
     BACKLINKCOUNT: "Brugt på:"
     PAGES: side(r)
+  BackLink_Button_ss:
+    Back: Tilbage
   BrokenLinksReport:
     Any: Alle
     BROKENLINKS: "Rapport over brudte links"
@@ -26,8 +58,16 @@ da:
   CMSAddPageController:
     Title: "Tilføj side"
   CMSBatchActions:
+    ARCHIVE: Arkiv
+    ARCHIVED_PAGES: "Arkiverede %d sider"
+    DELETED_DRAFT_PAGES: "Slettede %d sider fra kladdesiden, %d fejl"
+    DELETED_PAGES: "Slettede %d sider fra udgivet webside, %d fejl"
+    DELETE_DRAFT_PAGES: "Slet fra kladder"
+    DELETE_PAGES: "Slet fra publiseret side"
     PUBLISHED_PAGES: "Publiserede %d sider"
     PUBLISH_PAGES: Publisér
+  CMSFileAddController:
+    MENUTITLE: Filer
   CMSMain:
     ACCESS: "Adgang til '{title}' sektionen"
     ACCESS_HELP: "Tillad visning af den sektion, som indeholder sidetræet og indhold. Visnings- og redigeringstilladelser kan håndteres gennem sidespecifikke rullemenuer, såvel som de enkelte \"Inholdstilladelser\"."
@@ -37,6 +77,11 @@ da:
     ChoosePageParentMode: "Vælg hvor denne side skal oprettes"
     ChoosePageType: "Vælg sidetype"
     Create: Opret
+    DELETE: "Slet fra fra udkast-sitet"
+    DELETEFP: Slet
+    DESCREMOVED: "og {count} efterkommere"
+    EditTree: "Rediger sidetræ"
+    MENUTITLE: "Rediger side"
     NEWPAGE: "Ny {pagetype}"
     PAGENOTEXISTS: "Denne side eksisterer ikke"
     PAGETYPEANYOPT: Enhver
@@ -48,15 +93,23 @@ da:
     REMOVEDPAGEFROMDRAFT: "'%s'  fjernet fra udkast-sitet"
     RESTORED: "Genskabte '{title}' korrekt"
     ROLLBACK: "Rul tilbage til denne version"
+    SAVE: Gem
     TabContent: Indhold
     TabHistory: Historik
     TabSettings: Indstillinger
+  CMSMain_left_ss:
+    RESET: Nulstil
   CMSPageAddController:
+    MENUTITLE: "Tilføj side"
     ParentMode_child: "Under en anden side"
     ParentMode_top: "Højeste niveau"
+  CMSPageEditController:
+    MENUTITLE: "Rediger side"
   CMSPageHistoryController:
     COMPAREMODE: "Sammenligningstilstand (vælg to)"
     COMPAREVERSIONS: "Sammenlign versioner"
+    COMPARINGVERSION: "Sammenligner versionerne {version1} og {version2}."
+    MENUTITLE: Historik
     REVERTTOTHISVERSION: "Genskab denne version"
     SHOWUNPUBLISHED: "Vis versioner der ikke er udgivne"
     SHOWVERSION: "Vis version"
@@ -68,7 +121,10 @@ da:
     PUBLISHER: Udgiver
     UNKNOWN: Ukendt
     WHEN: Hvornår
+  CMSPageSettingsController:
+    MENUTITLE: "Rediger side"
   CMSPagesController:
+    GalleryView: Gallerivisning
     ListView: Listevisning
     MENUTITLE: Sider
     TreeView: Trævisning
@@ -76,7 +132,10 @@ da:
     FILTER: Filtre
   CMSSearch:
     FILTERDATEFROM: Fra
+    FILTERDATEHEADING: Dato
     FILTERDATETO: Til
+  CMSSettingsController:
+    MENUTITLE: Indstillinger
   CMSSiteTreeFilter_Search:
     Title: "Alle sider"
   ContentControl:
@@ -84,6 +143,7 @@ da:
   ContentController:
     ARCHIVEDSITEFROM: "Arkiveret side fra"
     DRAFTSITE: Kladdeside
+    DRAFT_SITE_ACCESS_RESTRICTION: "Du skal være logget ind med din CMS adgangskode for se indhold af kladder eller arkiv. <a href=\"%s\">Klik her for at komme tilbage til den udgivne side.</a>"
     InstallFilesDeleted: "Installationsfilerne blev slettet korrekt."
     InstallSecurityWarning: "Af sikkerhedmæssige årsager bør du slette installationsfilerne, medmindre du planlægger at installere igen på et senere tidspunkt (<em>kræver admin login, se det ovenstående</em>). Webserveren behøver også kun skriverettigheder til mappen \"assets\", du kan fjerne skriverettigheder til alle de andre mapper. <a href=\"{link}\" style=\"text-align: center;\">Klik her for at slette installationsfilerne.</a>"
     LOGGEDINAS: "Logget på som"
@@ -101,30 +161,73 @@ da:
     DEFAULTERRORPAGETITLE: "Siden blev ikke fundet"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Der opstod desværre et problem med at håndtere din forespørgsel.</p>"
     DEFAULTSERVERERRORPAGETITLE: Serverfejl
+    DESCRIPTION: "Brugerdefineret indhold for forskellige fejltyper (f.eks. \"Siden blev ikke fundet\")"
+    ERRORFILEPROBLEM: "Kunne ikke åbne filen \"{filename}\" til skrivning. Undersøg filrettighederne."
+  Folder:
+    AddFolderButton: "Tilføj mappe"
+    DELETEUNUSEDTHUMBNAILS: "Slet ubrugte miniaturer"
+    UNUSEDFILESTITLE: "Ubrugte filer"
+    UNUSEDTHUMBNAILSTITLE: "Ubrugte miniaturer"
+    UploadFilesButton: Overfør
+  LeftAndMain:
+    DELETED: Slettet.
+    PreviewButton: Forhåndsvisning
+    SAVEDUP: Gemt.
+    SearchResults: Søgeresultater
+  Permission:
+    CMS_ACCESS_CATEGORY: "CMS Adgang"
   Permissions:
     CONTENT_CATEGORY: Indholdsrettigheder
     PERMISSIONS_CATEGORY: "Roller og adgangstilladelser"
   RedirectorPage:
+    DESCRIPTION: "Omdirigerer til en anden intern side"
     HASBEENSETUP: "En omdirigeringsside er blevet sat op, uden et sted at omdirigere til."
     HEADER: "Denne side omdirigerer besøgende til en anden side"
     OTHERURL: "Andet websteds URL"
     REDIRECTTO: "Omdiriger til"
     REDIRECTTOEXTERNAL: "Et andet websted"
     REDIRECTTOPAGE: "En side på dit websted"
+    SINGULARNAME: "Viderestillende side"
     YOURPAGE: "Side på dit websted"
+  ReportAdmin:
+    MENUTITLE: Rapporter
+    ReportTitle: Titel
+  ReportAdminForm:
+    FILTERBY: "Filtrer ved"
   SearchForm:
     GO: Send
     SEARCH: Søg
     SearchResults: Søgeresultater
   SideReport:
     BROKENFILES: "Sider med ødelagt filer"
+    BROKENLINKS: "Sider med links der ikke virker"
     BROKENREDIRECTORPAGES: "Viderestillingssider der henviser til slettede sider"
     BROKENVIRTUALPAGES: "Virtuelle sider der henviser til slettede sider"
     BrokenLinksGroupTitle: "Rapporteringer om links der ikke virker"
     ContentGroupTitle: Indholdsrapporter
     EMPTYPAGES: "Tomme sider"
     LAST2WEEKS: "Sider ændret indenfor de sidste 2 uger"
+    OtherGroupTitle: Anden
     ParameterLiveCheckbox: "Tjek det udgivne websted"
+    REPEMPTY: "{title}rapporten er tom."
+  SilverStripeNavigatorLink:
+    ShareLink: "Del link"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Luk
+  SiteConfig:
+    DEFAULTTHEME: "(Brug standard tema)"
+    EDITHEADER: "Hvem kan redigere sider på dette websted ?"
+    EDIT_PERMISSION: "Administrer sideopsætningen"
+    EDIT_PERMISSION_HELP: "Mulighed for at ændre indstillingerne for global adgang / topniveauside tilladelser."
+    SITENAMEDEFAULT: "Dit sidenavn"
+    SITETAGLINE: "Webstedets Tagline/Slogan"
+    SITETITLE: Sidetitel
+    TABACCESS: Adgang
+    TABMAIN: Primær
+    TAGLINEDEFAULT: "din tagline her"
+    THEME: Tema
+    TOPLEVELCREATE: "Hvem kan oprette sider i roden af dette websted ?"
+    VIEWHEADER: "Hvem kan se sider på dette websted?"
   SiteTree:
     ACCESSANYONE: Enhver
     ACCESSHEADER: "Hvem kan se denne side?"
@@ -132,6 +235,7 @@ da:
     ACCESSONLYTHESE: "Kun disse personer (vælg fra liste)"
     ADDEDTODRAFTHELP: "Siden er ikke blevet udgivet endnu"
     ADDEDTODRAFTSHORT: Kladde
+    ALLOWCOMMENTS: "Tillad kommentarer på denne side?"
     APPEARSVIRTUALPAGES: "Dette indhold er også på de virtuelle sider i {title}sektionerne"
     BUTTONCANCELDRAFT: "Annuller ændringer i kladden "
     BUTTONCANCELDRAFTDESC: "Slet kladden og benyt istedet den nuværende side"
@@ -145,6 +249,9 @@ da:
     DEFAULTABOUTTITLE: "Om os"
     DEFAULTCONTACTTITLE: "Kontakt os"
     DEFAULTHOMETITLE: Forside
+    DELETEDPAGEHELP: "Siden er ikke længere udgiven"
+    DELETEDPAGESHORT: Slettet
+    DESCRIPTION: "Standard indholdsside"
     DependtPageColumnLinkType: Linktype
     EDITANYONE: "Enhver der kan logge ind på CMS"
     EDITHEADER: "Hvem kan redigere denne side ?"
@@ -169,17 +276,22 @@ da:
     PARENTTYPE_SUBPAGE: "Underside fra en overliggende side"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Administrer adgangsrettigheder for indhold"
     PERMISSION_GRANTACCESS_HELP: "Tillad indstilling af side-specifikke adgangsbegrænsninger i sektionen \"Sider\" ."
+    PLURALNAME: Sider
     PageTypNotAllowedOnRoot: "Sidetypen \"{type}\" er ikke tilladt på rodniveau"
     PageTypeNotAllowed: "Sidetypen {type} er ikke tilladt som underside til denne side"
+    REMOVEDFROMDRAFTHELP: "Siden er udgivet, men er blevet slette fra kladder"
+    REMOVEDFROMDRAFTSHORT: "Slettet fra kladde"
     REMOVE_INSTALL_WARNING: "Advarsel: Du bør, af sikkerhedsmæssige årsager, slette install.php fra SilverStripe installationsmappen."
     REORGANISE_DESCRIPTION: "Ændre webstedets struktur"
     REORGANISE_HELP: "Omarranger sider i sidetræet ved hjælp af træk&slip."
     SHOWINMENUS: "Vis i menuer ?"
     SHOWINSEARCH: "Vis i søgninger?"
+    SINGULARNAME: Side
     TABBEHAVIOUR: Opførsel
     TABCONTENT: "Primært indhold"
     TABDEPENDENT: "Afhængige sider"
     TOPLEVEL: "Sideindhold (Top niveau)"
+    TOPLEVELCREATORGROUPS: "Top level skabere"
     VIEWERGROUPS: Visningsgrupper
     VIEW_ALL_DESCRIPTION: "Vis enhver side"
     VIEW_DRAFT_CONTENT: "Vis indhold af kladde"
@@ -195,5 +307,7 @@ da:
     CANACCESS: "Du kan tilgå¨den arkiverede side på dette link:"
     HAVEASKED: "Du har spurgt om at se indholdet af vores side på"
   VirtualPage:
+    DESCRIPTION: "Viser indholdet fra en anden side"
     HEADER: "Dette er en virtuel side"
     PageTypNotAllowedOnRoot: "Original side type \"{type}\" er ikke tilladt på rodniveau for denne virtuelle side"
+    SINGULARNAME: "Virtuel side"

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -1,7 +1,42 @@
 de:
+  AssetAdmin:
+    ADDFILES: "Dateien hinzufügen"
+    ActionAdd: "Ordner hinzufügen"
+    AppCategoryArchive: Archivieren
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Bild
+    AppCategoryVideo: Video
+    BackToFolder: "Zurück zum Ordner"
+    CMSMENU_OLD: "Alte Dateien"
+    CREATED: Datum
+    CurrentFolderOnly: "Auf den aktuellen Ordner beschränken?"
+    DetailsView: Details
+    FILES: Dateien
+    FILESYSTEMSYNC: "Dateien synchronisieren"
+    FILESYSTEMSYNCTITLE: "Aktualisiere die CMS Datenbankeinträge zu Dateien auf dem Server. Dies ist dann hilfreich, wenn Dateien ausserhalb des CMS hochgeladen wurden, z.B. mit FTP."
+    FROMTHEINTERNET: "Aus dem Internet"
+    FROMYOURCOMPUTER: "Von Ihrem Computer"
+    Filetype: Dateityp
+    ListView: Listenansicht
+    MENUTITLE: Dateien
+    NEWFOLDER: "Neuer Ordner"
+    SIZE: Größe
+    THUMBSDELETED: "{count} unbenutzte Vorschaubilder wurden gelöscht"
+    TreeView: Baumansicht
+    Upload: Hochladen
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Ordner löschen"
+  AssetAdmin_Tools:
+    FILTER: Filter
+  AssetAdmin_left_ss:
+    GO: Los
   AssetTableField:
     BACKLINKCOUNT: "Verwendet auf:"
     PAGES: Seite(n)
+  BackLink_Button_ss:
+    Back: Zurück
   BrokenLinksReport:
     Any: Alle
     BROKENLINKS: "Defekte Links"
@@ -29,10 +64,18 @@ de:
   CMSBatchAction_Archive:
     TITLE: "Veröffentlichung zurücknehmen und archivieren"
   CMSBatchActions:
+    ARCHIVE: Archivieren
+    ARCHIVED_PAGES: "%d Seiten archiviert"
+    DELETED_DRAFT_PAGES: "%d Seiten wurden von der Entwurfs-Site gelöscht, %d Fehler"
+    DELETED_PAGES: "%d Seiten wurden von der veröffentlichten Site gelöscht, %d Fehler"
+    DELETE_DRAFT_PAGES: "Von der Entwurfsansicht löschen"
+    DELETE_PAGES: "Von veröffentlichter Site löschen"
     PUBLISHED_PAGES: "%d Seiten veröffentlicht, %d Fehler"
     PUBLISH_PAGES: Veröffentlichen
     RESTORE: Wiederherstellen
     RESTORED_PAGES: "%d Seiten wiederhergestellt"
+  CMSFileAddController:
+    MENUTITLE: Dateien
   CMSMain:
     ACCESS: "Zugang zum Bereich '{title}'"
     ACCESS_HELP: "Seiteninhalt im CMS anzeigen. Anzeige- und Bearbeitungsberechtigungen können sowohl seitenspezifische als auch über die globalen Inhaltsberechtigungen gesetzt werden."
@@ -45,9 +88,14 @@ de:
     ChoosePageParentMode: "Wo soll diese Seite erstellt werden?"
     ChoosePageType: "Seitentyp auswählen"
     Create: Erstellen
+    DELETE: "Von Entwurf-Seite löschen"
+    DELETEFP: Löschen
+    DESCREMOVED: "und {count} untergeordnete Seiten"
     DUPLICATED: "'{title}'  wurde erfolgreich dupliziert"
     DUPLICATEDWITHCHILDREN: "'{title}' und alle Unterseiten wurden erfolgreich dupliziert"
     EMAIL: E-Mail
+    EditTree: "Seitenbaum bearbeiten"
+    MENUTITLE: "Seite bearbeiten"
     NEWPAGE: "Neue {pagetype}"
     PAGENOTEXISTS: "Diese Seite existiert nicht"
     PAGETYPEANYOPT: Alle
@@ -56,6 +104,7 @@ de:
     PUBLISHED: "'{title}' wurde erfolgreich veröffentlicht."
     PUBPAGES: "Abgeschlossen: {count} Seiten wurden veröffentlicht"
     PageAdded: "Seite erfolgreich erstellt"
+    REMOVED: "Lösche '{title}'{description} von Live Umgebung"
     REMOVEDPAGE: "'{title}' wurde von der veröffentlichten Site entfernt"
     REMOVEDPAGEFROMDRAFT: "Lösche '%s' von der Entwurfs-Site"
     RESTORED: "'{title}' wurde wiederhergestellt"
@@ -65,18 +114,26 @@ de:
     ROLLBACK: "Diese Version wiederherstellen"
     ROLLEDBACKPUBv2: "Veröffentlichte Version wiederhergestellt"
     ROLLEDBACKVERSIONv2: "Version #%d wiederhergestellt."
+    SAVE: Speichern
     SAVED: "'{title}' erfolgreich gespeichert."
     SAVEDRAFT: "Entwurf speichern"
     TabContent: Inhalt
     TabHistory: Historie
     TabSettings: Einstellungen
     UNPUBLISH_AND_ARCHIVE: "Veröffentlichung zurücknehmen und archivieren"
+  CMSMain_left_ss:
+    RESET: Zurücksetzen
   CMSPageAddController:
+    MENUTITLE: "Seite hinzufügen"
     ParentMode_child: "Einer anderen Seite untergeordnet"
     ParentMode_top: "Auf der obersten Ebene"
+  CMSPageEditController:
+    MENUTITLE: "Seite bearbeiten"
   CMSPageHistoryController:
     COMPAREMODE: "Vergleichsmodus (wähle zwei)"
     COMPAREVERSIONS: "Versionen vergleichen"
+    COMPARINGVERSION: "Vergleiche Versionen {version1} und {version2}."
+    MENUTITLE: Historie
     REVERTTOTHISVERSION: "Zurück zu dieser Version"
     SHOWUNPUBLISHED: "Zeige unveröffentlichte Versionen"
     SHOWVERSION: "Zeige Version"
@@ -90,7 +147,10 @@ de:
     PUBLISHER: Herausgeber
     UNKNOWN: Unbekannt
     WHEN: Wann
+  CMSPageSettingsController:
+    MENUTITLE: "Seite bearbeiten"
   CMSPagesController:
+    GalleryView: "Galerieansicht "
     ListView: Listenansicht
     MENUTITLE: Seiten
     TreeView: Baumansicht
@@ -100,8 +160,11 @@ de:
     Title: "Veröffentlichte Seiten"
   CMSSearch:
     FILTERDATEFROM: Von
+    FILTERDATEHEADING: Datum
     FILTERDATETO: Bis
     PAGEFILTERDATEHEADING: "Zuletzt bearbeitet"
+  CMSSettingsController:
+    MENUTITLE: Einstellungen
   CMSSiteTreeFilter_Search:
     Title: "Alle Seiten"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -114,6 +177,7 @@ de:
     CMS: CMS
     DRAFT: Entwurf
     DRAFTSITE: Vorschau-Site
+    DRAFT_SITE_ACCESS_RESTRICTION: "Sie müssen sich mit Ihrem CMS Passwort einloggen, um den Entwurf oder den archivierten Inhalt zu sehen. <a href=\"%s\">Zurück zur veröffentlichten Seite.</a>"
     Email: E-Mail
     INSTALL_SUCCESS: "Installation erfolgreich!"
     InstallFilesDeleted: "Die Installationsdateien wurden erfolgreich gelöscht."
@@ -161,22 +225,49 @@ de:
     DEFAULTERRORPAGETITLE: "Seite nicht gefunden"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Entschuldigung, bei der Bearbeitung ihrer Anfrage ist ein Problem aufgetreten.</p>"
     DEFAULTSERVERERRORPAGETITLE: Serverfehler
+    DESCRIPTION: "Spezieller Inhalt für andere Fehlerfälle (z.B. \"Seite nicht gefunden\")"
+    ERRORFILEPROBLEM: "Die Datei \"{filename}\" konnte nicht zum Schreiben geöffnet werden. Bitte überprüfen Sie die Dateiberechtigungen."
+    PLURALNAME: Fehlerseiten
+    SINGULARNAME: Fehlerseite
+  File:
+    Title: Titel
+  Folder:
+    AddFolderButton: "Ordner hinzufügen"
+    DELETEUNUSEDTHUMBNAILS: "Unbenutzte Vorschaubilder löschen"
+    UNUSEDFILESTITLE: "Unbenutzte Dateien"
+    UNUSEDTHUMBNAILSTITLE: "Unbenutzte Vorschaubilder"
+    UploadFilesButton: Hochladen
+  LeftAndMain:
+    DELETED: Gelöscht.
+    PreviewButton: Vorschau
+    SAVEDUP: Gespeichert.
+    SearchResults: Suchergebnisse
+  Permission:
+    CMS_ACCESS_CATEGORY: "CMS Zugriff"
   Permissions:
     CONTENT_CATEGORY: Inhaltsberechtigungen
     PERMISSIONS_CATEGORY: "Rollen- und Zugriffsberechtigungen"
   RedirectorPage:
+    DESCRIPTION: "Leitet zu einer anderen internen Seite weiter"
     HASBEENSETUP: "Eine Weiterleitungsseite wurde erstellt ohne das eine Weiterleitung definiert wurde."
     HEADER: "Diese Seite wird Nutzer auf eine andere Seite weiterleiten"
     OTHERURL: "Andere Webseiten URL"
+    PLURALNAME: Weiterleitungsseiten
     REDIRECTTO: "Weiterleiten zu"
     REDIRECTTOEXTERNAL: "Andere Website"
     REDIRECTTOPAGE: "Eine Seite auf Ihrer Website"
+    SINGULARNAME: Weiterleitungsseite
     YOURPAGE: "Seite auf Ihrer Website"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Ausführen
     NONEREMOVED: "Keine entfernt"
     SELECTALL: "alle auswählen"
     UNSELECTALL: "Auswahl aufheben"
+  ReportAdmin:
+    MENUTITLE: Berichte
+    ReportTitle: Titel
+  ReportAdminForm:
+    FILTERBY: "Filtern nach"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Bitte veröffentlichen Sie die vernküpfte Seite um die virtuelle Seite zu veröffentlichen"
     VIRTUALPAGEWARNING: "Um diese Seite veröffentlichen zu können müssen Sie zu erst eine verknüpfte Seite auswählen"
@@ -187,15 +278,22 @@ de:
     SearchResults: Suchergebnisse
   SideReport:
     BROKENFILES: "Seiten mit defekten Dateiverknüpfungen"
+    BROKENLINKS: "Seiten mit defekten Links"
     BROKENREDIRECTORPAGES: "Weiterleitungen, die auf gelöschte Seiten verweisen"
     BROKENVIRTUALPAGES: "Virtuelle Seiten, die auf gelöschte Seiten verweisen"
     BrokenLinksGroupTitle: "Defekte Links"
     ContentGroupTitle: Inhaltsberichte
     EMPTYPAGES: "Leere Seiten"
     LAST2WEEKS: "Seiten die in den letzten zwei Wochen bearbeitet wurden"
+    OtherGroupTitle: Andere
     ParameterLiveCheckbox: "Veröffentlichte Seite überprüfen"
+    REPEMPTY: "Der Bericht '{title}' ist leer."
   SilverStripeNavigator:
     ARCHIVED: Archiviert
+  SilverStripeNavigatorLink:
+    ShareLink: "Link teilen"
+  SilverStripeNavigatorLinkl:
+    CloseLink: schließen
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Seite hinzufügen"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -222,6 +320,22 @@ de:
     DESCRIPTION: "Zeigt den Inhalt einer anderen Seite an"
     PLURALNAME: "Virtuelle Seiten"
     SINGULARNAME: "Virtuelle Seite"
+  SiteConfig:
+    DEFAULTTHEME: "(Standardtheme verwenden)"
+    EDITHEADER: "Wer kann Seiten auf dieser Website bearbeiten?"
+    EDIT_PERMISSION: "Websiteeinstellungen editieren"
+    EDIT_PERMISSION_HELP: "Möglichkeit, die globalen Zugrifsseinstellungen sowie die Berechtigungen für die Hauptebene zu editieren."
+    PLURALNAME: Seitenkonfigurationen
+    SINGULARNAME: Seitenkonfiguration
+    SITENAMEDEFAULT: "Name Ihrer Website"
+    SITETAGLINE: "Ihr Websiteslogan"
+    SITETITLE: "Titel der Site"
+    TABACCESS: Zugriff
+    TABMAIN: Hauptteil
+    TAGLINEDEFAULT: "Ihr Websiteslogan"
+    THEME: Theme
+    TOPLEVELCREATE: "Wer kann Seiten auf der Hauptebene erstellen?"
+    VIEWHEADER: "Wer kann Seiten auf dieser Website sehen?"
   SiteTree:
     ACCESSANYONE: Jeder
     ACCESSHEADER: "Wer kann diese Seite auf meiner Website ansehen?"
@@ -229,9 +343,11 @@ de:
     ACCESSONLYTHESE: "Nur folgende Personen (aus der der Liste wählen)"
     ADDEDTODRAFTHELP: "Die Seite wurde noch nicht veröffentlicht"
     ADDEDTODRAFTSHORT: Entwurf
+    ALLOWCOMMENTS: "Kommentare auf dieser Seite erlauben?"
     APPEARSVIRTUALPAGES: "Dieser Inhalt erscheint außerdem auf virtuellen Seiten im {title} Bereich."
     ARCHIVEDPAGEHELP: "Die Seite wird von Entwurf und Live entfernt"
     ARCHIVEDPAGESHORT: Archiviert
+    BUTTONARCHIVEDESC: "Veröffentlichung zurücknehmen und in das Archiv verschieben"
     BUTTONCANCELDRAFT: "Verwerfe Entwurfsänderungen"
     BUTTONCANCELDRAFTDESC: "Löschen Sie Ihren Entwurf und kehren Sie zur derzeit veröffentlichten Seite zurück."
     BUTTONPUBLISHED: Veröffentlicht
@@ -245,7 +361,10 @@ de:
     DEFAULTCONTACTTITLE: Kontakt
     DEFAULTHOMECONTENT: "<p>Willkommen bei SilverStripe! Sie sehen hier die standard Homepage. Diese können Sie im <a href=\"admin/\">CMS</a> bearbeiten.</p><p>Sie können auch die englische  <a href=\"http://docs.silverstripe.org\">Dokumentation für Entwickler</a> lesen oder mit den <a href=\"http://www.silverstripe.org/learn/lessons\">SilverStripe lessons</a> lernen, wie Sie das CMS an Ihre Bedürfnisse anpassen.</p>"
     DEFAULTHOMETITLE: Startseite
+    DELETEDPAGEHELP: "Die Seite ist nicht länger veröffentlicht"
+    DELETEDPAGESHORT: Gelöscht
     DEPENDENT_NOTE: "Die folgenden Seiten hängen von dieser Seite ab. Dies schließt Virtuelle Seiten, Weiterleitungen und Seiten mit Links im Inhalt ein."
+    DESCRIPTION: "Allgemeine Inhaltsseite"
     DependtPageColumnLinkType: Linktyp
     DependtPageColumnURL: URL
     EDITANYONE: "Jeder der sich in das CMS einloggen kann"
@@ -285,17 +404,22 @@ de:
     PARENTTYPE_SUBPAGE: "Seite unterhalb einer übergeordneten Seite"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Zugriffsrechte für Inhalte verwalten"
     PERMISSION_GRANTACCESS_HELP: "Einstellung von seitenspezifischen Zugriffsbeschränkungen im Bereich \"Seiteninhalt\" erlauben"
+    PLURALNAME: Seiten
     PageTypNotAllowedOnRoot: "Der Seitentyp \"{type}\" darf nicht auf der Grundebene verwendet werden."
     PageTypeNotAllowed: "Der Seitentyp \"{type}\" kann nicht als Kind dieser übergeordneten Seite verwendet werden"
+    REMOVEDFROMDRAFTHELP: "Die Seite ist veröffentlicht, wurde aber von der Entwurf Seite gelöscht."
+    REMOVEDFROMDRAFTSHORT: "Aus Entwurf entfernt"
     REMOVE_INSTALL_WARNING: "Warnung: Aus Sicherheitsgründen sollte die Datei install.php aus dieser SilverStripe Installation entfernt werden."
     REORGANISE_DESCRIPTION: "Kann die Site-Struktur reorganisieren"
     REORGANISE_HELP: "Seiten im Seitenbaum per Drag&Drop sortieren."
     SHOWINMENUS: "In Menüs anzeigen?"
     SHOWINSEARCH: "In der Suche anzeigen?"
+    SINGULARNAME: Seite
     TABBEHAVIOUR: Verhalten
     TABCONTENT: Haupt-Inhalt
     TABDEPENDENT: "Abhängige Seiten"
     TOPLEVEL: "Seiten Inhalt (Top Level)"
+    TOPLEVELCREATORGROUPS: Bearbeitergruppen
     URLSegment: URL-Segment
     VIEWERGROUPS: Betrachtergruppen
     VIEW_ALL_DESCRIPTION: "Kann beliebige Seiten betrachten"
@@ -309,6 +433,8 @@ de:
     many_many_ImageTracking: Bild-Verfolgung
     many_many_LinkTracking: Link-Verfolgung
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Diese Liste zeigt alle Seiten, bei denen eine Datei mit dem WYSIWIG-Editor hinzugefügt wurde"
+    EDIT: Bearbeiten
     TITLE_INDEX: "#"
     TITLE_TYPE: Typ
     TITLE_USED_ON: "Verwendet auf"
@@ -324,7 +450,10 @@ de:
     HAVEASKED: "Sie haben darum gebeten, den Inhalt unserer Site zu sehen, am"
   VirtualPage:
     CHOOSE: "Verknüpfte Seite"
+    DESCRIPTION: "Zeigt den Inhalt einer anderen Seite"
     EditLink: Bearbeiten
     HEADER: "Dies ist eine virtuelle Seite"
     HEADERWITHLINK: "Dies ist eine virtuelle Seite, die den Inhalt von \"{title}\" ({link}) kopiert"
+    PLURALNAME: "Virtuelle Seiten"
     PageTypNotAllowedOnRoot: "Der ursprüngliche Seitentyp \"{type}\" ist nicht zulässig für diese virtuelle Seite. "
+    SINGULARNAME: "Virtuelle Seite"

--- a/lang/el.yml
+++ b/lang/el.yml
@@ -1,7 +1,40 @@
 el:
+  AssetAdmin:
+    ADDFILES: "Προσθήκη Αρχείων"
+    ActionAdd: "Προσθήκη φακέλου"
+    AppCategoryArchive: Αρχείο
+    AppCategoryAudio: Ήχος
+    AppCategoryDocument: Έγγραφο
+    AppCategoryImage: Εικόνα
+    AppCategoryVideo: Βίντεο
+    BackToFolder: "Πίσω στο φάκελο"
+    CREATED: Ημερομηνία
+    CurrentFolderOnly: "Μόνο στον τρέχοντα φάκελο;"
+    DetailsView: Λεπτομέρειες
+    FILES: Αρχεία
+    FILESYSTEMSYNC: "Συγχρονισμός αρχείων"
+    FILESYSTEMSYNCTITLE: "Ενημέρωση των καταχωρήσεων της βάσης δεδομένων του CMS για αρχεία τα οποία υπάρχουν στο σύστημα. Χρήσιμο όταν οι νέα αρχεία έχουν φορτωθεί εκτός CMS, π.χ. μέσω FTP."
+    FROMTHEINTERNET: "Από το Internet"
+    FROMYOURCOMPUTER: "Από τον υπολογιστή σας"
+    Filetype: "Τύπος αρχείου"
+    ListView: "Προβολή Λίστας"
+    MENUTITLE: Αρχεία
+    NEWFOLDER: ΝέοςΦάκελος
+    SIZE: Μέγεθος
+    THUMBSDELETED: "{count} αχρησιμοποίητα εικονίδια έχουν διαγραφεί"
+    TreeView: "Προβολή Δέντρου"
+    Upload: Μεταφόρτωση
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Διαγραφή φακέλων"
+  AssetAdmin_Tools:
+    FILTER: Φίλτρο
+  AssetAdmin_left_ss:
+    GO: Μετάβαση
   AssetTableField:
     BACKLINKCOUNT: "Χρησιμοποιείται σε:"
     PAGES: σελίδες
+  BackLink_Button_ss:
+    Back: Πίσω
   BrokenLinksReport:
     Any: Οποιοδήποτε
     BROKENLINKS: "Αναφορά ανενεργών συνδέσμων"
@@ -26,27 +59,41 @@ el:
   CMSAddPageController:
     Title: "Προσθήκη σελίδας"
   CMSBatchActions:
+    DELETED_PAGES: "Διαγράφηκαν %d σελίδες απο τις δημοσιευμένες, με %d αποτυχίες"
     PUBLISH_PAGES: Δημοσίευση
+  CMSFileAddController:
+    MENUTITLE: Αρχεία
   CMSMain:
     AddNew: "Προσθήκη σελίδας"
     AddNewButton: Προσθήκη
     Cancel: Άκυρο
     ChoosePageType: "Επιλέξτε τύπο σελίδας"
     Create: Δημιουργία
+    DELETEFP: Διαγραφή
+    EditTree: "Επεξεργασία Δένδρου"
+    MENUTITLE: "Επεξεργασία Σελίδας"
     NEWPAGE: "Νέο {pagetype}"
     PAGENOTEXISTS: "Αυτή η σελίδα δεν υπάρχει"
     PAGETYPEANYOPT: Οποιοδήποτε
     PUBALLFUN: "Λειτουργία \"Δημοσίευση Όλων\""
     PUBPAGES: "Ολοκληρώθηκε: Δημοσίευση {count} σελίδων"
     PageAdded: "Η σελίδα δημιουργήθηκε με επιτυχία"
+    SAVE: Αποθήκευση
     TabContent: Περιεχόμενο
     TabHistory: Ιστορικό
     TabSettings: Ρυθμίσεις
+  CMSMain_left_ss:
+    RESET: Επαναφορά
   CMSPageAddController:
+    MENUTITLE: "Προσθήκη σελίδας"
     ParentMode_child: "Κάτω από άλλη σελίδα"
     ParentMode_top: "Επίπεδο κορυφής"
+  CMSPageEditController:
+    MENUTITLE: "Επεξεργασία Σελίδας"
   CMSPageHistoryController:
     COMPAREVERSIONS: "Σύγκριση Εκδόσεων"
+    COMPARINGVERSION: "Σύγκριση Εκδόσεων {version1} και {version2}."
+    MENUTITLE: Ιστορικό
     REVERTTOTHISVERSION: "Επαναφορά σε αυτήν την έκδοση"
     SHOWVERSION: "Προβολή Έκδοσης"
     VIEW: προβολή
@@ -56,6 +103,8 @@ el:
     PUBLISHER: Εκδότης
     UNKNOWN: Άγνωστο
     WHEN: Όταν
+  CMSPageSettingsController:
+    MENUTITLE: "Επεξεργασία Σελίδας"
   CMSPagesController:
     ListView: "Προβολή Λίστας"
     MENUTITLE: Σελίδες
@@ -64,7 +113,10 @@ el:
     FILTER: Φίλτρο
   CMSSearch:
     FILTERDATEFROM: Από
+    FILTERDATEHEADING: Ημερομηνία
     FILTERDATETO: Έως
+  CMSSettingsController:
+    MENUTITLE: Ρυθμίσεις
   CMSSiteTreeFilter_Search:
     Title: "Όλες οι σελίδες"
   ContentController:
@@ -83,12 +135,32 @@ el:
     CODE: "Κωδικός σφάλματος"
     DEFAULTERRORPAGETITLE: "Η σελίδα δεν βρέθηκε"
     DEFAULTSERVERERRORPAGETITLE: "Σφάλμα διακομιστή"
+    SINGULARNAME: "Σελίδα Σφάλματος"
+  Folder:
+    AddFolderButton: "Προσθήκη φακέλου"
+    DELETEUNUSEDTHUMBNAILS: "Διαγραφή αχρησιμοποίητων εικονιδίων"
+    UNUSEDFILESTITLE: "Αχρησιμοποίητα αρχεία"
+    UNUSEDTHUMBNAILSTITLE: "Αχρησιμοποίητα εικονίδια"
+    UploadFilesButton: Μεταφόρτωση
+  LeftAndMain:
+    DELETED: "Έγινε Διαγραφή."
+    PreviewButton: Προεπισκόπιση
+    SAVEDUP: "Έγινε Αποθήκευση."
+    SearchResults: "Αναζήτηση Αποτελεσμάτων"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Πρόσβαση στο CMS"
   Permissions:
     CONTENT_CATEGORY: "Δικαιώματα περιεχόμενου"
     PERMISSIONS_CATEGORY: "Ρόλοι και δικαιώματα"
   RedirectorPage:
+    DESCRIPTION: "Κάνει ανακατεύθυνση σε μια διαφορετική εσωτερική σελίδα"
     HEADER: "Αυτή η σελίδα θα ανακατευθύνει τους χρήστες σε μια άλλη σελίδα"
     REDIRECTTO: "Ανακατεύθυνση σε"
+  ReportAdmin:
+    MENUTITLE: Αναφορές
+    ReportTitle: Τίτλος
+  ReportAdminForm:
+    FILTERBY: "Φίλτρο κατά"
   SearchForm:
     GO: Μετάβαση
     SEARCH: Αναζήτηση
@@ -97,13 +169,27 @@ el:
     BrokenLinksGroupTitle: "Αναφορές ανενεργών συνδέσμων"
     ContentGroupTitle: "Αναφορές περιεχομένου"
     EMPTYPAGES: "Σελίδες χωρίς περιεχόμενο"
+    OtherGroupTitle: Άλλο
   SilverStripeNavigator:
     ARCHIVED: Αρχειοθετημένο
+  SilverStripeNavigatorLinkl:
+    CloseLink: Κλείσιμο
+  SiteConfig:
+    PLURALNAME: "Ρύθμισεις Ιστότοπου"
+    SINGULARNAME: "Ρύθμιση Ιστότοπου"
+    SITENAMEDEFAULT: "Όνομα Ιστότοπου"
+    SITETITLE: "Τίτλος ιστοτόπου"
+    TABACCESS: Πρόσβαση
+    TABMAIN: Βασικό
+    THEME: "Θεματική παραλλαγή"
+    TOPLEVELCREATE: "Ποιος μπορεί να δημιουργεί σελίδες στην ρίζα του ιστοτόπου;"
+    VIEWHEADER: "Ποιος μπορεί να βλέπει σελίδες σε αυτόν τον ιστότοπο;"
   SiteTree:
     ACCESSANYONE: Οποιοσδήποτε
     ACCESSHEADER: "Ποιος μπορεί να δεί αυτή τη σελίδα;"
     ACCESSLOGGEDIN: "Συνδεδεμένοι χρήστες"
     ADDEDTODRAFTHELP: "Η σελίδα δεν έχει δημοσιευθεί ακόμη"
+    ALLOWCOMMENTS: "Να επιτρέπονται σχόλια σε αυτή τη σελίδα;"
     BUTTONPUBLISHED: Δημοσιευμένο
     BUTTONSAVED: Αποθηκεύτηκε
     BUTTONSAVEPUBLISH: "Αποθήκευση & δημοσίευση"
@@ -113,6 +199,9 @@ el:
     DEFAULTABOUTTITLE: "Ποιοί είμαστε"
     DEFAULTCONTACTTITLE: Επικοινωνία
     DEFAULTHOMETITLE: Αρχική
+    DELETEDPAGEHELP: "Η σελίδα δεν είναι πλέον δημοσιευμένη"
+    DELETEDPAGESHORT: "Έγινε Διαγραφή"
+    DESCRIPTION: "Σελίδα γενικού περιεχομένου"
     DependtPageColumnLinkType: "Τύπος συνδέσμου"
     DependtPageColumnURL: "Διεύθυνση URL"
     EDITHEADER: "Ποιος μπορεί να επεξεργαστεί αυτή τη σελίδα;"
@@ -137,9 +226,11 @@ el:
     PAGETYPE: "Τύπος σελίδας"
     PARENTID: "Γονική Σελίδα"
     PARENTTYPE: "Θέση σελίδας"
+    PLURALNAME: Σελίδες
     REORGANISE_DESCRIPTION: "Αλλαγή δομής του ιστοτόπου "
     SHOWINMENUS: "Να φαίνεται στα μενού;"
     SHOWINSEARCH: "Να φαίνεται στην αναζήτηση"
+    SINGULARNAME: Σελίδα
     TABBEHAVIOUR: Συμπεριφορά
     TABCONTENT: "Κυρίως Περιεχόμενο"
     TABDEPENDENT: "Εξαρτώμενες σελίδες "
@@ -158,5 +249,7 @@ el:
     HAVEASKED: "Επιθυμείται να εμφανιστεί το περιεχόμενο του ιστοχώρου σας την "
   VirtualPage:
     CHOOSE: "Συνδεδεμένη σελίδα"
+    DESCRIPTION: "Εμφανίζει το περιεχόμενο μιας άλλης σελίδας"
     EditLink: επεξεργασία
     HEADER: "Αυτή είναι μια εικονική σελίδα"
+    SINGULARNAME: "Εικονική Σελίδα"

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -9,6 +9,7 @@ en:
     AppCategoryImage: Image
     AppCategoryVideo: Video
     BackToFolder: 'Back to folder'
+    CMSMENU_OLD: 'Files (old)'
     CREATED: Date
     CurrentFolderOnly: 'Limit to current folder?'
     DetailsView: Details
@@ -29,11 +30,15 @@ en:
     Upload: Upload
   AssetAdmin_DeleteBatchAction:
     TITLE: 'Delete folders'
+  AssetAdmin_Tools:
+    FILTER: Filter
   AssetAdmin_left_ss:
     GO: Go
   AssetTableField:
     BACKLINKCOUNT: 'Used on:'
     PAGES: page(s)
+  BackLink_Button_ss:
+    Back: Back
   BrokenLinksReport:
     Any: Any
     BROKENLINKS: 'Broken links report'
@@ -94,6 +99,7 @@ en:
     DUPLICATED: 'Duplicated ''{title}'' successfully'
     DUPLICATEDWITHCHILDREN: 'Duplicated ''{title}'' and children successfully'
     EMAIL: Email
+    EditTree: 'Edit Tree'
     ListFiltered: 'Showing search results.'
     MENUTITLE: 'Edit Page'
     NEWPAGE: 'New {pagetype}'
@@ -118,6 +124,7 @@ en:
     ROLLBACK: 'Roll back to this version'
     ROLLEDBACKPUBv2: 'Rolled back to published version.'
     ROLLEDBACKVERSIONv2: 'Rolled back to version #%d.'
+    SAVE: Save
     SAVED: 'Saved ''{title}'' successfully.'
     SAVEDRAFT: 'Save draft'
     TabContent: Content
@@ -157,6 +164,7 @@ en:
   CMSPageSettingsController:
     MENUTITLE: 'Edit Page'
   CMSPagesController:
+    GalleryView: 'Gallery View'
     ListView: 'List View'
     MENUTITLE: Pages
     TreeView: 'Tree View'
@@ -194,6 +202,7 @@ en:
     CMS: CMS
     DRAFT: Draft
     DRAFTSITE: 'Draft Site'
+    DRAFT_SITE_ACCESS_RESTRICTION: 'You must log in with your CMS password in order to view the draft or archived content. <a href="%s">Click here to go back to the published site.</a>'
     Email: Email
     INSTALL_SUCCESS: 'Installation Successful!'
     InstallFilesDeleted: 'Installation files have been successfully deleted.'
@@ -245,6 +254,8 @@ en:
     ERRORFILEPROBLEM: 'Error opening file "{filename}" for writing. Please check file permissions.'
     PLURALNAME: 'Error Pages'
     SINGULARNAME: 'Error Page'
+  File:
+    Title: Title
   Folder:
     AddFolderButton: 'Add folder'
     DELETEUNUSEDTHUMBNAILS: 'Delete unused thumbnails'
@@ -252,7 +263,12 @@ en:
     UNUSEDTHUMBNAILSTITLE: 'Unused thumbnails'
     UploadFilesButton: Upload
   LeftAndMain:
+    DELETED: Deleted.
+    PreviewButton: Preview
+    SAVEDUP: Saved.
     SearchResults: 'Search Results'
+  Permission:
+    CMS_ACCESS_CATEGORY: 'CMS Access'
   Permissions:
     CONTENT_CATEGORY: 'Content permissions'
     PERMISSIONS_CATEGORY: 'Roles and access permissions'
@@ -277,6 +293,11 @@ en:
     OPERATION_REMOVE: 'Remove selected from all stages (WARNING: Will destroy all selected pages from both stage and live)'
     SELECTALL: 'select all'
     UNSELECTALL: 'unselect all'
+  ReportAdmin:
+    MENUTITLE: Reports
+    ReportTitle: Title
+  ReportAdminForm:
+    FILTERBY: 'Filter by'
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: 'Please publish the linked page in order to publish the virtual page'
     VIRTUALPAGEWARNING: 'Please choose a linked page and save first in order to publish this page'
@@ -287,13 +308,16 @@ en:
     SearchResults: 'Search Results'
   SideReport:
     BROKENFILES: 'Pages with broken files'
+    BROKENLINKS: 'Pages with broken links'
     BROKENREDIRECTORPAGES: 'RedirectorPages pointing to deleted pages'
     BROKENVIRTUALPAGES: 'VirtualPages pointing to deleted pages'
     BrokenLinksGroupTitle: 'Broken links reports'
     ContentGroupTitle: 'Content reports'
     EMPTYPAGES: 'Pages with no content'
     LAST2WEEKS: 'Pages edited in the last 2 weeks'
+    OtherGroupTitle: Other
     ParameterLiveCheckbox: 'Check live site'
+    REPEMPTY: 'The {title} report is empty.'
   SilverStripeNavigator:
     ARCHIVED: Archived
   SilverStripeNavigatorLink:
@@ -314,31 +338,35 @@ en:
   SilverStripe\CMS\Model\ErrorPage:
     DESCRIPTION: 'Custom content for different error cases (e.g. "Page not found")'
     PLURALNAME: 'Error Pages'
-    PLURALS:
-      one: 'An Error Page'
-      other: '{count} Error Pages'
     SINGULARNAME: 'Error Page'
   SilverStripe\CMS\Model\RedirectorPage:
     DESCRIPTION: 'Redirects to an internal page or an external URL'
     PLURALNAME: 'Redirector Pages'
-    PLURALS:
-      one: 'A Redirector Page'
-      other: '{count} Redirector Pages'
     SINGULARNAME: 'Redirector Page'
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: 'Generic content page'
-    PLURALNAME: Pages
-    PLURALS:
-      one: 'A Page'
-      other: '{count} Pages'
-    SINGULARNAME: Page
+    PLURALNAME: 'Site Trees'
+    SINGULARNAME: 'Site Tree'
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: 'Displays the content of another page'
     PLURALNAME: 'Virtual Pages'
-    PLURALS:
-      one: 'A Virtual Page'
-      other: '{count} Virtual Pages'
     SINGULARNAME: 'Virtual Page'
+  SiteConfig:
+    DEFAULTTHEME: '(Use default theme)'
+    EDITHEADER: 'Who can edit pages on this site?'
+    EDIT_PERMISSION: 'Manage site configuration'
+    EDIT_PERMISSION_HELP: 'Ability to edit global access settings/top-level page permissions.'
+    PLURALNAME: 'Site Configs'
+    SINGULARNAME: 'Site Config'
+    SITENAMEDEFAULT: 'Your Site Name'
+    SITETAGLINE: 'Site Tagline/Slogan'
+    SITETITLE: 'Site title'
+    TABACCESS: Access
+    TABMAIN: Main
+    TAGLINEDEFAULT: 'your tagline here'
+    THEME: Theme
+    TOPLEVELCREATE: 'Who can create pages in the root of the site?'
+    VIEWHEADER: 'Who can view pages on this site?'
   SiteTree:
     ACCESSANYONE: Anyone
     ACCESSHEADER: 'Who can view this page?'
@@ -346,6 +374,7 @@ en:
     ACCESSONLYTHESE: 'Only these people (choose from list)'
     ADDEDTODRAFTHELP: 'Page has not been published yet'
     ADDEDTODRAFTSHORT: Draft
+    ALLOWCOMMENTS: 'Allow comments on this page?'
     APPEARSVIRTUALPAGES: 'This content also appears on the virtual pages in the {title} sections.'
     ARCHIVEDPAGEHELP: 'Page is removed from draft and live'
     ARCHIVEDPAGESHORT: Archived
@@ -366,6 +395,8 @@ en:
     DEFAULTCONTACTTITLE: 'Contact Us'
     DEFAULTHOMECONTENT: '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>You can now access the <a href="http://docs.silverstripe.org">developer documentation</a>, or begin the <a href="http://www.silverstripe.org/learn/lessons">SilverStripe lessons</a>.</p>'
     DEFAULTHOMETITLE: Home
+    DELETEDPAGEHELP: 'Page is no longer published'
+    DELETEDPAGESHORT: Deleted
     DEPENDENT_NOTE: 'The following pages depend on this page. This includes virtual pages, redirector pages, and pages with content links.'
     DESCRIPTION: 'Generic content page'
     DependtPageColumnLinkType: 'Link type'
@@ -424,6 +455,7 @@ en:
     TABCONTENT: 'Main Content'
     TABDEPENDENT: 'Dependent pages'
     TOPLEVEL: 'Site Content (Top Level)'
+    TOPLEVELCREATORGROUPS: 'Top level creators'
     URLSegment: 'URL Segment'
     VIEWERGROUPS: 'Viewer Groups'
     VIEW_ALL_DESCRIPTION: 'View any page'

--- a/lang/eo.yml
+++ b/lang/eo.yml
@@ -1,10 +1,44 @@
 eo:
   AssetAdmin:
+    ADDFILES: "Enmeti dosierojn"
+    ActionAdd: "Aldoni dosierujon"
+    AppCategoryArchive: Arkivo
+    AppCategoryAudio: Sono
+    AppCategoryDocument: Dokumento
+    AppCategoryFlash: Flash
+    AppCategoryImage: Bildo
+    AppCategoryVideo: Video
+    BackToFolder: "Retroe al dosierujo"
+    CMSMENU_OLD: "Dosieroj (malnovaj)"
+    CREATED: Dato
+    CurrentFolderOnly: "Limigo de aktuala dosierujo"
+    DetailsView: Detaloj
     ErrorItemPermissionDenied: "Ŝajnas ke vi ne havas la bezonatajn permesojn por aldoni je {ObjectTitle} al kampanjo"
     ErrorNotFound: "Ne eblis trovi tiun {Type}"
+    FILES: Dosieroj
+    FILESYSTEMSYNC: "Sinkronigaj dosieroj"
+    FILESYSTEMSYNCTITLE: "Aktualigi la CMS-datumbazerojn de dosieroj en la dosiera sistemo. Utile kiam novaj dosieroj estas alŝutitaj ekster la CMS, ekzemple per FTP."
+    FROMTHEINTERNET: "De la interreto"
+    FROMYOURCOMPUTER: "El via komputilo"
+    Filetype: "Tipo de dosiero"
+    ListView: "Lista vido"
+    MENUTITLE: Dosieroj
+    NEWFOLDER: "Nova dosierujo"
+    SIZE: Grando
+    THUMBSDELETED: "{count} neuzitaj miniaturoj estas forigitaj"
+    TreeView: "Arba vido"
+    Upload: Alŝuti
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Forigi dosierujojn"
+  AssetAdmin_Tools:
+    FILTER: Filtrilo
+  AssetAdmin_left_ss:
+    GO: Ek
   AssetTableField:
     BACKLINKCOUNT: "Uzite ĉe:"
     PAGES: paĝo(j)
+  BackLink_Button_ss:
+    Back: Retro
   BrokenLinksReport:
     Any: Ajna
     BROKENLINKS: "Raporto pri rompitaj ligiloj"
@@ -33,12 +67,20 @@ eo:
     RESULT: "Forigis %d paĝojn el malneta kaj publika, kaj sendis ilin al la arĥivo"
     TITLE: "Malpublikigi kaj sendi al arkivo"
   CMSBatchActions:
+    ARCHIVE: Arkivo
+    ARCHIVED_PAGES: "Enarkivigis %d paĝojn"
+    DELETED_DRAFT_PAGES: "Forigis %d paĝojn el malneta retejo, %d malsukcesoj"
+    DELETED_PAGES: "Forigis %d paĝojn el publikigita retejo, %d malsukcesoj"
+    DELETE_DRAFT_PAGES: "Forigi el malneta retejo"
+    DELETE_PAGES: "Forigi el publikigita retejo"
     PUBLISHED_PAGES: "Publikigis %d paĝojn, %d malsukcesojn"
     PUBLISH_PAGES: Publikigi
     RESTORE: Restaŭri
     RESTORED_PAGES: "Restaŭris %d paĝojn"
     UNPUBLISHED_PAGES: "Nepublikigitaj %d paĝoj"
     UNPUBLISH_PAGES: Malpublikigi
+  CMSFileAddController:
+    MENUTITLE: Dosieroj
   CMSMain:
     ACCESS: "Aliro al sekcio '{title}'"
     ACCESS_HELP: "Permesi vidigi la sekcion kiu enhavas paĝarbon kaj enhavon. Vidigaj kaj redaktaj permesoj estas trakteblaj per paĝspecifaj fallistoj, kaj ankaŭ la apartaj \"Enhavaj permesoj\"."
@@ -51,10 +93,15 @@ eo:
     ChoosePageParentMode: "Elekti kie krei ĉi tiun paĝon"
     ChoosePageType: "Elekti tipon de paĝo"
     Create: Krei
+    DELETE: "Forigi la malnetan"
+    DELETEFP: Forigi
+    DESCREMOVED: "kaj {count} posteuloj"
     DUPLICATED: "Sukcese duobligis je '{title}'"
     DUPLICATEDWITHCHILDREN: "Sukcese duobligis je '{title}' kaj idoj"
     EMAIL: Retpoŝto
+    EditTree: "Redakta arbo"
     ListFiltered: "Vidigas rezultojn de serĉo."
+    MENUTITLE: "Redakti paĝon"
     NEWPAGE: "Nova {pagetype}"
     PAGENOTEXISTS: "Ĉi tiu paĝo ne ekzistas"
     PAGES: "Stato de paĝo"
@@ -66,6 +113,7 @@ eo:
     PUBLISHED: "Sukcese publikigis je '{title}'"
     PUBPAGES: "Farite: publikigis {count} paĝojn"
     PageAdded: "Sukcese kreis paĝon"
+    REMOVED: "Forigis je '{title}'{description} el la publikigita retejo"
     REMOVEDPAGE: "Forigis je '{title}' el la publikigita retejo"
     REMOVEDPAGEFROMDRAFT: "Forigis je '%s' el la malneta retejo"
     RESTORE: "Restaŭri malneton"
@@ -76,6 +124,7 @@ eo:
     ROLLBACK: "Malfari al ĉi tiu versio"
     ROLLEDBACKPUBv2: "Malfaris ŝanĝojn ĝis la publikigita versio."
     ROLLEDBACKVERSIONv2: "Malfaris ŝanĝojn ĝis versio #%d."
+    SAVE: Konservi
     SAVED: "Sukcese konservis je '{title}'"
     SAVEDRAFT: "Konservi malneton"
     TabContent: Enhavo
@@ -87,12 +136,18 @@ eo:
   CMSMain_left_ss:
     APPLY_FILTER: Serĉi
     CLEAR_FILTER: Vakigi
+    RESET: Restartigi
   CMSPageAddController:
+    MENUTITLE: "Enmeti paĝon"
     ParentMode_child: "Sub alia paĝo"
     ParentMode_top: "Supra nivelo"
+  CMSPageEditController:
+    MENUTITLE: "Redakti paĝon"
   CMSPageHistoryController:
     COMPAREMODE: "Kompara reĝimo (elektu du)"
     COMPAREVERSIONS: "Kompari versiojn"
+    COMPARINGVERSION: "Komparas versiojn {version1} kaj {version2}."
+    MENUTITLE: Historio
     REVERTTOTHISVERSION: "Malfari al ĉi tiu versio"
     SHOWUNPUBLISHED: "Vidigi nepublikigitajn versiojn"
     SHOWVERSION: "Vidigi version"
@@ -106,7 +161,10 @@ eo:
     PUBLISHER: Publikiginto
     UNKNOWN: Nekonata
     WHEN: Kiam
+  CMSPageSettingsController:
+    MENUTITLE: "Redakti paĝon"
   CMSPagesController:
+    GalleryView: "Galeria vido"
     ListView: "Lista vido"
     MENUTITLE: Paĝoj
     TreeView: "Arba vido"
@@ -118,9 +176,12 @@ eo:
     Title: "Publikigitaj paĝoj"
   CMSSearch:
     FILTERDATEFROM: De
+    FILTERDATEHEADING: Dato
     FILTERDATETO: Al
     FILTERLABELTEXT: Serĉi
     PAGEFILTERDATEHEADING: "Laste redaktita"
+  CMSSettingsController:
+    MENUTITLE: Agordoj
   CMSSiteTreeFilter_ChangedPages:
     Title: "Ŝanĝitaj paĝoj"
   CMSSiteTreeFilter_DeletedPages:
@@ -141,6 +202,7 @@ eo:
     CMS: CMS
     DRAFT: Malneta
     DRAFTSITE: "Malneta retejo"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Vi devas ensaluti per via CMS-pasvorto por vidi la projektan aŭ enarkivigitan enhavon.  <a href=\"%s\">Alklaku ĉi tie por reiri al la publika retejo.</a>"
     Email: Retpoŝto
     INSTALL_SUCCESS: "Instalis sukcese!"
     InstallFilesDeleted: "Sukcesis forigi instalajn dosierojn."
@@ -188,16 +250,38 @@ eo:
     DEFAULTERRORPAGETITLE: "Ne trovis paĝon"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Bedaŭrinde, estis problemo pri via peto.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Servila eraro"
+    DESCRIPTION: "Propra enhavo por diversaj kazoj de eraro (ekzemple, \"Ne trovis paĝon\")"
+    ERRORFILEPROBLEM: "Eraro okazis malfermante dosieron \"{filename}\" por skribi. Bonvolu kontroli permesojn."
+    PLURALNAME: "Prieraraj paĝoj"
+    SINGULARNAME: "Prierara paĝo"
+  File:
+    Title: Titolo
+  Folder:
+    AddFolderButton: "Aldoni dosierujon"
+    DELETEUNUSEDTHUMBNAILS: "Forigi neuzitajn miniaturojn"
+    UNUSEDFILESTITLE: "Neuzitaj dosieroj"
+    UNUSEDTHUMBNAILSTITLE: "Neuzitaj miniaturoj"
+    UploadFilesButton: Alŝuti
+  LeftAndMain:
+    DELETED: Forigita.
+    PreviewButton: Aspekto
+    SAVEDUP: Konservita.
+    SearchResults: "Serĉaj rezultoj"
+  Permission:
+    CMS_ACCESS_CATEGORY: CMS-aliro
   Permissions:
     CONTENT_CATEGORY: Enhavopermesoj
     PERMISSIONS_CATEGORY: "Roloj kaj aliraj permesoj"
   RedirectorPage:
+    DESCRIPTION: "Alidirektas al malsama interna paĝo"
     HASBEENSETUP: "Alidirekta paĝo estis agordita sen ie al kie alidirekti."
     HEADER: "Ĉi tiu paĝo redirektos uzantojn al alia paĝo"
     OTHERURL: "URL de alia retejo"
+    PLURALNAME: "Alidirektaj paĝoj"
     REDIRECTTO: "Alidirekti al"
     REDIRECTTOEXTERNAL: "Alia retejo"
     REDIRECTTOPAGE: "Paĝo en via retejo"
+    SINGULARNAME: "Alidirekta paĝo"
     YOURPAGE: "Paĝo en via retejo"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Ruli
@@ -209,6 +293,11 @@ eo:
     OPERATION_REMOVE: "Forigi elektitajn el ĉiuj stadioj. (AVERTO: detruos ĉiujn elektitajn paĝojn el kaj stadio kaj publika)"
     SELECTALL: "elekti ĉion"
     UNSELECTALL: "malelekti ĉion"
+  ReportAdmin:
+    MENUTITLE: Raportoj
+    ReportTitle: Titolo
+  ReportAdminForm:
+    FILTERBY: "Filtri laŭ"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Bonvolu publikigi la ligitan paĝon por publikigi la virtualan paĝon"
     VIRTUALPAGEWARNING: "Bonvolu elekti ligitan paĝon kaj unue konservi ĝin por publikigi ĉi tiun paĝon"
@@ -219,15 +308,23 @@ eo:
     SearchResults: "Serĉaj rezultoj"
   SideReport:
     BROKENFILES: "Paĝoj kun rompitaj dosieroj"
+    BROKENLINKS: "Paĝoj kun rompitaj ligiloj"
     BROKENREDIRECTORPAGES: "Redirektaj paĝoj indikantaj forigitajn paĝojn"
     BROKENVIRTUALPAGES: "VirtualajPaĝoj indikantaj forigitajn paĝojn"
     BrokenLinksGroupTitle: "Raporto pri rompitaj ligiloj"
     ContentGroupTitle: "Raportoj pri enhavo"
     EMPTYPAGES: "Malplenaj paĝoj"
     LAST2WEEKS: "Paĝoj redaktitaj dum la lastaj 2 semajnoj"
+    OtherGroupTitle: Alia
     ParameterLiveCheckbox: "Kontroli publikan retejon"
+    REPEMPTY: "La raporto {title} estas malplena."
   SilverStripeNavigator:
     ARCHIVED: Enarkivigita
+  SilverStripeNavigatorLink:
+    ShareInstructions: "Por kunhavigi ĉi tiun paĝon, kopiu kaj algluu la suban ligilon."
+    ShareLink: "Komunigi ligilon"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Fermi
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Enmeti paĝon"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -248,12 +345,28 @@ eo:
     SINGULARNAME: "Paĝo pri alidirekto"
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: "Paĝo por ĝenerala enhavo"
-    PLURALNAME: Paĝoj
-    SINGULARNAME: Paĝo
+    PLURALNAME: "Retejaj arboj"
+    SINGULARNAME: "Reteja arbo"
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: "Vidigas la enhavon de alia paĝo"
     PLURALNAME: "Virtualaj paĝoj"
     SINGULARNAME: "Virtuala paĝo"
+  SiteConfig:
+    DEFAULTTHEME: "(Uzi aprioran etoson)"
+    EDITHEADER: "Kiu povas redakti paĝojn en ĉi tiu retejo?"
+    EDIT_PERMISSION: "Agordi konfiguron de retejo"
+    EDIT_PERMISSION_HELP: "Eblo agordi ĉieajn alirajn agordojn/supronivelajn paĝajn permesojn."
+    PLURALNAME: "Retejaj agordaroj"
+    SINGULARNAME: "Agordi retejon"
+    SITENAMEDEFAULT: "Nomo de via retejo"
+    SITETAGLINE: "Slogano de retejo"
+    SITETITLE: "Titolo de retejo"
+    TABACCESS: Aliro
+    TABMAIN: Ĉefa
+    TAGLINEDEFAULT: "jen via slogano"
+    THEME: Etoso
+    TOPLEVELCREATE: "Kiu povas krei paĝojn en la radiko de la retejo?"
+    VIEWHEADER: "Kiu povas vidigi paĝojn en ĉi tiu retejo?"
   SiteTree:
     ACCESSANYONE: Iu
     ACCESSHEADER: "Kiuj povas vidi ĉi tiun paĝon?"
@@ -261,9 +374,11 @@ eo:
     ACCESSONLYTHESE: "Nur ĉi tiuj homoj (elektu el listo)"
     ADDEDTODRAFTHELP: "Paĝo ankoraŭ estas ne publikigita"
     ADDEDTODRAFTSHORT: Malneto
+    ALLOWCOMMENTS: "Permesi rimarkojn en ĉi tiu paĝo?"
     APPEARSVIRTUALPAGES: "Ĉi tiu enhavo ankaŭ aperas en la virtualaj paĝoj en la sekcioj {title}."
     ARCHIVEDPAGEHELP: "Paĝo estas forigita el malneta kaj publika"
     ARCHIVEDPAGESHORT: Enarkivigita
+    BUTTONARCHIVEDESC: "Malpublikigi kaj sendi al arkivo"
     BUTTONCANCELDRAFT: "Nuligi malnetajn ŝanĝojn"
     BUTTONCANCELDRAFTDESC: "Forigi vian malneton kaj reveni al la aktuale eldonita paĝo"
     BUTTONDELETEDESC: "Forigi el malneta aŭ publika, kaj sendi ilin al la arĥivo"
@@ -274,13 +389,16 @@ eo:
     BUTTONUNPUBLISHDESC: "Forigi ĉi tiun paĝon de la publikigita retejo"
     Comments: Komentoj
     Content: Enhavo
-    DEFAULTABOUTCONTENT: "<p>Vi povas plenigi ĉi tiun paĝon per via materialo, aŭ forigi ĝin kaj krei viajn proprajn paĝojn.</p>"
+    DEFAULTABOUTCONTENT: "<p>Vi povas plenigi ĉi tiun paĝon per via materialo, aŭ forigi ĝin kaj krei viajn proprajn paĝojn.<br /></p>"
     DEFAULTABOUTTITLE: "Pri ni"
-    DEFAULTCONTACTCONTENT: "<p>Vi povas plenigi ĉi tiun paĝon per via materialo, aŭ forigi ĝin kaj krei viajn proprajn paĝojn.</p>"
+    DEFAULTCONTACTCONTENT: "<p>Vi povas plenigi ĉi tiun paĝon per via materialo, aŭ forigi ĝin kaj krei viajn proprajn paĝojn.<br /></p>"
     DEFAULTCONTACTTITLE: "Kontakti nin"
     DEFAULTHOMECONTENT: "<p>Bonvenon al SilverStripe! Jen la apriora hejmpaĝo. Vi povas redakti la paĝon malfermante je <a href=\"admin/\">la CMS</a>.</p><p>Vi povas nun aliri la <a href=\"http://docs.silverstripe.org\">dokumentaron por programistoj</a>, aŭ komenci la <a href=\"http://www.silverstripe.org/learn/lessons\">SilverStripe-lecionojn</a>.</p>"
     DEFAULTHOMETITLE: Hejmo
+    DELETEDPAGEHELP: "Paĝo ne plu estas publikigita"
+    DELETEDPAGESHORT: Forigita
     DEPENDENT_NOTE: "La sekvaj paĝoj dependas de ĉi tiu paĝo. Tio inkluzivas virtualajn paĝojn, alidirektajn paĝojn, kaj paĝojn kun enhavaj ligiloj."
+    DESCRIPTION: "Ĝenerala paĝo por enhavo"
     DependtPageColumnLinkType: "Ligila tipo"
     DependtPageColumnURL: URL
     EDITANYONE: "Tiu, kiu povas ensaluti en la CMS"
@@ -322,17 +440,22 @@ eo:
     PARENTTYPE_SUBPAGE: "Subpaĝo sub patra paĝo"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Regi alirajn rajtojn por enhavo"
     PERMISSION_GRANTACCESS_HELP: "Permesi agordi paĝspecifajn alirajn limigojn en la sekcio \"Paĝoj\"."
+    PLURALNAME: Paĝoj
     PageTypNotAllowedOnRoot: "Paĝa tipo \"{type}\" ne estas permesita ĉe la radika nivelo"
     PageTypeNotAllowed: "Paĝa tipo \"{type}\" ne estas permesita kiel ido de ĉi tiu patra paĝo"
+    REMOVEDFROMDRAFTHELP: "Paĝo estas publikigita, sed ĝi estas forigita el malneto"
+    REMOVEDFROMDRAFTSHORT: "Forigita el malneta"
     REMOVE_INSTALL_WARNING: "Averto: vi devus forigi je install.php el ĉi tiu Silverstripe-instalaĵo por sekureco."
     REORGANISE_DESCRIPTION: "Reorganizi la retejan arbon"
     REORGANISE_HELP: "Rearanĝi paĝojn en la reteja arbo per ŝovado."
     SHOWINMENUS: "Vidigi en menuoj?"
     SHOWINSEARCH: "Vidigi en serĉo?"
+    SINGULARNAME: Paĝo
     TABBEHAVIOUR: Konduto
     TABCONTENT: "Ĉefa enhavo"
     TABDEPENDENT: "Dependaj paĝoj"
     TOPLEVEL: "Enhavo de Retejo (Supra Nivelo)"
+    TOPLEVELCREATORGROUPS: "Supranivelaj kreiloj"
     URLSegment: URL-segmento
     VIEWERGROUPS: "Grupoj de vidantoj"
     VIEW_ALL_DESCRIPTION: "Vidigi ajnan paĝon"
@@ -346,6 +469,8 @@ eo:
     many_many_ImageTracking: "Spuri Bildojn"
     many_many_LinkTracking: "Spuri Ligilojn"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Ĉi tiu listo vidigas ĉiujn paĝojn kie la dosiero estas enmetita per la faksimila redaktilo."
+    EDIT: Redakti
     TITLE_INDEX: "#"
     TITLE_TYPE: Tipo
     TITLE_USED_ON: "Uzita je"
@@ -361,7 +486,10 @@ eo:
     HAVEASKED: "Vi petis vidi la enhavon de nia retejo en"
   VirtualPage:
     CHOOSE: "Ligita paĝo"
+    DESCRIPTION: "Vidigas la enhavon de alia paĝo"
     EditLink: redakti
     HEADER: "Ĉi tiu estas virtuala paĝo"
     HEADERWITHLINK: "Ĉi tiu estas virtuala paĝo kopianta enhavon el \"{title}\" ({link})"
+    PLURALNAME: "Virtualaj paĝoj"
     PageTypNotAllowedOnRoot: "Origina paĝa tipo \"{type}\" ne estas permesita ĉe la root-nivelo por ĉi tiu virtuala paĝo."
+    SINGULARNAME: "Virtuala paĝo"

--- a/lang/es.yml
+++ b/lang/es.yml
@@ -1,10 +1,41 @@
 es:
   AssetAdmin:
-    ErrorItemPermissionDenied: "Parece que no tienes los permisos necesarios para añadir {ObjectTitle} a una campaña"
-    ErrorNotFound: "Ese {Type} no pudo ser encontrado"
+    ADDFILES: "Añadir Archivos"
+    ActionAdd: "Añadir carpeta"
+    AppCategoryArchive: Archivar
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Documento
+    AppCategoryFlash: Flash
+    AppCategoryImage: Imagen
+    AppCategoryVideo: Vídeo
+    BackToFolder: "Volver a la carpeta"
+    CREATED: Fecha
+    CurrentFolderOnly: "¿Límite a la carpeta actual?"
+    DetailsView: Detalles
+    FILES: Archivos
+    FILESYSTEMSYNC: "Sincronizar archivos"
+    FILESYSTEMSYNCTITLE: "Actualizar las entradas de base de datos del CMS de archivos en el sistema de archivos. Es útil cuando los nuevos archivos se han subido desde fuera del CMS, p.e., a través de FTP."
+    FROMTHEINTERNET: "Desde internet"
+    FROMYOURCOMPUTER: "Desde tu ordenador"
+    Filetype: "Tipo de archivo"
+    ListView: "Vista de Lista"
+    MENUTITLE: Archivos
+    NEWFOLDER: NuevaCarpeta
+    SIZE: Tamaño
+    THUMBSDELETED: "{count} miniaturas no utilizadas han sido eliminadas"
+    TreeView: "Vista en árbol"
+    Upload: Subir
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Eliminar carpetas"
+  AssetAdmin_Tools:
+    FILTER: Filtro
+  AssetAdmin_left_ss:
+    GO: Ir
   AssetTableField:
     BACKLINKCOUNT: "Usado en:"
     PAGES: página(s)
+  BackLink_Button_ss:
+    Back: Atras
   BrokenLinksReport:
     Any: Cualquiera
     BROKENLINKS: "Informe de enlaces rotos"
@@ -29,16 +60,19 @@ es:
     VirtualPageNonExistent: "página virtual apuntando a una página que no existe"
   CMSAddPageController:
     Title: "Añadir página"
-  CMSBatchAction_Archive:
-    RESULT: "Eliminadas %d páginas desde el borrador y publicadas, y enviadas al archivo"
-    TITLE: "Despublicar y archivar"
   CMSBatchActions:
+    ARCHIVE: Archivar
+    ARCHIVED_PAGES: "%d páginas archivadas"
+    DELETED_DRAFT_PAGES: "Eliminadas %d páginas del sitio en borrador, %d fallos"
+    DELETED_PAGES: "Eliminadas %d páginas del sitio publicado, %d fallos"
+    DELETE_DRAFT_PAGES: "Eliminar del sitio borrador"
+    DELETE_PAGES: "Eliminar del sitio público"
     PUBLISHED_PAGES: "Publicadas %d páginas, %d fallos"
     PUBLISH_PAGES: Publicar
     RESTORE: Restaurar
     RESTORED_PAGES: "%d páginas restauradas"
-    UNPUBLISHED_PAGES: "%d páginas despublicadas"
-    UNPUBLISH_PAGES: Despublicar
+  CMSFileAddController:
+    MENUTITLE: Archivos
   CMSMain:
     ACCESS: "Acceso a la sección '{title}'"
     ACCESS_HELP: "Permitir la visualización de la sección que contiene el árbol de la página y el contenido. Ver y editar permisos puede ser gestionado a través de menús desplegables específicos de las páginas, así como los \"permisos de contenido\" separados."
@@ -51,24 +85,23 @@ es:
     ChoosePageParentMode: "Elegir donde crear esta página"
     ChoosePageType: "Elegir tipo de página"
     Create: Crear
+    DELETE: "Eliminar del borrador de la web"
+    DELETEFP: "Eliminar de la web publicada"
+    DESCREMOVED: "y {count} descendientes"
     DUPLICATED: Duplicado
     DUPLICATEDWITHCHILDREN: "Duplicado con hijos"
-    EMAIL: "Correo electrónico"
-    ListFiltered: "Mostrando resultados de la búsqueda."
+    EditTree: "Editar árbol"
+    MENUTITLE: "Editar página"
     NEWPAGE: "Nuevo {pagetype}"
     PAGENOTEXISTS: "Esta página no existe"
-    PAGES: "Estado de página"
     PAGETYPEANYOPT: Cualquiera
-    PAGETYPEOPT: "Tipo de página"
     PUBALLCONFIRM: "Por favor publica todas las páginas del sitio, copiando el contenido del borrador al sitio público"
     PUBALLFUN: "Función \"Publicar Todo\""
-    PUBALLFUN2: "Presionando este botón haremos el equivalente a ir a cada página y pulsar \"publicar\". Está destinado a ser utilizado después de haber habido ediciones masivas del contenido, como cuando el sitio fue construido por primera vez."
-    PUBLISHED: "'{title}' publicado satisfactoriamente."
     PUBPAGES: "Hecho: Publicadas {count} páginas"
     PageAdded: "Página creada correctamente"
+    REMOVED: Removido
     REMOVEDPAGE: "Eliminado '{title}' del sitio publicado"
     REMOVEDPAGEFROMDRAFT: "Borrado '%s'%s desde el sitio no publicado"
-    RESTORE: "Restaurar borrador"
     RESTORED: "Restablecido '{title}' correctamente"
     RESTORE_DESC: "Recuperar la versión archivada del borrador"
     RESTORE_TO_ROOT: "Recuperar borrador al nivel superior"
@@ -76,23 +109,24 @@ es:
     ROLLBACK: "Restaurar esta versión"
     ROLLEDBACKPUBv2: Restaurado
     ROLLEDBACKVERSIONv2: "Versión #%d restaurada"
-    SAVED: "'{title}' guardado satisfactoriamente."
+    SAVE: Guardar
     SAVEDRAFT: "Guardar borrador"
     TabContent: Contenido
     TabHistory: Historial
     TabSettings: Ajustes
-    TreeFiltered: "Mostrando resultados de la búsqueda."
-    TreeFilteredClear: Limpiar
-    UNPUBLISH_AND_ARCHIVE: "Despublicar y archivar"
   CMSMain_left_ss:
-    APPLY_FILTER: Buscar
-    CLEAR_FILTER: Limpiar
+    RESET: Restablecer
   CMSPageAddController:
+    MENUTITLE: "Añadir página"
     ParentMode_child: "Debajo de otra página"
     ParentMode_top: "Nivel superior"
+  CMSPageEditController:
+    MENUTITLE: "Editar página"
   CMSPageHistoryController:
     COMPAREMODE: "Modo comparación (seleccionar dos)"
     COMPAREVERSIONS: "Comparar Versiones"
+    COMPARINGVERSION: "Comparando versiones {version1} y {version2}"
+    MENUTITLE: Historial
     REVERTTOTHISVERSION: "Volver a esta versión"
     SHOWUNPUBLISHED: "Mostrar versiones no publicadas"
     SHOWVERSION: "Mostrar Versión"
@@ -102,35 +136,29 @@ es:
   CMSPageHistoryController_versions_ss:
     AUTHOR: Autor
     NOTPUBLISHED: "Sin publicar"
-    PREVIEW: "Previsualizar Sitio Web"
     PUBLISHER: "Publicado por"
     UNKNOWN: Desconocido
     WHEN: Cuando
+  CMSPageSettingsController:
+    MENUTITLE: "Editar página"
   CMSPagesController:
+    GalleryView: "Ver como galería"
     ListView: "Vista como lista"
     MENUTITLE: Páginas
     TreeView: "Ver como árbol"
-  CMSPagesController_ContentToolbar_ss:
-    MULTISELECT: "Acciones por lotes"
   CMSPagesController_Tools_ss:
     FILTER: Filtro
   CMSSIteTreeFilter_PublishedPages:
     Title: "Páginas publicadas"
   CMSSearch:
     FILTERDATEFROM: De
+    FILTERDATEHEADING: Fecha
     FILTERDATETO: Hasta
-    FILTERLABELTEXT: Buscar
     PAGEFILTERDATEHEADING: "Última actualización"
-  CMSSiteTreeFilter_ChangedPages:
-    Title: "Páginas modificadas"
-  CMSSiteTreeFilter_DeletedPages:
-    Title: "Todas las páginas, incluidas las archivadas"
+  CMSSettingsController:
+    MENUTITLE: Ajustes
   CMSSiteTreeFilter_Search:
     Title: "Todas las paginas"
-  CMSSiteTreeFilter_StatusDeletedPages:
-    Title: "Páginas archivadas"
-  CMSSiteTreeFilter_StatusDraftPages:
-    Title: "Páginas en borrador"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
     Title: "Publicada, pero eliminada de los borradores"
   ContentControl:
@@ -141,6 +169,7 @@ es:
     CMS: CMS
     DRAFT: Borrador
     DRAFTSITE: "Sitio en Borrador"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Debe iniciar sesión para poder acceder a los contenidos archivados o al borrador. <a href=\"%s\">De un click aquí para regresar al sitio publicado.</a>"
     Email: "Correo electrónico"
     INSTALL_SUCCESS: "¡Instalación Correcta!"
     InstallFilesDeleted: "Los archivos de instalación han sido borrados correctamente."
@@ -188,27 +217,42 @@ es:
     DEFAULTERRORPAGETITLE: "Página no encontrada"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Lo sentimos, hubo un problema al gestionar tu solicitud.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Error de servidor"
+    DESCRIPTION: "Contenido personalizado para los distintos casos de error (p.e. \"Página no encontrada\")"
+    ERRORFILEPROBLEM: "Error abriendo el archivo \"{filename}\" para escritura. Por favor comprueba los permisos del archivo."
+    SINGULARNAME: "Página de error"
+  File:
+    Title: Título
+  Folder:
+    AddFolderButton: "Añadir carpeta"
+    DELETEUNUSEDTHUMBNAILS: "Borrar miniaturas sin usar"
+    UNUSEDFILESTITLE: "Archivos sin usar"
+    UNUSEDTHUMBNAILSTITLE: "Miniaturas sin usar"
+    UploadFilesButton: Subir
+  LeftAndMain:
+    DELETED: Borrado.
+    PreviewButton: Previsualizar
+    SAVEDUP: Guardado
+    SearchResults: "Resultados de la búsqueda"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Acceso CMS"
   Permissions:
     CONTENT_CATEGORY: "Permisos de contenido"
     PERMISSIONS_CATEGORY: "Permisos de roles y accesos"
   RedirectorPage:
+    DESCRIPTION: "Redirige a un página interna diferente"
     HASBEENSETUP: "Se ha establecido una página redireccionadora sin ningún sitio al cual redireccionar."
     HEADER: "Esta página redireccionará a los usuarios a otra página"
     OTHERURL: "Otra dirección URL de un sitio web"
     REDIRECTTO: "Redireccionar a"
     REDIRECTTOEXTERNAL: "Otro sitio web"
     REDIRECTTOPAGE: "Una página en su sitio web"
+    SINGULARNAME: "Página de redirección apuntando a una página que no existe"
     YOURPAGE: "Página en su sitio web"
-  RemoveOrphanedPagesTask:
-    BUTTONRUN: Ejecutar
-    CHOOSEOPERATION: "Elegir operación:"
-    DELETEWARNING: "Advertencia: Estas operaciones no son reversibles. Por favor, manejese con precaución."
-    HEADER: "Tarea de eliminar todas las páginas huérfanas"
-    NONEFOUND: "No se han encontrado huérfanos"
-    NONEREMOVED: "Ninguno eliminado"
-    OPERATION_REMOVE: "Eliminar seleccionado de todas los escenarios (ADVERTENCIA: Destruirá todas las páginas seleccionadas de ambos escenarios y en vivo)"
-    SELECTALL: "seleccionar todo"
-    UNSELECTALL: "deselecciona todo"
+  ReportAdmin:
+    MENUTITLE: Informes
+    ReportTitle: Título
+  ReportAdminForm:
+    FILTERBY: "Filtrar por"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Esta página es un borrador de página virtual"
     VIRTUALPAGEWARNING: "Esta es una página virtual"
@@ -219,53 +263,38 @@ es:
     SearchResults: "Resultados de la búsqueda"
   SideReport:
     BROKENFILES: "Páginas con archivos rotos"
+    BROKENLINKS: "Página con enlaces rotos"
     BROKENREDIRECTORPAGES: "Páginas de redirección apuntando a páginas borradas"
     BROKENVIRTUALPAGES: "Páginas Virtuales apuntando a páginas borradas"
     BrokenLinksGroupTitle: "Informes de enlaces rotos"
     ContentGroupTitle: "Informes de contenido"
     EMPTYPAGES: "Páginas vacías"
     LAST2WEEKS: "Páginas editadas en las últimas 2 semanas"
+    OtherGroupTitle: Otro
     ParameterLiveCheckbox: "Comprobar sitio activo"
+    REPEMPTY: "El informe {title} está vacío."
   SilverStripeNavigator:
     ARCHIVED: Archivado
-  SilverStripe\CMS\Controllers\CMSPageAddController:
-    MENUTITLE: "Añadir página"
-  SilverStripe\CMS\Controllers\CMSPageEditController:
-    MENUTITLE: "Editar página"
-  SilverStripe\CMS\Controllers\CMSPageHistoryController:
-    MENUTITLE: Historial
-  SilverStripe\CMS\Controllers\CMSPageSettingsController:
-    MENUTITLE: "Editar página"
-  SilverStripe\CMS\Controllers\CMSPagesController:
-    MENUTITLE: Páginas
-  SilverStripe\CMS\Model\ErrorPage:
-    DESCRIPTION: "Contenido personalizado para los distintos casos de error (p.e. \"Página no encontrada\")"
-    PLURALNAME: "Páginas de error"
-    PLURALS:
-      one: "Una Página de error"
-      other: "{count} Páginas de error"
-    SINGULARNAME: "Página de error"
-  SilverStripe\CMS\Model\RedirectorPage:
-    DESCRIPTION: "Redirecciona a una página interna o a una URL externa"
-    PLURALNAME: "Páginas de redirección"
-    PLURALS:
-      one: "Una Página de redirección"
-      other: "{count} Páginas de redirección"
-    SINGULARNAME: "Página de redirección"
-  SilverStripe\CMS\Model\SiteTree:
-    DESCRIPTION: "Página de contenido genérico"
-    PLURALNAME: Páginas
-    PLURALS:
-      one: "Una Página"
-      other: "{count} Páginas"
-    SINGULARNAME: Página
-  SilverStripe\CMS\Model\VirtualPage:
-    DESCRIPTION: "Muestra el contenido de otra página"
-    PLURALNAME: "Páginas virtuales"
-    PLURALS:
-      one: "Una Página Virtuales"
-      other: "{count} Páginas Virtuales"
-    SINGULARNAME: "Página Virtual"
+  SilverStripeNavigatorLink:
+    ShareLink: "Compartir enlace"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Cerrar
+  SiteConfig:
+    DEFAULTTHEME: "(Usar tema por defecto)"
+    EDITHEADER: "¿Quién puede editar páginas en este sitio?"
+    EDIT_PERMISSION: "Gestionar configuración del sitio"
+    EDIT_PERMISSION_HELP: "Capacidad de editar el acceso de configuración global/permisos de página de nivel superior."
+    PLURALNAME: "Configuraciones del sitio"
+    SINGULARNAME: "Configuración del sitio"
+    SITENAMEDEFAULT: "Nombre de tu Sitio"
+    SITETAGLINE: "Lema/Eslogan del Sitio"
+    SITETITLE: "Título de tu sitio"
+    TABACCESS: Acceso
+    TABMAIN: Principal
+    TAGLINEDEFAULT: "tu lema aquí"
+    THEME: Tema
+    TOPLEVELCREATE: "¿Quién puede crear páginas en este sitio?"
+    VIEWHEADER: "¿Quién puede ver páginas en este sitio?"
   SiteTree:
     ACCESSANYONE: Cualquiera
     ACCESSHEADER: "¿Quién puede ver esta página?"
@@ -273,12 +302,13 @@ es:
     ACCESSONLYTHESE: "Solo estas personas (elija de la lista)"
     ADDEDTODRAFTHELP: "La página aún no ha sido publicada"
     ADDEDTODRAFTSHORT: Borrador
+    ALLOWCOMMENTS: "¿Permitir comentarios en esta página?"
     APPEARSVIRTUALPAGES: "Este contenido también aparece en las páginas virtuales en las secciones {title}."
     ARCHIVEDPAGEHELP: "Esta página ha sido removida de los borradores y del sitio en vivo"
     ARCHIVEDPAGESHORT: Archivada
+    BUTTONARCHIVEDESC: "Ocultar y mandar al archivo"
     BUTTONCANCELDRAFT: "Cancelar los cambios en el borrador"
     BUTTONCANCELDRAFTDESC: "Elimine el borrador y regrese a la página que se encuentra publicada actualmente"
-    BUTTONDELETEDESC: "Eliminar desde el borrador/publicadas y enviar al archivo"
     BUTTONPUBLISHED: Publicado
     BUTTONSAVED: Guardado
     BUTTONSAVEPUBLISH: "Guardar y publicar"
@@ -286,13 +316,14 @@ es:
     BUTTONUNPUBLISHDESC: "Elimine esta página del sitio publicado"
     Comments: Comentarios
     Content: Contenido
-    DEFAULTABOUTCONTENT: "<p>Puede llenar esta página con su propio contenido, o eliminarla y crear sus propias páginas.</p>"
     DEFAULTABOUTTITLE: "Sobre nosotros"
-    DEFAULTCONTACTCONTENT: "<p>Puede llenar esta página con su propio contenido, o eliminarla y crear sus propias páginas.</p>"
     DEFAULTCONTACTTITLE: "Contacta con nosotros"
     DEFAULTHOMECONTENT: "<p>¡Bienvenido a SilverStripe! Esta es la página de inicio por defecto. Tú puedes editar esta página abriendo <a href=\"admin/\">el CMS</a>.</p><p>También puedes acceder a la  <a href=\"http://docs.silverstripe.org\">documentación de desarrollo</a>, o comenzar con las<a href=\"http://www.silverstripe.org/learn/lessons\">Lecciones de SilverStripe</a>.</p>"
     DEFAULTHOMETITLE: Inicio
+    DELETEDPAGEHELP: "La página ya no está publicada"
+    DELETEDPAGESHORT: Borrado
     DEPENDENT_NOTE: "Las siguientes páginas dependen de esta página. Esto incluye páginas virtuales, páginas de redireccionamiento, y las páginas con enlaces de contenido."
+    DESCRIPTION: "Página genérica de contenido"
     DependtPageColumnLinkType: "Tipo de enlace"
     DependtPageColumnURL: "Depende de"
     EDITANYONE: "Cualquiera que pueda iniciar sesión en el CMS"
@@ -310,8 +341,6 @@ es:
     LASTSAVED: "Última vez que se guardó"
     LASTUPDATED: "Última actualización"
     LINKCHANGENOTE: "Cambio el enlace de esta página también afectará a los enlaces de todas las páginas hijas."
-    LINKSALREADYUNIQUE: "{url} ya es único"
-    LINKSCHANGEDTO: " cambiado {url1} -> {url2}"
     MENUTITLE: "Etiqueta de Navegación"
     METADESC: Descripción
     METADESCHELP: "Los motores de búsqueda usan este contenido para mostrar resultados de búsqueda (aunque no influirá en su ranking)."
@@ -323,8 +352,6 @@ es:
     MoreOptions: "Más opciones"
     NOTPUBLISHED: "No publicado"
     OBSOLETECLASS: "Clase obsoleta"
-    ONLIVEONLYSHORT: "Solo en vivo"
-    ONLIVEONLYSHORTHELP: "La página está publicada, pero ha sido eliminada de borrador"
     PAGELOCATION: "Localización de la página"
     PAGETITLE: "Nombre de la página"
     PAGETYPE: "Tipo de Página"
@@ -334,17 +361,22 @@ es:
     PARENTTYPE_SUBPAGE: "Sub-página por debajo de una página padre"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Controlar qué grupos pueden acceder o editar determinadas páginas"
     PERMISSION_GRANTACCESS_HELP: "Permitir la creación de restricciones de acceso específicas a la página en la sección \"Páginas\"."
+    PLURALNAME: Páginas
     PageTypNotAllowedOnRoot: "La página tipo \"{type}\" no está permitida en el nivel raiz"
     PageTypeNotAllowed: "El tipo de página \"{type}\" no está permitido como hijo de esta página padre"
+    REMOVEDFROMDRAFTHELP: "La página está publicada, pero ha sido eliminada de borrador"
+    REMOVEDFROMDRAFTSHORT: "Eliminar de borrador"
     REMOVE_INSTALL_WARNING: "Aviso: Deberías eliminar install.php de esta instalación de SilverStripe por motivos de seguridad."
     REORGANISE_DESCRIPTION: "Cambiar la estructura del sitio"
     REORGANISE_HELP: "Reorganizar las páginas en el árbol del sitio a través de drag&drop."
     SHOWINMENUS: "¿Mostrar en menús?"
     SHOWINSEARCH: "¿Mostrar en la búsqueda?"
+    SINGULARNAME: Página
     TABBEHAVIOUR: Comportamiento
     TABCONTENT: Contenido
     TABDEPENDENT: "Páginas dependientes"
     TOPLEVEL: "Contenido del Sitio (Top Level)"
+    TOPLEVELCREATORGROUPS: "Creadores de nivel superior"
     URLSegment: "Segmento de URL"
     VIEWERGROUPS: "Visor de Grupos"
     VIEW_ALL_DESCRIPTION: "Ver cualquier página"
@@ -358,9 +390,8 @@ es:
     many_many_ImageTracking: "Rastreo de Imágenes"
     many_many_LinkTracking: "Rastreo de Enlaces"
   SiteTreeFileExtension:
-    TITLE_INDEX: "#"
-    TITLE_TYPE: Tipo
-    TITLE_USED_ON: "Usado en:"
+    BACKLINK_LIST_DESCRIPTION: "Esta lista muestra todas las páginas que han sido añadidas mediante un editor WYSIWYG."
+    EDIT: Editar
   SiteTreeURLSegmentField:
     EMPTY: Vacío
     HelpChars: "Los caracteres especiales son automáticamente convertidos o eliminados."
@@ -373,7 +404,9 @@ es:
     HAVEASKED: "Ha pedido ver el contenido de nuestro sitio el"
   VirtualPage:
     CHOOSE: Seleccionar
+    DESCRIPTION: "Muestra el contenido de otra página"
     EditLink: Editar
     HEADER: "Esta es una página virtual"
     HEADERWITHLINK: "Título con link"
     PageTypNotAllowedOnRoot: "Tipo de página original \"{type}\" no se permite en el nivel raíz para esta página virtual"
+    SINGULARNAME: "Página Virtual"

--- a/lang/es_AR.yml
+++ b/lang/es_AR.yml
@@ -1,4 +1,8 @@
 es_AR:
+  AssetAdmin:
+    NEWFOLDER: "Nueva Carpeta"
+  AssetAdmin_left_ss:
+    GO: Ir
   BrokenLinksReport:
     Any: Cualquiera
     BROKENLINKS: "Informe de enlaces rotos"
@@ -21,15 +25,20 @@ es_AR:
     RedirectorNonExistent: "la página de redireccionamiento apunta a una página inexistente"
     VirtualPageNonExistent: "página virtual apuntando a una página no existente"
   CMSBatchActions:
+    DELETE_DRAFT_PAGES: "Eliminado del sitio borrador"
+    DELETE_PAGES: "Eliminar del sitio publicado"
     PUBLISHED_PAGES: "Se publicaron %d páginas, %d fallas"
     PUBLISH_PAGES: Publicar
   CMSMain:
     ACCESS_HELP: "Permitir la visualización de la sección que contiene el árbol de páginas y el contenido. Ver y editar permisos que se pueden manejar mediante listas desplegables específicas de la página, así como el apartado \"Permisos del contenido\"."
+    DELETE: "Eliminar del sitio borrador"
+    DELETEFP: "Eliminar del sitio publicado"
     PAGENOTEXISTS: "Esta página no existe"
     PUBALLCONFIRM: "Por favor publica todas las páginas del sitio, copiando el contenido del boceto al sitio público"
     PUBALLFUN: "Funcionalidad \"Publicar Todo\""
     REMOVEDPAGEFROMDRAFT: "Quitados '%s' del borrador del sitio"
     ROLLBACK: "Restaurar a ésta versión"
+    SAVE: Guardar
   ContentControl:
     NOTEWONTBESHOWN: "Nota: este mensage no se mostrará a sus visitantes"
   ContentController:
@@ -67,6 +76,12 @@ es_AR:
     CODE: "Código de Error"
     DEFAULTERRORPAGECONTENT: "<p>Disculpa, parece que estás tratando de ingresar a una página que no existe.</p><p>Por favor verifica la escritura de la URL que deseas visitar e inténtalo de nuevo.</p>"
     DEFAULTERRORPAGETITLE: "Página inexistente"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Eliminar  miniaturas sin utilizar"
+    UNUSEDFILESTITLE: "Archivos sin utilizar"
+    UNUSEDTHUMBNAILSTITLE: "Miniaturas sin utilizar"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Acceso al CMS"
   Permissions:
     CONTENT_CATEGORY: "Permisos de contenido"
     PERMISSIONS_CATEGORY: "Roles y permisos de acceso"
@@ -78,24 +93,46 @@ es_AR:
     REDIRECTTOEXTERNAL: "Otro sitio web"
     REDIRECTTOPAGE: "Una página en tu sitio web"
     YOURPAGE: "Página en tu sitio web"
+  ReportAdminForm:
+    FILTERBY: "Filtrar por"
   SearchForm:
     GO: Ir
     SEARCH: Buscar
     SearchResults: "Resultados de la búsqueda"
   SideReport:
     BROKENFILES: "Páginas con archivos rotos"
+    BROKENLINKS: "Páginas con enlaces rotos"
     BROKENREDIRECTORPAGES: "RedirectorPages apunta a páginas eliminadas"
     BROKENVIRTUALPAGES: "VirtualPages apunta a páginas eliminadas"
     BrokenLinksGroupTitle: "Informes de enlaces rotos"
     ContentGroupTitle: "Informes del contenido"
     EMPTYPAGES: "Páginas sin contenido"
     LAST2WEEKS: "Páginas editadas en las últimas 2 semanas"
+    OtherGroupTitle: Otro
     ParameterLiveCheckbox: "Verificar el sitio en vivo"
+  SilverStripeNavigatorLink:
+    ShareLink: "Compartir enlace"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Cerrar
+  SiteConfig:
+    DEFAULTTHEME: "(Usar tema por defecto)"
+    EDITHEADER: "¿Quien puede editar páginas en este sitio?"
+    EDIT_PERMISSION: "Administrar la configuración del sitio"
+    SITENAMEDEFAULT: "Nombre de su sitio"
+    SITETAGLINE: "Lema/slogan del sitio"
+    SITETITLE: "Título del sitio"
+    TABACCESS: Acceso
+    TABMAIN: Principal
+    TAGLINEDEFAULT: "su lema aquí"
+    THEME: Tema
+    TOPLEVELCREATE: "¿Quien puede crear páginas en la raíz del sitio?"
+    VIEWHEADER: "¿Quien puede ver páginas en este sitio?"
   SiteTree:
     ACCESSANYONE: Cualquiera
     ACCESSHEADER: "¿Quién puede ver ésta página?"
     ACCESSLOGGEDIN: "Usuarios registrados"
     ACCESSONLYTHESE: "Únicamente estas personas (selecciona de la lista)"
+    ALLOWCOMMENTS: "¿Permitir comentarios en ésta página?"
     BUTTONCANCELDRAFT: "Cancelar cambios al borrador"
     BUTTONCANCELDRAFTDESC: "Eliminar el borrador y regresar a la página actualmente publicada"
     BUTTONUNPUBLISH: "No Publicar"
@@ -135,6 +172,7 @@ es_AR:
     TABCONTENT: Contenido
     TABDEPENDENT: "Páginas dependientes"
     TOPLEVEL: "Contenido del Sitio (Nivel Superior)"
+    TOPLEVELCREATORGROUPS: "Creadores de alto nivel"
     URLSegment: "Segmento del URL"
     VIEW_ALL_DESCRIPTION: "Ver cualquier página"
     VIEW_DRAFT_CONTENT: "Ver contenido borrador"
@@ -148,3 +186,4 @@ es_AR:
     HAVEASKED: "Has solicitado ver el contenido de nuestro sitio en"
   VirtualPage:
     HEADER: "Esta es una página virtual"
+    SINGULARNAME: "Página Virtual"

--- a/lang/es_MX.yml
+++ b/lang/es_MX.yml
@@ -1,4 +1,8 @@
 es_MX:
+  AssetAdmin:
+    NEWFOLDER: "Nueva Carpeta"
+  AssetAdmin_left_ss:
+    GO: Ir
   BrokenLinksReport:
     Any: Cualquiera
     BROKENLINKS: "Informe de enlaces rotos"
@@ -21,14 +25,19 @@ es_MX:
     RedirectorNonExistent: "la redirección de página apunta a una página inexistente"
     VirtualPageNonExistent: "la página virtual apunta a una página inexistente"
   CMSBatchActions:
+    DELETE_DRAFT_PAGES: "Eliminar del boceto del sitio"
+    DELETE_PAGES: "Eliminada del sito público"
     PUBLISHED_PAGES: "Se publicaron %d páginas, %d fallos"
     PUBLISH_PAGES: Publicar
   CMSMain:
+    DELETE: "Eliminar del boceto del sitio"
+    DELETEFP: "Eliminar del sitio público"
     PAGENOTEXISTS: "Esta página no existe"
     PUBALLCONFIRM: "Por favor publique todas las páginas del sitio, copiando el contenido del boceto al sitio público"
     PUBALLFUN: "Funcionalidad \"Publicar todo\""
     REMOVEDPAGEFROMDRAFT: "Se ha eliminado '%s' del boceto del sitio"
     ROLLBACK: "Restaurar a ésta versión"
+    SAVE: Guardar
   ContentControl:
     NOTEWONTBESHOWN: "Nota: este mensaje no será mostrado a sus visitantes"
   ContentController:
@@ -67,6 +76,12 @@ es_MX:
     CODE: "Código de Error"
     DEFAULTERRORPAGECONTENT: "<p>Disculpe, parece que está tratando de ingresar a una página que no existe.</p><p>Por favor verifique la URL que desea visitar e inténtelo de nuevo.</p>"
     DEFAULTERRORPAGETITLE: "Página inexistente"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Eliminar  miniaturas de imágenes sin utilizar"
+    UNUSEDFILESTITLE: "Archivo sin utilizar"
+    UNUSEDTHUMBNAILSTITLE: "Miniaturas de imágenes sin utilizar"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Acceder al CMS"
   Permissions:
     CONTENT_CATEGORY: "Permisos de contenido"
     PERMISSIONS_CATEGORY: "Roles y permisos de acceso"
@@ -78,24 +93,45 @@ es_MX:
     REDIRECTTOEXTERNAL: "Otro sitio web"
     REDIRECTTOPAGE: "Una página en tu sitio web"
     YOURPAGE: "Página en tu sitio web"
+  ReportAdminForm:
+    FILTERBY: "Filtrar por"
   SearchForm:
     GO: Ir
     SEARCH: Buscar
     SearchResults: "Resultados de la búsqueda"
   SideReport:
     BROKENFILES: "Páginas con archivos en mal estado"
+    BROKENLINKS: "Páginas con enlaces rotos"
     BROKENREDIRECTORPAGES: "La redirección de página está apuntando a páginas eliminadas"
     BROKENVIRTUALPAGES: "Las páginas virtuales están apuntando a páginas eliminadas"
     BrokenLinksGroupTitle: "Informe de enlaces rotos"
     ContentGroupTitle: "Informe de contenido"
     EMPTYPAGES: "Páginas vacías"
     LAST2WEEKS: "Páginas editadas en las últimas 2 semanas"
+    OtherGroupTitle: Otro
     ParameterLiveCheckbox: "Comprobar el sitio vivo"
+  SilverStripeNavigatorLink:
+    ShareLink: "Compartir enlace"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Cerrar
+  SiteConfig:
+    DEFAULTTHEME: "(Usar tema predeterminado)"
+    EDITHEADER: "¿Quién puede editar páginas en este sitio?"
+    EDIT_PERMISSION: "Administrar la configuración del sitio"
+    SITENAMEDEFAULT: "Nombre de su sitio"
+    SITETAGLINE: "Lema/Slogan del Sitio"
+    SITETITLE: "Título del sitio"
+    TABACCESS: Acceso
+    TABMAIN: Principal
+    TAGLINEDEFAULT: "su lema aquí"
+    THEME: Tema
+    VIEWHEADER: "¿Quién puede ver las páginas en este sitio?"
   SiteTree:
     ACCESSANYONE: Cualquiera
     ACCESSHEADER: "¿Quién puede ver ésta página?"
     ACCESSLOGGEDIN: "Usuarios registrados"
     ACCESSONLYTHESE: "Únicamente estas personas (seleccione de la lista)"
+    ALLOWCOMMENTS: "¿Permitir comentarios en ésta página?"
     BUTTONCANCELDRAFT: "Cancelar cambios al boceto"
     BUTTONCANCELDRAFTDESC: "Eliminar el boceto y regresar a la página publicada actualmente"
     BUTTONUNPUBLISH: "Ocultar al público"
@@ -135,6 +171,7 @@ es_MX:
     TABCONTENT: Contenido
     TABDEPENDENT: "Páginas dependientes"
     TOPLEVEL: "Contenido del sitio (Nivel Superior)"
+    TOPLEVELCREATORGROUPS: "Creadores de nivel superior"
     URLSegment: "Segmento de la URL"
     VIEWERGROUPS: "Ver grupos"
     VIEW_ALL_DESCRIPTION: "Ver cualquier página"
@@ -149,3 +186,4 @@ es_MX:
     HAVEASKED: "Has solicitado ver el contenido de nuestro sitio en"
   VirtualPage:
     HEADER: "Esta es una página virtual"
+    SINGULARNAME: "Página virtual"

--- a/lang/et_EE.yml
+++ b/lang/et_EE.yml
@@ -1,7 +1,41 @@
 et_EE:
+  AssetAdmin:
+    ADDFILES: "Lisa fail"
+    ActionAdd: "Lisa kaust"
+    AppCategoryArchive: Arhiiv
+    AppCategoryAudio: Heli
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Pilt
+    AppCategoryVideo: Video
+    BackToFolder: "Tagasi kausta"
+    CREATED: Kuupäev
+    CurrentFolderOnly: "Kas lubada juurdepääs ainult praegusele kaustale?"
+    DetailsView: Üksikasjad
+    FILES: Failid
+    FILESYSTEMSYNC: "Sünkrooni failid"
+    FILESYSTEMSYNCTITLE: "Uuenda failisüsteemis CMS-andmebaasi failisisendeid. Kasulik, kui uued failid on laaditud üles väljaspool CMS-i, näiteks FTP vahendusel."
+    FROMTHEINTERNET: Internetist
+    FROMYOURCOMPUTER: "Teie arvutist"
+    Filetype: "Faili tüüp"
+    ListView: Loendivaade
+    MENUTITLE: Failid
+    NEWFOLDER: "Uus kaust"
+    SIZE: Suurus
+    THUMBSDELETED: "{count} kasutamata pisipilti on kustutatud"
+    TreeView: Puuvaade
+    Upload: "Laadi üles"
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Kustuta kaustad"
+  AssetAdmin_Tools:
+    FILTER: Filtreeri
+  AssetAdmin_left_ss:
+    GO: Mine
   AssetTableField:
     BACKLINKCOUNT: "Kasutatakse:"
     PAGES: "leht (lehed)"
+  BackLink_Button_ss:
+    Back: Tagasi
   BrokenLinksReport:
     Any: Kõik
     BROKENLINKS: "Katkiste linkide aruanne"
@@ -27,8 +61,14 @@ et_EE:
   CMSAddPageController:
     Title: "Lisa leht"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "Mustandi saidilt kustutati %d lehte, %d tõrget"
+    DELETED_PAGES: "Avaldatud saidilt kustutati %d lehte, %d tõrget"
+    DELETE_DRAFT_PAGES: "Kustuta mustandite saidilt"
+    DELETE_PAGES: "Kustuta avaldatud lehekülgede hulgast"
     PUBLISHED_PAGES: "Avaldatud %d lehte, %d tõrget"
     PUBLISH_PAGES: Avalda
+  CMSFileAddController:
+    MENUTITLE: Failid
   CMSMain:
     ACCESS: "Juurdepääs jaotisele '{title}'"
     ACCESS_HELP: "Luba lehepuud ja sisu hõlmava jaotise vaatamine. Vaatamis- ja redigeerimisõigusi on võimalik hallata nii lehepõhiselt kui ka eraldi jaotise \"Sisu õigused\" abil."
@@ -37,6 +77,11 @@ et_EE:
     ChoosePageParentMode: "Valige, kuhu see leht luua"
     ChoosePageType: "Valige lehe tüüp"
     Create: Loo
+    DELETE: "Kustuta mustand"
+    DELETEFP: "Kustuta avaldatud leht"
+    DESCREMOVED: "ja {count} järglast"
+    EditTree: Redigeeri
+    MENUTITLE: "Redigeeri lehte"
     NEWPAGE: "Uus {pagetype}"
     PAGENOTEXISTS: "Antud lehekülge ei eksisteeri"
     PAGETYPEANYOPT: Kõik
@@ -48,16 +93,24 @@ et_EE:
     REMOVEDPAGEFROMDRAFT: "'%s' eemaldatud visandi lehelt"
     RESTORED: "'{title}' taastati edukalt"
     ROLLBACK: "Pööra tagasi sellesse versiooni"
+    SAVE: Salvesta
     SAVEDRAFT: "Salvesta mustand"
     TabContent: Sisu
     TabHistory: Ajalugu
     TabSettings: Seaded
+  CMSMain_left_ss:
+    RESET: Lähtesta
   CMSPageAddController:
+    MENUTITLE: "Lisa leht"
     ParentMode_child: "Teise lehe all"
     ParentMode_top: "Kõrgem tase"
+  CMSPageEditController:
+    MENUTITLE: "Muuda lehte"
   CMSPageHistoryController:
     COMPAREMODE: "Võrdlusrežiim (valige kaks)"
     COMPAREVERSIONS: "Võrdle versioone"
+    COMPARINGVERSION: "Versioonide {version1} ja {version2} võrdlus."
+    MENUTITLE: Ajalugu
     REVERTTOTHISVERSION: "Taasta valitud versioon"
     SHOWUNPUBLISHED: "Näita ka avaldamata versioone"
     SHOWVERSION: "Näita versiooni"
@@ -68,7 +121,10 @@ et_EE:
     NOTPUBLISHED: Avaldamata
     PUBLISHER: Avaldaja
     UNKNOWN: Tundmatu
+  CMSPageSettingsController:
+    MENUTITLE: "Muuda lehte"
   CMSPagesController:
+    GalleryView: Galeriivaade
     ListView: Loendivaade
     MENUTITLE: Lehed
     TreeView: Puuvaade
@@ -76,7 +132,10 @@ et_EE:
     FILTER: Filtreeri
   CMSSearch:
     FILTERDATEFROM: Alates
+    FILTERDATEHEADING: Kuupäev
     FILTERDATETO: Kuni
+  CMSSettingsController:
+    MENUTITLE: Seaded
   CMSSiteTreeFilter_Search:
     Title: "Kõik lehed"
   ContentControl:
@@ -86,6 +145,7 @@ et_EE:
     ARCHIVEDSITEFROM: "Arhiveeritud sait asukohast"
     DRAFT: Mustand
     DRAFTSITE: "Mustandi sait"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Pead olema sisse logitud oma sisuhalduse parooliga, et vaadata mustandeid ja arhiveeritud sisu. <a href=\"%s\">Vajuta siia, et minna tagasi avaldatud lehe juurde.</a>"
     Email: E-post
     INSTALL_SUCCESS: "Paigaldus oli edukas!"
     InstallFilesDeleted: "Installifailid on edukalt kustutatud."
@@ -130,32 +190,78 @@ et_EE:
     DEFAULTERRORPAGETITLE: "Lehekülge ei leitud"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Vabandust, teie taotluse töötlemisel ilmnes probleem.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Serveri viga"
+    DESCRIPTION: "Kohandatud sisu erinevate tõrgete korral (nt \"Lehte ei leitud\")"
+    ERRORFILEPROBLEM: "Tõrge faili \"{filename}\" avamisel kirjutamiseks. Kontrollige faili õigusi."
+    SINGULARNAME: Vealehekülg
+  Folder:
+    AddFolderButton: "Lisa kaust"
+    DELETEUNUSEDTHUMBNAILS: "Kustuta kasutamata väikepildid"
+    UNUSEDFILESTITLE: "Kasutamata failid"
+    UNUSEDTHUMBNAILSTITLE: "Kasutamata väikepildid"
+    UploadFilesButton: "Laadi üles"
+  LeftAndMain:
+    DELETED: Kustutatud.
+    PreviewButton: Eelvaade
+    SAVEDUP: Salvestatud.
+    SearchResults: Otsingutulemused
+  Permission:
+    CMS_ACCESS_CATEGORY: CMS-juurdepääs
   Permissions:
     CONTENT_CATEGORY: "Sisu õigused"
     PERMISSIONS_CATEGORY: "Rollid ja juurdepääsuõigused"
   RedirectorPage:
+    DESCRIPTION: "Suunab teisele siselehele"
     HASBEENSETUP: "Suunav lehekülg seati üles ilma, et ta kuhugile suunaks."
     HEADER: "See lehekülg suunab kasutajad teisele leheküljele"
     OTHERURL: "Teise veebisaidi URL"
     REDIRECTTO: "Suuna ümber"
     REDIRECTTOEXTERNAL: "Teisele veebisaidile"
     REDIRECTTOPAGE: "Leheküljele sinu veebisaidil"
+    SINGULARNAME: Ümbersuunamisleht
     YOURPAGE: "Lehekülg sinu veebisaidil"
+  ReportAdmin:
+    MENUTITLE: Aruanded
+    ReportTitle: Pealkiri
+  ReportAdminForm:
+    FILTERBY: Filtreeri
   SearchForm:
     GO: Mine
     SEARCH: Otsi
     SearchResults: Otsingutulemused
   SideReport:
     BROKENFILES: "Katkiste failidega lehed"
+    BROKENLINKS: "Katkiste linkidega lehed"
     BROKENREDIRECTORPAGES: "Ümbersuunamislehed, mis suunavad kustutatud lehtedele"
     BROKENVIRTUALPAGES: "Virtuaallehed, mis suunavad kustutatud lehtedele"
     BrokenLinksGroupTitle: "Katkiste linkide aruanded"
     ContentGroupTitle: Sisuaruanded
     EMPTYPAGES: "Tühjad leheküljed"
     LAST2WEEKS: "Viimase kahe nädala jooksul muudetud leheküljed"
+    OtherGroupTitle: Muu
     ParameterLiveCheckbox: "Kontrolli avaldatud saiti"
+    REPEMPTY: "Lehe {title} aruanne on tühi."
   SilverStripeNavigator:
     ARCHIVED: Arhiveeritud
+  SilverStripeNavigatorLink:
+    ShareLink: "Jaga linki"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Sulge
+  SiteConfig:
+    DEFAULTTHEME: "(Kasuta vaikekujundust)"
+    EDITHEADER: "Kes saavad sellel saidil lehti redigeerida?"
+    EDIT_PERMISSION: "Saidi konfiguratsiooni haldamine"
+    EDIT_PERMISSION_HELP: "Võimalus redigeerida üldiseid juurdepääsuseadeid / kõrgema taseme lehe õigusi."
+    PLURALNAME: "Saidi konfiguratsioonid"
+    SINGULARNAME: "Saidi konfiguratsioon"
+    SITENAMEDEFAULT: "Teie saidi nimi"
+    SITETAGLINE: "Saidi reklaamlause"
+    SITETITLE: "Saidi pealkiri"
+    TABACCESS: Juurdepääs
+    TABMAIN: Sisu
+    TAGLINEDEFAULT: "teie reklaamlause siin"
+    THEME: Kujundus
+    TOPLEVELCREATE: "Kes saavad luua lehti saidi juurtasandil?"
+    VIEWHEADER: "Kes saavad sellel saidil olevaid lehti vaadata?"
   SiteTree:
     ACCESSANYONE: Igaüks
     ACCESSHEADER: "Kes tohib seda lehekülge minu veebisaidil vaadata?"
@@ -163,6 +269,7 @@ et_EE:
     ACCESSONLYTHESE: "Ainult järgnevad isikud (vali nimekirjast)"
     ADDEDTODRAFTHELP: "Leht ei ole veel avaldatud"
     ADDEDTODRAFTSHORT: Mustand
+    ALLOWCOMMENTS: "Luba kommentaare sellel lehel?"
     APPEARSVIRTUALPAGES: "Sisu on kuvatud ka virtuaalsetel lehtedel jaotistes {title}."
     BUTTONCANCELDRAFT: "Tühista visandi muudatused"
     BUTTONCANCELDRAFTDESC: "Kustuta oma visand ja pöördu tagasi hetkel avaldatud lehekülje kujule"
@@ -176,7 +283,10 @@ et_EE:
     DEFAULTABOUTTITLE: Meist
     DEFAULTCONTACTTITLE: Kontakt
     DEFAULTHOMETITLE: Avaleht
+    DELETEDPAGEHELP: "Leht ei ole enam avaldatud"
+    DELETEDPAGESHORT: Kustutatud
     DEPENDENT_NOTE: "Alljärgnevad lehed sõltuvad sellest lehest. See hõlmab virtuaalseid lehti, ümbersuunamislehti ja sisulinkidega lehti."
+    DESCRIPTION: "Üldine sisuleht"
     DependtPageColumnLinkType: "Lingi tüüp"
     DependtPageColumnURL: URL
     EDITANYONE: "Igaüks, kes sisuhaldussüsteemi sisse võib logida"
@@ -211,17 +321,22 @@ et_EE:
     PARENTTYPE_SUBPAGE: "Vanemlehe all olev alamleht"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Kontroli millised gruppid saavad ligipääsu ja võimaluse muuta mingeid lehti"
     PERMISSION_GRANTACCESS_HELP: "Luba jaotises Lehed lehepõhiste juurdepääsupiirangute seadistamine."
+    PLURALNAME: Lehed
     PageTypNotAllowedOnRoot: "\"{type} tüüpi lehekülg ei ole juurkataloogi tasemel lubatud"
     PageTypeNotAllowed: "Lehe tüüp \"{type}\" ei ole selle vanemlehe alamlehena lubatud"
+    REMOVEDFROMDRAFTHELP: "Lehekülg on avalikustatud, kuid mustand on kustutatud"
+    REMOVEDFROMDRAFTSHORT: "Eemaldati mustandite hulgast"
     REMOVE_INSTALL_WARNING: "Hoiatus! Peaksite eemaldama faili install.php sellest SilverStripe'i installist turvalisuse kaalutlustel."
     REORGANISE_DESCRIPTION: "Muuda saidi struktuuri"
     REORGANISE_HELP: "Korraldage lehti saidipuus ümber pukseerimisega."
     SHOWINMENUS: "Näita menüüdes?"
     SHOWINSEARCH: "Näita otsingus?"
+    SINGULARNAME: Leht
     TABBEHAVIOUR: Käitumine
     TABCONTENT: Sisu
     TABDEPENDENT: "Sõltuvad lehed"
     TOPLEVEL: "Lehe sisu (kõrgeim tase)"
+    TOPLEVELCREATORGROUPS: "Kõrgema taseme loojad"
     URLSegment: "URL-i jagu"
     VIEWERGROUPS: Vaatajagrupid
     VIEW_ALL_DESCRIPTION: "Kuva mis tahes leht"
@@ -241,6 +356,8 @@ et_EE:
     CANACCESS: "Arhiveeritud lehele pääsed ligi selle lingi kaudu:"
     HAVEASKED: "Soovid vaadata meie lehe sisu kuupäeval"
   VirtualPage:
+    DESCRIPTION: "Kuvab sisu teiselt lehelt"
     EditLink: redigeeri
     HEADER: "See on virtuaalne leht"
     PageTypNotAllowedOnRoot: "Lehe originaaltüüp \"{type}\" ei ole selle virtuaalse lehe juurtasandil lubatud."
+    SINGULARNAME: "Virtuaalne leht"

--- a/lang/fa_IR.yml
+++ b/lang/fa_IR.yml
@@ -1,10 +1,44 @@
 fa_IR:
   AssetAdmin:
+    ADDFILES: "اضافه کردن فایل"
+    ActionAdd: "اضافه کردن پوشه"
+    AppCategoryArchive: بایگانی
+    AppCategoryAudio: صوتی
+    AppCategoryDocument: اسناد
+    AppCategoryFlash: فلش
+    AppCategoryImage: تصویر
+    AppCategoryVideo: ویدئو
+    BackToFolder: "بازگشت به پوشه"
+    CMSMENU_OLD: "فایل‌ها (قدیمی)"
+    CREATED: تاریخ
+    CurrentFolderOnly: "محدود به پوشه‌ی کنونی؟"
+    DetailsView: جزییات
     ErrorItemPermissionDenied: "به نظر می‌رسد شما دسترسی‌های لازم برای افزودن {ObjectTitle} به کمپین را ندارید"
     ErrorNotFound: "این {Type} یافت نشد"
+    FILES: فایل‌ها
+    FILESYSTEMSYNC: "همگام‌سازی فایل‌ها"
+    FILESYSTEMSYNCTITLE: "به روز رسانی مداخل پایگاه داده CMS از فایل‌های روی فایل‌سیستم. مفید برای وقتی که فایل‌های جدید خارج از CMS بارگذاری شده‌اند، مثلاً از طریقFTP."
+    FROMTHEINTERNET: "از اینترنت"
+    FROMYOURCOMPUTER: "از کامپیوتر شما"
+    Filetype: "نوع فایل"
+    ListView: "نمایش لیستی"
+    MENUTITLE: فایل‌ها
+    NEWFOLDER: "پوشه جديد"
+    SIZE: حجم
+    THUMBSDELETED: "{count} تصویر انگشتی بلااستفاده حذف گردید"
+    TreeView: "نمایش درختی"
+    Upload: بارگذاری
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "حذف پوشه‌ها"
+  AssetAdmin_Tools:
+    FILTER: پالایش
+  AssetAdmin_left_ss:
+    GO: برو
   AssetTableField:
     BACKLINKCOUNT: "استفاده شده در:"
     PAGES: صفحه(ها)
+  BackLink_Button_ss:
+    Back: بازگشت
   BrokenLinksReport:
     Any: هر
     BROKENLINKS: "گزارش پیوندهای معیوب"
@@ -33,12 +67,20 @@ fa_IR:
     RESULT: "حذف %d صفحه از سایت پیش‌نویس و زنده، و ارسال آنها به آرشیو"
     TITLE: "عدم انتشار و بایگانی"
   CMSBatchActions:
+    ARCHIVE: بایگانی
+    ARCHIVED_PAGES: "بایگانی %d صفحه"
+    DELETED_DRAFT_PAGES: "حذف %d صفحه از سایت پیش‌نویس، %d عدم موفقیت"
+    DELETED_PAGES: "حذف %d صفحه از سایت منتشر شده، %d عدم موفقیت"
+    DELETE_DRAFT_PAGES: "حذف از سایت پیش‌نویس"
+    DELETE_PAGES: "حذف از سایت منتشر شده"
     PUBLISHED_PAGES: "انتشار %d صفحه، %d عدم موفقیت"
     PUBLISH_PAGES: انتشار
     RESTORE: بازنشاندن
     RESTORED_PAGES: "بازنشاندن %d صفحه"
     UNPUBLISHED_PAGES: "عدم انتشار %d صفحه"
     UNPUBLISH_PAGES: "عدم انتشار"
+  CMSFileAddController:
+    MENUTITLE: فایل‌ها
   CMSMain:
     ACCESS: "دسترسی به بخش '{title}'"
     ARCHIVE: بایگانی
@@ -50,10 +92,15 @@ fa_IR:
     ChoosePageParentMode: "انتخاب کنید کجا این صفحه ایجاد شود"
     ChoosePageType: "انتخاب نوع صفحه"
     Create: ایجاد
+    DELETE: "حذف پیش‌نویس"
+    DELETEFP: "حذف کردن از منتشر شده های سایت"
+    DESCREMOVED: "و {count} فرزندان"
     DUPLICATED: "'{title}' باموفقیت دونسخه شد"
     DUPLICATEDWITHCHILDREN: "'{title}' و زیرمجموعه‌های آن با موفقیت دونسخه شد"
     EMAIL: ایمیل
+    EditTree: "ویرایش درخت"
     ListFiltered: "نمایش نتایج جستجو"
+    MENUTITLE: "ویرایش صفحه"
     NEWPAGE: "{pagetype} جدید"
     PAGENOTEXISTS: "این صفحه وجود ندارد"
     PAGES: "وضعیت صفحه"
@@ -64,6 +111,7 @@ fa_IR:
     PUBLISHED: "انتشار موفقیت‌آمیز '{title}'"
     PUBPAGES: "انجام شد: انتشار {count} صفحه"
     PageAdded: "صفحه با موفقیت ایجاد شد"
+    REMOVED: "حذف '{title}'{description} از سایت لایو"
     REMOVEDPAGE: "حذف '{title}' از سایت منتشر شده"
     REMOVEDPAGEFROMDRAFT: "حذف '%s' از سایت پیش‌نویس"
     RESTORE: "بازنشانی پیش‌نویس"
@@ -74,6 +122,7 @@ fa_IR:
     ROLLBACK: "بازگردانی به این نسخه"
     ROLLEDBACKPUBv2: "بازگردانی به نسخه‌ی منتشرشده."
     ROLLEDBACKVERSIONv2: "بازگردانی به نسخه‌ی #%d."
+    SAVE: ذخیره
     SAVED: "دخیره‌سازی '{title}' باموفقیت انجام شد."
     SAVEDRAFT: "ذخیره پیش‌نویس"
     TabContent: محتوا
@@ -85,12 +134,18 @@ fa_IR:
   CMSMain_left_ss:
     APPLY_FILTER: جستجو
     CLEAR_FILTER: پاک‌کردن
+    RESET: "تنظیم مجدد"
   CMSPageAddController:
+    MENUTITLE: "افزودن صفحه"
     ParentMode_child: "زیر صفحه‌ی دیگر"
     ParentMode_top: "سطح بالا"
+  CMSPageEditController:
+    MENUTITLE: "ویرایش صفحه"
   CMSPageHistoryController:
     COMPAREMODE: "وضعیت مقایسه (دو مورد انتخاب کنید)"
     COMPAREVERSIONS: "مقایسه نسخه‌ها"
+    COMPARINGVERSION: "مقایسه نسخه‌های {version1} و {version2}."
+    MENUTITLE: تاریخچه
     REVERTTOTHISVERSION: "بازگشت به این نسخه"
     SHOWUNPUBLISHED: "نمایش نسخه‌های منتشر نشده"
     SHOWVERSION: "نمایش ویرایش"
@@ -104,7 +159,10 @@ fa_IR:
     PUBLISHER: "منتشر کننده"
     UNKNOWN: نامشخص
     WHEN: "چه وقت"
+  CMSPageSettingsController:
+    MENUTITLE: "ویرایش صفحه"
   CMSPagesController:
+    GalleryView: "نمایش نگارخانه"
     ListView: "نمایش لیستی"
     MENUTITLE: صفحات
     TreeView: "نمایش درختی"
@@ -116,9 +174,12 @@ fa_IR:
     Title: "صفحات منتشر شده"
   CMSSearch:
     FILTERDATEFROM: از
+    FILTERDATEHEADING: تاریخ
     FILTERDATETO: تا
     FILTERLABELTEXT: جستجو
     PAGEFILTERDATEHEADING: "آخرین ویرایش"
+  CMSSettingsController:
+    MENUTITLE: تنظیمات
   CMSSiteTreeFilter_ChangedPages:
     Title: "صفحات تغییر یافته"
   CMSSiteTreeFilter_DeletedPages:
@@ -139,6 +200,7 @@ fa_IR:
     CMS: CMS
     DRAFT: پیش‌نویس
     DRAFTSITE: "سایت پیش‌نویس"
+    DRAFT_SITE_ACCESS_RESTRICTION: "برای نمایش پیش‌نویس یا محتوای آرشیو شده باید با رمز عبور سی‌ام‌اس خود وارد شوید. <a href=\"%s\">اینجا را کلیک کنید</a> تا به سایت منتشر‌شده بازگردید."
     Email: ای‌میل
     INSTALL_SUCCESS: "نصب موفقیت‌آمیز!"
     InstallFilesDeleted: "فایل‌های نصبی با موفقیت حذف شدند."
@@ -186,16 +248,38 @@ fa_IR:
     DEFAULTERRORPAGETITLE: "برگ پیدا نشد"
     DEFAULTSERVERERRORPAGECONTENT: "<p>با پوزش، در پردازش درخواست شما ایرادی بوجود آمد.</p>"
     DEFAULTSERVERERRORPAGETITLE: "خطای سرور"
+    DESCRIPTION: "محتوای دلخواه برای وضعیت‌های گوناگون خطا (به عنوان مثال \"صفحه یافت نشد\")"
+    ERRORFILEPROBLEM: "خطا در بازکردن فایل \"{filename}\" جهت نگارش. لطفاً اجازه‌های دسترسی فایل را بررسی نمایید."
+    PLURALNAME: "صفحات خطا"
+    SINGULARNAME: "صفحه‌ی خطا"
+  File:
+    Title: عنوان
+  Folder:
+    AddFolderButton: "افزودن پوشه"
+    DELETEUNUSEDTHUMBNAILS: "حذف تصاویر انگشتی بلااستفاده"
+    UNUSEDFILESTITLE: "فایل‌های بلااستفاده"
+    UNUSEDTHUMBNAILSTITLE: "تصاویر انگشتی بلااستفاده"
+    UploadFilesButton: بارگذاری
+  LeftAndMain:
+    DELETED: "حذف شده"
+    PreviewButton: پیش‌نمایش
+    SAVEDUP: "ذخیره شده"
+    SearchResults: "نتایج جستجو"
+  Permission:
+    CMS_ACCESS_CATEGORY: "دسترسی CMS"
   Permissions:
     CONTENT_CATEGORY: "دسترسی محتوا"
     PERMISSIONS_CATEGORY: "مجوز دسترسی ها و وظایف"
   RedirectorPage:
+    DESCRIPTION: "به صفحه‌ی داخلی دیگری هدایت می‌کند"
     HASBEENSETUP: "یک صفحه‌ی هدایت‌گر ایجاد گردیده است بدون این‌که به جایی ارجاع داشته باشد."
     HEADER: "این صفحه کاربران را به صفحه‌ای دیگر هدایت می‌کند"
     OTHERURL: "نشانی تارگاه دیگر"
+    PLURALNAME: "صفحات هدایت‌گر"
     REDIRECTTO: "بازگردانی به"
     REDIRECTTOEXTERNAL: "یک تارگاه دیگر"
     REDIRECTTOPAGE: "یک برگ روی تارگاه شما"
+    SINGULARNAME: "صفحه هدایت‌گر"
     YOURPAGE: "برگ روی تارگاه شما"
   RemoveOrphanedPagesTask:
     BUTTONRUN: اجرا
@@ -206,6 +290,11 @@ fa_IR:
     NONEREMOVED: "هیچ‌کدام حذف نگشت"
     SELECTALL: "انتخاب همه"
     UNSELECTALL: "لغو انتخاب همه"
+  ReportAdmin:
+    MENUTITLE: گزارشات
+    ReportTitle: عنوان
+  ReportAdminForm:
+    FILTERBY: "فیلتر به وسیله"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "لطفاً صفحه‌ی پیوند‌شده را ذخیره نمایید تا صفحه‌ی مجازی انتشار یابد"
     VIRTUALPAGEWARNING: "لطفاً یک صفحه‌ی پیوند‌شده را انتخاب نموده و ذخیره نمایید تا این صفحه بتواند منتشر شود"
@@ -216,15 +305,23 @@ fa_IR:
     SearchResults: "نتایج جستجو"
   SideReport:
     BROKENFILES: "صفحات دارای فایل معیوب"
+    BROKENLINKS: "صفحات دارای پیوند معیوب"
     BROKENREDIRECTORPAGES: "صفحات هدایت‌گر اشاره‌کننده به صفحات حذف شده"
     BROKENVIRTUALPAGES: "صفحات مجازی اشاره‌کننده به صفحات حذف شده"
     BrokenLinksGroupTitle: "گزارش پیوندهای معیوب"
     ContentGroupTitle: "گزارشات محتوا"
     EMPTYPAGES: "صفحات بدون مطلب"
     LAST2WEEKS: "صفحات ویرایش شده در 2 هفته گذشته"
+    OtherGroupTitle: سایر
     ParameterLiveCheckbox: "بررسی سایت به صورت زنده"
+    REPEMPTY: "گزارش {title} خالی است."
   SilverStripeNavigator:
     ARCHIVED: "بایگانی شده"
+  SilverStripeNavigatorLink:
+    ShareInstructions: "جهت به‌اشتراک‌گذاری این صفحه، لینک زیر را کپی و پیست نمایید."
+    ShareLink: "پیوند اشتراک‌گذاری"
+  SilverStripeNavigatorLinkl:
+    CloseLink: بستن
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "افزودن صفحه"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -243,10 +340,27 @@ fa_IR:
     SINGULARNAME: "صفحه هدایت‌گر"
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: "صفحه محتوای عمومی"
+    PLURALNAME: "لیست‌های درختی سایت"
+    SINGULARNAME: "لیست درختی سایت"
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: "نمایش‌دهنده‌ی محتوای صفحه‌ی دیگر"
     PLURALNAME: "صفحات مجازی"
     SINGULARNAME: "صفحه مجازی"
+  SiteConfig:
+    DEFAULTTHEME: "(استفاده از پوسته پیشفرض)"
+    EDITHEADER: "چه کسی میتواند صفحات را در این سایت ویرایش کند؟"
+    EDIT_PERMISSION: "مدیریت پیکربندی سایت"
+    PLURALNAME: "تنظیمات سایت"
+    SINGULARNAME: "تنظیم سایت"
+    SITENAMEDEFAULT: "نام سایت شما"
+    SITETAGLINE: "شعار سایت"
+    SITETITLE: "عنوان سایت"
+    TABACCESS: دسترسی
+    TABMAIN: اصلی
+    TAGLINEDEFAULT: "شعار شما در اینجا"
+    THEME: پوسته
+    TOPLEVELCREATE: "چه کسی میتواند صفحه جدیدی در ریشه(root) سایت ایجاد کند؟"
+    VIEWHEADER: "چه کسی میتواند صفحات سایت را مشاهده کند؟"
   SiteTree:
     ACCESSANYONE: همه
     ACCESSHEADER: "چه کسی بتواند این صفحه را مشاهده کنید ؟"
@@ -254,9 +368,11 @@ fa_IR:
     ACCESSONLYTHESE: "فقط این افراد (انتخاب از لیست)"
     ADDEDTODRAFTHELP: "این صفحه تاکنون منتشر نشده است"
     ADDEDTODRAFTSHORT: پیش‌نویس
+    ALLOWCOMMENTS: "پذیرفتن نظرات در این صفحه ؟"
     APPEARSVIRTUALPAGES: "این محتوا همچنین در صفحات مجازی در بخش‌های {title}."
     ARCHIVEDPAGEHELP: "صفحه از پیش‌نویس و زنده حذف گردید"
     ARCHIVEDPAGESHORT: "بایگانی شده"
+    BUTTONARCHIVEDESC: "عدم انتشار و ارسال به بایگانی"
     BUTTONCANCELDRAFT: "لغو تغییرات پیش‌نویس"
     BUTTONCANCELDRAFTDESC: "حذف پیش‌نویس و بازگردانی به نسخه‌ی منتشر‌شده‌ی کنونی"
     BUTTONDELETEDESC: "حذف از پیش‌نویس/زنده و ارسال به بایگانی"
@@ -271,7 +387,10 @@ fa_IR:
     DEFAULTCONTACTTITLE: "تماس با ما"
     DEFAULTHOMECONTENT: "<p>به سیلوراسترایپ خوش آمدید! این صفحه اصلی پیش فرض است. میتوانید این صفحه را با بازکردن <a href=\"admin/\">سامانه مدیریت محتوا</a> ویرایش نمایید.</p><p>میتوانید به<a href=\"http://docs.silverstripe.org\">مستندات توسعه دهندگان</a> دسترسی یابید، و یا <a href=\"http://www.silverstripe.org/learn/lessons\">درس های سیلوراسترایپ</a> را آغاز نمایید.</p>"
     DEFAULTHOMETITLE: خانه
+    DELETEDPAGEHELP: "صفحه دیگر منتشر شده نیست"
+    DELETEDPAGESHORT: "حذف شده"
     DEPENDENT_NOTE: "صفحات زیر وابسته به این صفحه هستند. شامل صفحات مجازی، هدایت‌گر و صفحاتی با محتوای لینک"
+    DESCRIPTION: "صفحه محتوای عمومی"
     DependtPageColumnLinkType: "نوع پیوند"
     DependtPageColumnURL: "نشانی اینترنتی"
     EDITANYONE: "هر کسی بتواند به سیستم مدیریت محتوا وارد شود"
@@ -306,17 +425,22 @@ fa_IR:
     PARENTTYPE: "جایگاه برگ"
     PARENTTYPE_ROOT: "صفحه‌ی سطح بالا"
     PERMISSION_GRANTACCESS_DESCRIPTION: "مدیریت اجازه‌های دسترسی به محتوا"
+    PLURALNAME: صفحات
     PageTypNotAllowedOnRoot: "وجود نوع صفحه‌ی \"{type}\" در بخش ریشه‌ی سایت مجاز نیست."
     PageTypeNotAllowed: "وجود نوع صفحه‌ی \"{type}\" به عنوان فرزند این صفحه‌ی والد مجاز نیست."
+    REMOVEDFROMDRAFTHELP: "صفحه منتشر شده، اما از پیش‌نویس حذف گردیده است"
+    REMOVEDFROMDRAFTSHORT: "حذف شده از پیش‌نویس"
     REMOVE_INSTALL_WARNING: "هشدار: به دلایل امنیتی بایستی فایل install.php را از این سیلوراسترایپ نصب شده حذف نمایید."
     REORGANISE_DESCRIPTION: "تغییر ساختار سایت"
     REORGANISE_HELP: "مرتب‌سازی صفحات در این لیست درختی از طریق برداشتن و انداختن."
     SHOWINMENUS: "نمایش در منوها؟"
     SHOWINSEARCH: "نمایش در جستجو ؟"
+    SINGULARNAME: صفحه
     TABBEHAVIOUR: رفتار
     TABCONTENT: مطلب
     TABDEPENDENT: "صفحات وابسته"
     TOPLEVEL: "محتوای سایت (سطح بالا)"
+    TOPLEVELCREATORGROUPS: "خالقین رده بالا"
     URLSegment: "بخش آدرس URL"
     VIEWERGROUPS: "گروه‌های مشاهده‌کنندگان"
     VIEW_ALL_DESCRIPTION: "مشاهده هر صفحه‌ای"
@@ -328,6 +452,8 @@ fa_IR:
     many_many_ImageTracking: "ردیابی تصویر"
     many_many_LinkTracking: "ردیابی پیوند"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "این لیست نشان‌دهنده‌ی تمامی صفحاتی است که فایل توسط یک ویرایشگر ویزی‌ویگ (WYSIWYG) افزوده شده است."
+    EDIT: ویرایش
     TITLE_INDEX: "#"
     TITLE_TYPE: نوع
     TITLE_USED_ON: "استفاده شده در"
@@ -343,5 +469,8 @@ fa_IR:
     HAVEASKED: "شما خواسته اید که درون‌مایه تارگاه ما را ببینید در"
   VirtualPage:
     CHOOSE: "صفحه ارجاعی"
+    DESCRIPTION: "نمایش‌دهنده‌ی محتوای صفحه‌ی دیگر"
     EditLink: ویرایش
     HEADER: "این یک صفحه مجازی است"
+    PLURALNAME: "صفحات مجازی"
+    SINGULARNAME: "صفحه مجازی"

--- a/lang/fi.yml
+++ b/lang/fi.yml
@@ -1,10 +1,44 @@
 fi:
   AssetAdmin:
+    ADDFILES: "Lisää tiedostoja"
+    ActionAdd: "Lisää kansio"
+    AppCategoryArchive: Arkisto
+    AppCategoryAudio: Ääni
+    AppCategoryDocument: Asiakirja
+    AppCategoryFlash: Flash
+    AppCategoryImage: Kuva
+    AppCategoryVideo: Video
+    BackToFolder: "Takaisin kansioon"
+    CMSMENU_OLD: "Tiedostot (vanha)"
+    CREATED: Pvm
+    CurrentFolderOnly: "Rajoita tähän kansioon?"
+    DetailsView: Tiedot
     ErrorItemPermissionDenied: "Vaikuttaa siltä, ettei sinulla ole oikeuksia lisätä kampanjaan kohdetta {ObjectTitle}"
     ErrorNotFound: "{Type} ei löytynyt"
+    FILES: Tiedostot
+    FILESYSTEMSYNC: "Synkronoi tiedostot"
+    FILESYSTEMSYNCTITLE: "Päivitä palvelimella olevat tiedostot CMS-järjestelmän tietokantaan. Kätevä toiminto, kun olet siirtänyt tiedostoja suoraa palvelimelle ohi CMS-järjestelmän esim. FTP-ohjelmalla."
+    FROMTHEINTERNET: Internetistä
+    FROMYOURCOMPUTER: "Omalta tietokoneelta"
+    Filetype: Tiedostotyyppi
+    ListView: Listanäkymä
+    MENUTITLE: Tiedostot
+    NEWFOLDER: "Uusi kansio"
+    SIZE: Koko
+    THUMBSDELETED: "{count} käyttämätöntä esikatselukuvaa poistettiin"
+    TreeView: Puunäkymä
+    Upload: Siirrä
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Poista kansiot"
+  AssetAdmin_Tools:
+    FILTER: Suodatin
+  AssetAdmin_left_ss:
+    GO: Siirry
   AssetTableField:
     BACKLINKCOUNT: "Linkitetty:"
     PAGES: sivu(t)
+  BackLink_Button_ss:
+    Back: Takaisin
   BrokenLinksReport:
     Any: Yhtään
     BROKENLINKS: "Rikkinäisten linkkien raportti"
@@ -33,12 +67,20 @@ fi:
     RESULT: "Poistettiin %d sivua luonnoksista ja julkaistuista sivuista sekä arkistoitiin"
     TITLE: "Poista näkyviltä ja arkistoi"
   CMSBatchActions:
+    ARCHIVE: Arkisto
+    ARCHIVED_PAGES: "Arkistoitu %d sivua"
+    DELETED_DRAFT_PAGES: "Poistettiin %d sivua luonnostelusivustolta, %d virhettä"
+    DELETED_PAGES: "Poistettiin %d sivua julkaistulta sivustolta, %d virhettä"
+    DELETE_DRAFT_PAGES: "Poista luonnossivustosta"
+    DELETE_PAGES: "Poista julkaistulta sivustolta"
     PUBLISHED_PAGES: "Julkaistu %d sivua, %d epäonnistumista"
     PUBLISH_PAGES: Julkaise
     RESTORE: Palauta
     RESTORED_PAGES: "Palautettu %d sivua"
     UNPUBLISHED_PAGES: "Poistettiin näkyvistä %d sivua"
     UNPUBLISH_PAGES: "Poista näkyvistä"
+  CMSFileAddController:
+    MENUTITLE: Tiedostot
   CMSMain:
     ACCESS: "Pääsy '{title}' -osioon"
     ACCESS_HELP: "Oikeuttaa näkemään osion, joka sisältää sivurakenteen ja sisällön. Katselu- ja muokkausoikeuksia voidaan käsitellä sivukohtaisten pudotusvalikoiden kautta, kuten myös erillisestä \"Sisällön oikeudet\"-kohdasta."
@@ -51,10 +93,15 @@ fi:
     ChoosePageParentMode: "Valitse kohde, minne sivu luodaan"
     ChoosePageType: "Valitse sivutyyppi"
     Create: Luo
+    DELETE: "Poista luonnossivulta"
+    DELETEFP: "Poista julkaistulta sivulta"
+    DESCREMOVED: "ja {count} alasivua"
     DUPLICATED: "'{title}'  monistettu onnistuneesti"
     DUPLICATEDWITHCHILDREN: "'{title}' ja alasivu monistettiin onnistuneesti"
     EMAIL: Sähköposti
+    EditTree: "Muokkaa rakennepuuta"
     ListFiltered: "Näytetään haun tulokset."
+    MENUTITLE: "Muokkaa sivua"
     NEWPAGE: "Uusi {pagetype}"
     PAGENOTEXISTS: "Tätä sivua ei ole olemassa"
     PAGES: "Sivun tila"
@@ -66,6 +113,7 @@ fi:
     PUBLISHED: "Julkaistiin '{title}' onnistuneesti."
     PUBPAGES: "Valmis: julkaistiin {count} sivu(a)"
     PageAdded: "Sivun luonti onnistui"
+    REMOVED: "Poista '{title}'{description} näkyvältä sivustolta"
     REMOVEDPAGE: "'{title}' poistettiin julkaistulta sivustolta"
     REMOVEDPAGEFROMDRAFT: "Poistettu '%s' luonnossivustolta"
     RESTORE: "Palauta luonnos"
@@ -76,6 +124,7 @@ fi:
     ROLLBACK: "Siirry takaisin tähän versioon."
     ROLLEDBACKPUBv2: "Palattiin takaisin julkaistuun versioon"
     ROLLEDBACKVERSIONv2: "Palautettu versioon #%d."
+    SAVE: Tallenna
     SAVED: "Tallennettiin '{title}' onnistuneesti."
     SAVEDRAFT: "Tallenna luonnos"
     TabContent: Sisältö
@@ -87,12 +136,18 @@ fi:
   CMSMain_left_ss:
     APPLY_FILTER: Haku
     CLEAR_FILTER: Tyhjennä
+    RESET: Nollaa
   CMSPageAddController:
+    MENUTITLE: "Lisää sivu"
     ParentMode_child: "Toisen sivun alla"
     ParentMode_top: Ylätaso
+  CMSPageEditController:
+    MENUTITLE: "Muokkaa sivua"
   CMSPageHistoryController:
     COMPAREMODE: "Vertailutila (valitse kaksi)"
     COMPAREVERSIONS: "Vertaa versioita"
+    COMPARINGVERSION: "Vertaillaan versioita {version1} ja {version2}"
+    MENUTITLE: Historia
     REVERTTOTHISVERSION: "Palaa tähän versioon"
     SHOWUNPUBLISHED: "Näytä julkaisemattomat versiot"
     SHOWVERSION: "Näytä versionumero"
@@ -106,7 +161,10 @@ fi:
     PUBLISHER: Julkaisija
     UNKNOWN: Tuntematon
     WHEN: Milloin
+  CMSPageSettingsController:
+    MENUTITLE: "Muokkaa sivua"
   CMSPagesController:
+    GalleryView: "Suuret ikonit"
     ListView: Listanäkymä
     MENUTITLE: Sivut
     TreeView: Puunäkymä
@@ -118,9 +176,12 @@ fi:
     Title: "Julkaistut sivut"
   CMSSearch:
     FILTERDATEFROM: Alkaen
+    FILTERDATEHEADING: Pvm
     FILTERDATETO: Päättyen
     FILTERLABELTEXT: Haku
     PAGEFILTERDATEHEADING: "Viimeksi muokattu"
+  CMSSettingsController:
+    MENUTITLE: Asetukset
   CMSSiteTreeFilter_ChangedPages:
     Title: "Muokatut sivut"
   CMSSiteTreeFilter_DeletedPages:
@@ -141,6 +202,7 @@ fi:
     CMS: CMS
     DRAFT: Luonnos
     DRAFTSITE: Luonnossivusto
+    DRAFT_SITE_ACCESS_RESTRICTION: "Voidaksesi katsella luonnoksia tai arkistoitua sisältöä, sinun täytyy kirjautua sisään CMS:n salasanallasi. <a href=\"%s\">Palataksesi julkiselle sivulle, napsauta tästä</a>."
     Email: Sähköposti
     INSTALL_SUCCESS: "Asennus onnistui!"
     InstallFilesDeleted: "Asennustiedostot poistettiin onnistuneesti."
@@ -188,16 +250,38 @@ fi:
     DEFAULTERRORPAGETITLE: "Sivua ei löytynyt"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Pahoittelut, mutta pyyntösi aiheutti virheen.</p>"
     DEFAULTSERVERERRORPAGETITLE: Palvelinvirhe
+    DESCRIPTION: "Omat virheilmoitukset (sivuille, kuten \"Sivua ei löytynyt\")"
+    ERRORFILEPROBLEM: "Virhe avattaessa tiedostoa \"{filename}\" palvelimelle tallentamista varten. Tarkista tiedoston kirjoitusoikeudet."
+    PLURALNAME: Virhesivut
+    SINGULARNAME: Virhesivu
+  File:
+    Title: Nimi
+  Folder:
+    AddFolderButton: "Lisää kansio"
+    DELETEUNUSEDTHUMBNAILS: "Poista käyttämättömät pikkukuvat"
+    UNUSEDFILESTITLE: "Käyttämättömät tiedostot"
+    UNUSEDTHUMBNAILSTITLE: "Käyttämättömät pikkukuvat"
+    UploadFilesButton: Siirrä
+  LeftAndMain:
+    DELETED: Poistettu.
+    PreviewButton: Esikatselu
+    SAVEDUP: Tallennettu.
+    SearchResults: Hakutulokset
+  Permission:
+    CMS_ACCESS_CATEGORY: CMS-pääsy
   Permissions:
     CONTENT_CATEGORY: "Sisällön käyttöoikeudet"
     PERMISSIONS_CATEGORY: "Roolit ja käyttöoikeudet"
   RedirectorPage:
+    DESCRIPTION: "Edelleenohjaa toiselle sisäiselle sivulle"
     HASBEENSETUP: "Sivu, joka ohjaa käyttäjän toiselle sivulle on valmis, mutta sivua, jolle käyttäjä ohjataan, ei ole."
     HEADER: "Tämä sivu ohjaa käyttäjän toiselle sivulle"
     OTHERURL: "Toisen verkkosivuston URL-osoite"
+    PLURALNAME: "Uudelleenohjaavat sivut"
     REDIRECTTO: "Minne ohjataan?"
     REDIRECTTOEXTERNAL: "Muu verkkosivusto"
     REDIRECTTOPAGE: "Sivu verkkosivustollasi"
+    SINGULARNAME: "Uudelleenohjaava sivu"
     YOURPAGE: "Sivu verkkosivustollasi"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Suorita
@@ -209,6 +293,11 @@ fi:
     OPERATION_REMOVE: "Poista kaikki valitut kaikilta julkaisutasoilta (VAROITUS: Tämä poistaa kaikki julkaisua odottavat sekä julkaistut sivut)"
     SELECTALL: "valitse kaikki"
     UNSELECTALL: "poista valinta kaikista"
+  ReportAdmin:
+    MENUTITLE: Raportit
+    ReportTitle: Otsikko
+  ReportAdminForm:
+    FILTERBY: Suodata
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Ole hyvä ja julkaise linkitetty sivu, jotta virtuaalisivun julkaisu on mahdollista"
     VIRTUALPAGEWARNING: "Ole hyvä ja valitse linkitetty sivu ja tallenna se ensin, jotta tämän sivun julkaiseminen olisi mahdollista"
@@ -219,15 +308,23 @@ fi:
     SearchResults: Hakutulokset
   SideReport:
     BROKENFILES: "Sivut joissa rikkinäisiä tiedostoja"
+    BROKENLINKS: "Sivut joissa rikkinäisiä linkkejä"
     BROKENREDIRECTORPAGES: "Uudelleenohjatut sivut, jotka osoittavat poistettuihin sivuhin"
     BROKENVIRTUALPAGES: "Virtuaaliset sivut, jotka osoittavat poistettuihin sivuihin"
     BrokenLinksGroupTitle: "Rikkinäisten linkkien raportit"
     ContentGroupTitle: Sisältöraportit
     EMPTYPAGES: "Sivut, joilla ei ole sisältöä"
     LAST2WEEKS: "Sivut, joita on muokattu viimeisen kahden viikon aikana"
+    OtherGroupTitle: Muu
     ParameterLiveCheckbox: "Tarkista live-sivusto"
+    REPEMPTY: "{title}:n raportti on tyhjä."
   SilverStripeNavigator:
     ARCHIVED: Arkistoitu
+  SilverStripeNavigatorLink:
+    ShareInstructions: "Jakaaksesi tämän sivun kopioi alla oleva linkki."
+    ShareLink: "Jaa linkki"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Sulje
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Lisää sivu"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -248,10 +345,28 @@ fi:
     SINGULARNAME: "Uudelleenohjaava sivu"
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: "Yleinen sisältösivu"
+    PLURALNAME: Hakemistopuut
+    SINGULARNAME: Hakemistopuu
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: "Näyttää toisen sivun sisällön"
     PLURALNAME: Virtuaalisivut
     SINGULARNAME: Virtuaalisivu
+  SiteConfig:
+    DEFAULTTHEME: "(Käytä oletusteemaa)"
+    EDITHEADER: "Kuka voi muokata sivuja tällä sivustolla?"
+    EDIT_PERMISSION: "Hallinnoi sivun kokoonpanoa"
+    EDIT_PERMISSION_HELP: "Kyky muokata maailmanlaajuisia käyttöoikeusasetuksia/ ylätason sivujen käyttöoikeuksia."
+    PLURALNAME: "Sivuston asetuksia"
+    SINGULARNAME: "Sivuston asetukset"
+    SITENAMEDEFAULT: "Sivustosi nimi"
+    SITETAGLINE: "Sivuston mainoslause/slogan"
+    SITETITLE: "Sivuston otsikko"
+    TABACCESS: Oikeudet
+    TABMAIN: "Yleiset asetukset"
+    TAGLINEDEFAULT: "sinun mainoslauseesi tähän"
+    THEME: Teema
+    TOPLEVELCREATE: "Kuka voi luoda sivuja sivuston juureen?"
+    VIEWHEADER: "Kuka voi nähdä sivuja tällä sivustolla?"
   SiteTree:
     ACCESSANYONE: Jokainen
     ACCESSHEADER: "Ketkä saavat katsoa tätä sivua?"
@@ -259,9 +374,11 @@ fi:
     ACCESSONLYTHESE: "Vain seuraavat henkilöt (valitse listalta)"
     ADDEDTODRAFTHELP: "Sivua ei ole vielä julkaistu"
     ADDEDTODRAFTSHORT: Luonnos
+    ALLOWCOMMENTS: "Sallitaanko kommenttien jättö tälle sivulle?"
     APPEARSVIRTUALPAGES: "Tämä sisältö on käytössä myös virtuaalisivuilla osioissa {title}"
     ARCHIVEDPAGEHELP: "Sivu poistettiin luonnoksista ja näkyviltä"
     ARCHIVEDPAGESHORT: Arkistoitu
+    BUTTONARCHIVEDESC: "Poista näkyviltä ja lähetä arkistoon"
     BUTTONCANCELDRAFT: "Peruuta muutokset, jotka teit luonnokseen"
     BUTTONCANCELDRAFTDESC: "Poista luonnoksesi ja palauta julkaistu sivu"
     BUTTONDELETEDESC: "Poista luonnoksista/julkaistuista ja siirrä arkistoon"
@@ -272,11 +389,16 @@ fi:
     BUTTONUNPUBLISHDESC: "Poista tämä sivu julkaistulta sivustolta"
     Comments: Kommentit
     Content: Sisältö
+    DEFAULTABOUTCONTENT: "<p>Voit täyttää tämän sivun omalla sisällölläsi tai poistaa sen ja luoda uusia sivuja.<br /></p>"
     DEFAULTABOUTTITLE: "Tietoa meistä"
+    DEFAULTCONTACTCONTENT: "<p>Voit täyttää tämän sivun omalla sisällölläsi tai poistaa sen ja luoda omia sivuja.<br /></p>"
     DEFAULTCONTACTTITLE: "Ota yhteyttä meihin"
     DEFAULTHOMECONTENT: "<p>Tervetuloa käyttämään SilverStripe-järjestelmää! Tämä on oletus etusivu. Voit muokata tätä sivua avaamalla <a href=\"admin/\">ylläpidon</a>.</p><p>Voit tutustua <a href=\"http://docs.silverstripe.org\">kehittäjädokumentaatioon</a>, tai tutustua<a href=\"http://www.silverstripe.org/learn/lessons\">SilverStripe-koulutusmateriaaliin</a>.</p>"
     DEFAULTHOMETITLE: Koti
+    DELETEDPAGEHELP: "Sivu ei ole enää julkaistuna"
+    DELETEDPAGESHORT: Poistettu
     DEPENDENT_NOTE: "Seuraavat sivut riippuvat tästä sivusta. Tämä pitää sisällään virtuaaliset sivut, uudelleenohjaussivut ja sivut sisältölinkkien kanssa."
+    DESCRIPTION: Yleissisältösivu
     DependtPageColumnLinkType: "Linkin tyyppi"
     DependtPageColumnURL: URL
     EDITANYONE: "Jokainen, joka voi kirjautua sisään CMS:ään."
@@ -318,17 +440,22 @@ fi:
     PARENTTYPE_SUBPAGE: "Alasivu ylätason sivulle (valitse ylätaso)"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Hallitse sisällön käyttöoikeuksia"
     PERMISSION_GRANTACCESS_HELP: "Salli sivukohtaisten pääsyrajoitusten asettaminen \"Sivut\" -osiossa."
+    PLURALNAME: Sivut
     PageTypNotAllowedOnRoot: "\"{type}\" -sivutyyppi ei ole sallittu päätasolla"
     PageTypeNotAllowed: "\"{type}\" -sivutyyppi ei ole sallittu tämän sivun alasivuna."
+    REMOVEDFROMDRAFTHELP: "Sivu on julkaistu, mutta on poistettu luonnoksista"
+    REMOVEDFROMDRAFTSHORT: "Poistettiin luonnoksista"
     REMOVE_INSTALL_WARNING: "Varoitus: Turvallisuussyistä sinun tulisi poistaa install.php-tiedosto SilverStripe-asennuskansiosta."
     REORGANISE_DESCRIPTION: "Muuta sivuston rakennetta"
     REORGANISE_HELP: "Uudelleenjärjestä sivuston rakenne vetämällä ja pudottamalla sivu halutulle paikalle."
     SHOWINMENUS: "Näytetäänkö valikoissa?"
     SHOWINSEARCH: "Näytetäänkö hauissa?"
+    SINGULARNAME: Sivu
     TABBEHAVIOUR: Käyttäytyminen
     TABCONTENT: Sisältö
     TABDEPENDENT: "Riippuvaiset sivut"
     TOPLEVEL: "Sivuston sisältö (ylin taso)"
+    TOPLEVELCREATORGROUPS: "Huipputason tekijät"
     URLSegment: URL-osoite
     VIEWERGROUPS: Katsojaryhmät
     VIEW_ALL_DESCRIPTION: "Näytä mikä tahansa sivu"
@@ -342,6 +469,8 @@ fi:
     many_many_ImageTracking: "Kuvan seuranta"
     many_many_LinkTracking: "Linkin seuranta"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Tämä listaus näyttää kaikki sivut, joissa tiedosto on lisätty WYSIWYG-editorin avulla."
+    EDIT: Muokkaa
     TITLE_INDEX: "#"
     TITLE_TYPE: Tyyppi
     TITLE_USED_ON: Käytössä
@@ -357,7 +486,10 @@ fi:
     HAVEASKED: "Sinua on pyydetty katsomaan sivun sisältöä "
   VirtualPage:
     CHOOSE: "Linkitetty sivu"
+    DESCRIPTION: "Näytä toisen sivun sisältö"
     EditLink: muokkaa
     HEADER: "Tämä on virtuaalisivu"
     HEADERWITHLINK: "Tämä on virtuaalisivu, joka kopioi sisällön kohteesta \"{title}\" ({link})"
+    PLURALNAME: Virtuaalisivut
     PageTypNotAllowedOnRoot: "Alkuperäinen sivutyyppi \"{type}\" ei ole sallittu tämän virtuaalisen sivun päätasolla"
+    SINGULARNAME: Virtuaalisivu

--- a/lang/fo.yml
+++ b/lang/fo.yml
@@ -1,15 +1,24 @@
 fo:
+  AssetAdmin:
+    NEWFOLDER: "Nýggj skjátta"
+  AssetAdmin_left_ss:
+    GO: Víðari
   CMSMain:
+    DELETE: "Strika frá kladdu heimasíðuni"
+    DELETEFP: "Strika frá tí almennu heimasíðuni"
     PAGENOTEXISTS: "Hendan síðan finst ikki."
     PUBALLCONFIRM: "Vinarliga almenna kunngerð allar síðurnar á heimasíðuni,  avrita innihaldsstøðið til beinleiðis"
     PUBALLFUN: "\"Ger alt alment\" funka"
     REMOVEDPAGEFROMDRAFT: "Strikaði '%s' frá kladdu heimasíðuni"
     ROLLBACK: "Far aftur til hesa útgávuna"
+    SAVE: Goym
   ErrorPage:
     404: "404 - Ikki funnin"
     411: "411 - Longd er kravd"
     CODE: Feilkota
     DEFAULTERRORPAGETITLE: "Síðan var ikki funnin"
+  Folder:
+    UNUSEDFILESTITLE: "Óbrúktar fílur"
   RedirectorPage:
     REDIRECTTO: "Víðarisend til"
     REDIRECTTOEXTERNAL: "Onnur heimasíðu"
@@ -26,6 +35,7 @@ fo:
     ACCESSHEADER: "Hvør skal kunna síggja hesa síðuna?"
     ACCESSLOGGEDIN: "Innritaðir brúkarar"
     ACCESSONLYTHESE: "Bert hesi fólkini (vel fra yvirliti)"
+    ALLOWCOMMENTS: "Loyv viðmerkingum á hesari síðuni?"
     BUTTONCANCELDRAFT: "Avlýs kladdu broytingarnar"
     BUTTONCANCELDRAFTDESC: "Strika tína kladdu, og far aftur til tí nuverandi almennu síðuna"
     BUTTONUNPUBLISH: "Óalmenna kunngerð"

--- a/lang/fr.yml
+++ b/lang/fr.yml
@@ -1,7 +1,41 @@
 fr:
+  AssetAdmin:
+    ADDFILES: "Ajouter des fichiers"
+    ActionAdd: "Ajouter un dossier"
+    AppCategoryArchive: Archive
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Document
+    AppCategoryFlash: Flash
+    AppCategoryImage: Image
+    AppCategoryVideo: Vidéo
+    BackToFolder: "Revenir au dossier"
+    CREATED: Date
+    CurrentFolderOnly: "Limiter au dossier actuel ?"
+    DetailsView: Détails
+    FILES: Fichiers
+    FILESYSTEMSYNC: "Synchroniser les fichiers"
+    FILESYSTEMSYNCTITLE: "Met à jour la base de données du système de fichiers, de façon à prendre en compte des fichiers téléchargés en dehors du CMS (p. ex. par FTP)."
+    FROMTHEINTERNET: "En ligne"
+    FROMYOURCOMPUTER: "Depuis votre ordinateur"
+    Filetype: "Type de fichier"
+    ListView: Liste
+    MENUTITLE: Fichiers
+    NEWFOLDER: "Nouveau dossier"
+    SIZE: Taille
+    THUMBSDELETED: "{count} miniatures inutilisées ont été supprimées"
+    TreeView: Arbre
+    Upload: Télécharger
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Supprimer dossiers"
+  AssetAdmin_Tools:
+    FILTER: Filtrer
+  AssetAdmin_left_ss:
+    GO: Accéder
   AssetTableField:
     BACKLINKCOUNT: "Utilisé dans :"
     PAGES: page(s)
+  BackLink_Button_ss:
+    Back: Retour
   BrokenLinksReport:
     Any: "N'importe quel"
     BROKENLINKS: "Rapport des liens brisés"
@@ -27,10 +61,18 @@ fr:
   CMSAddPageController:
     Title: "Ajouter page"
   CMSBatchActions:
+    ARCHIVE: Archive
+    ARCHIVED_PAGES: "%d pages archivées"
+    DELETED_DRAFT_PAGES: "%d pages supprimées du site brouillon, %d échecs"
+    DELETED_PAGES: "%d pages supprimées du site, %d échecs"
+    DELETE_DRAFT_PAGES: "Supprimer du site brouillion"
+    DELETE_PAGES: "Supprimer du site publié"
     PUBLISHED_PAGES: "%d pages publiées, %d échecs"
     PUBLISH_PAGES: Publier
     RESTORE: Restaurer
     RESTORED_PAGES: "%d pages restaurées"
+  CMSFileAddController:
+    MENUTITLE: Fichiers
   CMSMain:
     ACCESS: "Droits d’accès à la section « {title} »"
     ACCESS_HELP: "Permettre l'affichage de la section contenant l'arborescence et le contenu. La gestion des permissions de visualisation et d'édition peut se faire à travers des liste spécifiques à chaque page. Et aussi la \"Permission de contenu\" séparé."
@@ -43,8 +85,13 @@ fr:
     ChoosePageParentMode: "Choisissez où créer cette page"
     ChoosePageType: "Choisir le type de page"
     Create: Créer
+    DELETE: "Supprimer du site brouillon"
+    DELETEFP: "Retirer du site publié"
+    DESCREMOVED: "et {count} descendants"
     DUPLICATED: "'{title}' dupliqué avec succès"
     DUPLICATEDWITHCHILDREN: "'{title}' et ses enfants dupliqués avec succès"
+    EditTree: "Editer l'arbre"
+    MENUTITLE: "Éditer la page"
     NEWPAGE: "Nouveau {pagetype}"
     PAGENOTEXISTS: "Cette page n'existe pas"
     PAGETYPEANYOPT: Tous
@@ -52,22 +99,31 @@ fr:
     PUBALLFUN: "Fonctionnalité \"Tout Publier\""
     PUBPAGES: "{count} pages ont été correctement publiées"
     PageAdded: "La page a été créée avec succès "
+    REMOVED: "'{title}'{description} supprimé du site live"
     REMOVEDPAGE: "« {title} » a été éliminée du site public "
     REMOVEDPAGEFROMDRAFT: "Supprimé '%s' du site de test"
     RESTORED: "« {title} » restaurée avec succès"
     ROLLBACK: "Retourner à cette version"
     ROLLEDBACKPUBv2: "Revenir à la version publiée"
     ROLLEDBACKVERSIONv2: "Revenir à la version #%d"
+    SAVE: Sauvegarder
     SAVEDRAFT: "Sauvegarder le brouillon"
     TabContent: Contenu
     TabHistory: Historique
     TabSettings: Paramètres
+  CMSMain_left_ss:
+    RESET: Réinitialiser
   CMSPageAddController:
+    MENUTITLE: "Ajouter page"
     ParentMode_child: "Sous une autre page"
     ParentMode_top: "Premier niveau"
+  CMSPageEditController:
+    MENUTITLE: "Éditer la page"
   CMSPageHistoryController:
     COMPAREMODE: "Comparer (choisissez deux)"
     COMPAREVERSIONS: "Comparer les versions"
+    COMPARINGVERSION: "Comparaison entre les versions {version1} et {version2}."
+    MENUTITLE: Historique
     REVERTTOTHISVERSION: "Revenir à cette version"
     SHOWUNPUBLISHED: "Afficher les versions non publiées"
     SHOWVERSION: "Afficher cette version"
@@ -80,7 +136,10 @@ fr:
     PUBLISHER: Éditeur
     UNKNOWN: Inconnu
     WHEN: Date
+  CMSPageSettingsController:
+    MENUTITLE: "Éditer la page"
   CMSPagesController:
+    GalleryView: Galerie
     ListView: Liste
     MENUTITLE: Pages
     TreeView: Arbre
@@ -90,7 +149,10 @@ fr:
     Title: "Pages publiées"
   CMSSearch:
     FILTERDATEFROM: De
+    FILTERDATEHEADING: Date
     FILTERDATETO: A
+  CMSSettingsController:
+    MENUTITLE: Paramètres
   CMSSiteTreeFilter_Search:
     Title: "Toutes les pages"
   ContentControl:
@@ -101,6 +163,7 @@ fr:
     CMS: CMS
     DRAFT: Brouillon
     DRAFTSITE: "Site Brouillon"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Vous devez vous authentifier avec votre mot de passe CMS afin de pouvoir consulter le contenu brouillon ou archivé. <a href=\"%s\">Cliquer ici pour revenir au site publié.</a>"
     Email: "Courrier électronique"
     INSTALL_SUCCESS: "Installation terminée!"
     InstallFilesDeleted: "Les fichiers d’installation ont été supprimés. "
@@ -146,17 +209,40 @@ fr:
     DEFAULTERRORPAGETITLE: "Page non trouvée"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Nous sommes désolés, un problème nous a empêché de traiter votre requête.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Erreur du serveur"
+    DESCRIPTION: "Contenu personnalisé pour diverses erreurs (p. ex. « Page introuvable »)"
+    ERRORFILEPROBLEM: " L’ouverture du fichier « {filename} » afin de le modifier a provoqué une erreur ; vérifiez les droits d’accès au fichier. "
+    SINGULARNAME: "Page d’erreur"
+  Folder:
+    AddFolderButton: "Ajouter un dossier"
+    DELETEUNUSEDTHUMBNAILS: "Supprimer les miniatures inutilisées"
+    UNUSEDFILESTITLE: "Fichiers inutilisés"
+    UNUSEDTHUMBNAILSTITLE: "Miniatures inutilisées"
+    UploadFilesButton: Télécharger
+  LeftAndMain:
+    DELETED: Supprimée.
+    PreviewButton: Aperçu
+    SAVEDUP: Sauvegardée.
+    SearchResults: "Résultats de la recherche"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Accès au CMS"
   Permissions:
     CONTENT_CATEGORY: "Permissions du contenu"
     PERMISSIONS_CATEGORY: "Rôles et autorisations d’accès"
   RedirectorPage:
+    DESCRIPTION: "Redirige vers une autre page du site"
     HASBEENSETUP: "Une page de redirection sans adresse de redirection a été créée."
     HEADER: "Cette page va rediriger les utilisateurs vers une autre page"
     OTHERURL: "Autre URL de site web"
     REDIRECTTO: "Rediriger vers"
     REDIRECTTOEXTERNAL: "Autre site web"
     REDIRECTTOPAGE: "Une page de votre site web"
+    SINGULARNAME: "Page de redirection"
     YOURPAGE: "Page de votre site web"
+  ReportAdmin:
+    MENUTITLE: Rapports
+    ReportTitle: Titre
+  ReportAdminForm:
+    FILTERBY: "Filtrer par"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Veuillez publier la page liée avant de publier la page virtuelle"
     VIRTUALPAGEWARNING: "Veuillez choisir une page liée et sauvegarder avant de publier cette page"
@@ -167,15 +253,38 @@ fr:
     SearchResults: "Résultats de la recherche "
   SideReport:
     BROKENFILES: "Pages avec des fichiers brisés"
+    BROKENLINKS: "Pages avec des liens brisés"
     BROKENREDIRECTORPAGES: "Pages de redirection pointant vers une page effacée."
     BROKENVIRTUALPAGES: "Pages virtuelles pointant vers une page effacée."
     BrokenLinksGroupTitle: "Rapports des liens brisés"
     ContentGroupTitle: "Rapports de contenu"
     EMPTYPAGES: "Pages vides"
     LAST2WEEKS: "Pages modifiées durant les 2 dernières semaines"
+    OtherGroupTitle: Autres
     ParameterLiveCheckbox: "Visiter le site de production"
+    REPEMPTY: "Le rapport {title} est vide"
   SilverStripeNavigator:
     ARCHIVED: Archivé
+  SilverStripeNavigatorLink:
+    ShareLink: "Partager le lien"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Fermer
+  SiteConfig:
+    DEFAULTTHEME: "(Utiliser le thème par défaut)"
+    EDITHEADER: "Qui peut modifier les pages sur ce site?"
+    EDIT_PERMISSION: "Configuration du site"
+    EDIT_PERMISSION_HELP: "Capacité d'édition des accès globales et permission des pages de premier niveau."
+    PLURALNAME: "Configurations du site"
+    SINGULARNAME: "Configuration du site"
+    SITENAMEDEFAULT: "Nom du site"
+    SITETAGLINE: "Slogan ou devise du site"
+    SITETITLE: "Titre du site"
+    TABACCESS: Accès
+    TABMAIN: Principal
+    TAGLINEDEFAULT: "Votre slogan ici"
+    THEME: Thème
+    TOPLEVELCREATE: "Qui peut créer des pages à la racine de ce site ?"
+    VIEWHEADER: "Qui peut consulter les pages sur ce site?"
   SiteTree:
     ACCESSANYONE: "Tout le monde"
     ACCESSHEADER: "Qui peut voir cette page?"
@@ -183,6 +292,7 @@ fr:
     ACCESSONLYTHESE: "Seulement ces personnes (choisir à partir de la liste)"
     ADDEDTODRAFTHELP: "La page n’est pas encore publiée"
     ADDEDTODRAFTSHORT: Brouillon
+    ALLOWCOMMENTS: "Autoriser les commentaires sur cette page ?"
     APPEARSVIRTUALPAGES: "Ce contenu apparaît aussi dans les sections {title} des pages virtuelles."
     ARCHIVEDPAGESHORT: Archivé
     BUTTONCANCELDRAFT: "Annuler les changements brouillons"
@@ -198,7 +308,10 @@ fr:
     DEFAULTCONTACTTITLE: Contactez-nous
     DEFAULTHOMECONTENT: "<p>Bienvenue dans SilverStripe! Ceci est la page d'accueil par défaut. Vous pouvez éditer cette page en ouvrant <a href=\"admin/\">le CMS</a>.</p><p>Vous pouvez maintenant accéder à la <a href=\"http://docs.silverstripe.org\">documentation développeur</a>, ou commencer les <a href=\"http://www.silverstripe.org/learn/lessons\">leçons SilverStripe</a>.</p>"
     DEFAULTHOMETITLE: Accueil
+    DELETEDPAGEHELP: "La page n’est plus publique "
+    DELETEDPAGESHORT: Supprimée
     DEPENDENT_NOTE: "Les pages suivantes dépendent de cette page. Ceci inclut les pages virtuelles, les redirections et les pages avec des liens."
+    DESCRIPTION: "Contenu de page générique"
     DependtPageColumnLinkType: "Type de lien"
     DependtPageColumnURL: URL
     EDITANYONE: "Toute personne pouvant se connecter au CMS"
@@ -236,17 +349,22 @@ fr:
     PARENTTYPE_SUBPAGE: "Sous-page d'une page parente (choisir en-dessous) "
     PERMISSION_GRANTACCESS_DESCRIPTION: "Contrôler les groupes qui peuvent accéder ou éditer certaines pages"
     PERMISSION_GRANTACCESS_HELP: "Autoriser la gestion des restrictions d'accès d'une page dans la section \"Pages\""
+    PLURALNAME: Pages
     PageTypNotAllowedOnRoot: "Le type de page « {type} » n’est pas autorisé au niveau racine"
     PageTypeNotAllowed: "Le type de page « {type} » n'est pas autorisé comme enfant de cette page parent"
+    REMOVEDFROMDRAFTHELP: "La page est publiée, mais a été effacée des brouillons"
+    REMOVEDFROMDRAFTSHORT: "'%s' supprimé du site brouillon"
     REMOVE_INSTALL_WARNING: "Attention : Vous devriez supprimer install.php pour des raisons de sécurité."
     REORGANISE_DESCRIPTION: "Modifier la structure du site"
     REORGANISE_HELP: "Réorganiser les pages dans l'arborescence du site par glisser & déposer."
     SHOWINMENUS: "Afficher dans les menus ?"
     SHOWINSEARCH: "Afficher dans les recherches ?"
+    SINGULARNAME: Page
     TABBEHAVIOUR: Comportement
     TABCONTENT: "Contenu principal"
     TABDEPENDENT: "Pages dépendantes"
     TOPLEVEL: "Contenu du Site ( Premier Niveau )"
+    TOPLEVELCREATORGROUPS: "Créateurs de premier niveau."
     URLSegment: "Segment d'URL"
     VIEWERGROUPS: "Groupes de Visualisation"
     VIEW_ALL_DESCRIPTION: "Voir toute la page"
@@ -259,6 +377,9 @@ fr:
     many_many_BackLinkTracking: "Suivi des liens retour"
     many_many_ImageTracking: "Suivi des images"
     many_many_LinkTracking: "Suivi des Liens"
+  SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Cette liste affiche toutes les pages où le fichier a été ajouté via l'éditeur WYSIWYG."
+    EDIT: Éditer
   SiteTreeURLSegmentField:
     EMPTY: "Merci d'entrer une URL ou cliquez sur Annuler"
     HelpChars: "Les caractères spéciaux sont automatiquement convertis ou supprimés."
@@ -271,7 +392,9 @@ fr:
     HAVEASKED: "Vous avez demandé à voir le contenu de notre site le"
   VirtualPage:
     CHOOSE: "Page liée"
+    DESCRIPTION: "Affiche le contenu d’une autre page"
     EditLink: éditer
     HEADER: "Cette page est virtuelle"
     HEADERWITHLINK: "Ceci est une page virtuelle copiant le contenu de \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Le type de page d’origine « {type} » n’est pas autorisé au niveau racine pour cette page virtuelle"
+    SINGULARNAME: "Page virtuelle"

--- a/lang/gl_ES.yml
+++ b/lang/gl_ES.yml
@@ -1,4 +1,29 @@
 gl_ES:
+  AssetAdmin:
+    ADDFILES: "Engadir Ficheiros"
+    ActionAdd: "Engadir cartafol"
+    AppCategoryArchive: Arquivo
+    AppCategoryImage: Imaxe
+    BackToFolder: "Retornar ao cartafol"
+    CREATED: Data
+    CurrentFolderOnly: "Limitar ao cartafol actual?"
+    DetailsView: Detalles
+    FROMTHEINTERNET: "Dende a Internet"
+    FROMYOURCOMPUTER: "Dende o teu Computador"
+    Filetype: "Tipo ficheiro"
+    ListView: "Vista en Listado"
+    MENUTITLE: Ficheiros
+    SIZE: Tamaño
+    TreeView: "Vista en Árbore"
+    Upload: Subir
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Eliminar cartafoles"
+  AssetAdmin_Tools:
+    FILTER: Filtro
+  AssetAdmin_left_ss:
+    GO: Ir
+  BackLink_Button_ss:
+    Back: Atrás
   BrokenLinksReport:
     Any: Ningún
     BROKENLINKS: "Informe de ligazóns rotas"
@@ -23,29 +48,43 @@ gl_ES:
   CMSAddPageController:
     Title: "Engadir páxina"
   CMSBatchActions:
+    DELETE_DRAFT_PAGES: "Eliminar do sitio borrador"
+    DELETE_PAGES: "Eliminar do sitio publicado"
     PUBLISHED_PAGES: "%d páxinas publicadas, %d erros"
     PUBLISH_PAGES: Publicar
+  CMSFileAddController:
+    MENUTITLE: Ficheiros
   CMSMain:
     AddNew: "Engadir nova páxina"
     AddNewButton: "Engadir novo"
     ChoosePageParentMode: "Escoller donde crear esta páxina"
     ChoosePageType: "Escoller tipo de páxina"
     Create: Crear
+    DELETE: "Eliminar borrador"
+    DELETEFP: Eliminar
+    MENUTITLE: "Editar Páxina"
     PAGENOTEXISTS: "Esta páxina non existe"
     PAGETYPEANYOPT: Ningún
     PUBALLCONFIRM: "Por favor publica toda a páxina no sitio, copiando o contido a contorna de produción"
     PUBALLFUN: "Funcionalidade \"Publicar Todo\""
     REMOVEDPAGEFROMDRAFT: "Eliminado '%s'  do borrador do sitio"
     ROLLBACK: "Desfacer a esta versión"
+    SAVE: Gardar
     TabContent: Contido
     TabHistory: Historial
     TabSettings: Configuracións
+  CMSMain_left_ss:
+    RESET: Reiniciar
   CMSPageAddController:
+    MENUTITLE: "Engadir páxina"
     ParentMode_child: "Baixo outra páxina"
     ParentMode_top: "Nivel superior"
+  CMSPageEditController:
+    MENUTITLE: "Editar Páxina"
   CMSPageHistoryController:
     COMPAREMODE: "Modo comparación (seleccionar dúas)"
     COMPAREVERSIONS: "Comparar Versións"
+    MENUTITLE: Historial
     REVERTTOTHISVERSION: "Retornar a esta versión"
     SHOWUNPUBLISHED: "Amosar versións sen publicar"
     SHOWVERSION: "Amosar Versión"
@@ -55,12 +94,17 @@ gl_ES:
     PUBLISHER: Editor
     UNKNOWN: Descoñecido
     WHEN: Cando
+  CMSPageSettingsController:
+    MENUTITLE: "Editar Páxina"
   CMSPagesController:
+    GalleryView: "Vista en Galería"
     ListView: "Vista en Listado"
     MENUTITLE: Páxinas
     TreeView: "Vista en Árbore"
   CMSPagesController_Tools_ss:
     FILTER: Filtro
+  CMSSettingsController:
+    MENUTITLE: Configuracións
   CMSSiteTreeFilter_Search:
     Title: "Todas as páxinas"
   ContentControl:
@@ -80,30 +124,66 @@ gl_ES:
     DEFAULTERRORPAGETITLE: "Páxina non atopada"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Sintoo, houbo un problema coa xestión da túa petición.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Erro Servidor"
+  Folder:
+    AddFolderButton: "Engadir cartafol"
+    DELETEUNUSEDTHUMBNAILS: "Eliminar as miniaturas sen usar"
+    UNUSEDFILESTITLE: "Ficheiros sen usar"
+    UNUSEDTHUMBNAILSTITLE: "Miniaturas sen usar"
+    UploadFilesButton: Subir
+  LeftAndMain:
+    PreviewButton: Previsualizar
+    SearchResults: "Resultados Busca"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Acceso CMS"
   Permissions:
     CONTENT_CATEGORY: "Permisos do Contido"
     PERMISSIONS_CATEGORY: "Roles e permisos de acceso"
   RedirectorPage:
+    DESCRIPTION: "Redireccións a unha páxina interna diferente"
     HEADER: "Esta páxina redirixirá os usuarios a outra páxina"
     OTHERURL: "Outra URL do sitio web"
     REDIRECTTO: "Redirixir a"
     REDIRECTTOEXTERNAL: "Outro sitio web"
     REDIRECTTOPAGE: "Unha páxina no teu sitio web"
     YOURPAGE: "Páxina no teu sitio web"
+  ReportAdmin:
+    MENUTITLE: Informes
+  ReportAdminForm:
+    FILTERBY: "Filtrar por"
   SideReport:
     BROKENFILES: "Páxinas con ficheiros rotos"
+    BROKENLINKS: "Páxinas con ligazóns rotas"
     BROKENREDIRECTORPAGES: "RedirectorPages apuntando a páxinas eliminadas"
     BROKENVIRTUALPAGES: "VirtualPages apuntando a páxinas eliminadas"
     BrokenLinksGroupTitle: "Informes de ligazóns rotas"
     ContentGroupTitle: "Informes do Contido"
     EMPTYPAGES: "Páxinas sen contido"
     LAST2WEEKS: "Páxinas editadas nas 2 últimas semanas"
+    OtherGroupTitle: Outro
     ParameterLiveCheckbox: "Probar o sitio en vivo"
+  SilverStripeNavigatorLink:
+    ShareLink: "Ligazón compartir"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Pechar
+  SiteConfig:
+    DEFAULTTHEME: "(Usar tema por defecto)"
+    EDITHEADER: "Quen pode editar neste sitio?"
+    EDIT_PERMISSION: "Xestionar a configuración do sitio"
+    SITENAMEDEFAULT: "O nome do teu Sitio"
+    SITETAGLINE: "Eslogan do sitio"
+    SITETITLE: "Título do Sitio"
+    TABACCESS: Acceder
+    TABMAIN: Principal
+    TAGLINEDEFAULT: "o teu eslogan aquí"
+    THEME: Tema
+    TOPLEVELCREATE: "Quen pode crear as páxinas na raíz do sitio?"
+    VIEWHEADER: "Quen pode ver as páxinas neste sitio?"
   SiteTree:
     ACCESSANYONE: Ninguén
     ACCESSHEADER: "Quen pode ver esta páxina?"
     ACCESSLOGGEDIN: "Usuarios con sesión iniciada"
     ACCESSONLYTHESE: "Só esta xente (escoller da lista)"
+    ALLOWCOMMENTS: "Permitir comentario nesta páxina?"
     BUTTONCANCELDRAFT: "Cancelar cambios do borrador"
     BUTTONCANCELDRAFTDESC: "Eliminar o borrador e revertir a páxina publicada actualmente"
     BUTTONUNPUBLISH: "Sen publicar"
@@ -113,6 +193,8 @@ gl_ES:
     DEFAULTABOUTTITLE: "Sobre nós"
     DEFAULTCONTACTTITLE: Contactarnos
     DEFAULTHOMETITLE: Inicio
+    DELETEDPAGESHORT: Eliminado
+    DESCRIPTION: "Páxina de contido xenérico"
     DependtPageColumnLinkType: "Tipo de ligazón"
     EDITANYONE: "Ningún pode iniciar sesión no CMS"
     EDITHEADER: "Quen pode editar esta páxina?"
@@ -135,6 +217,7 @@ gl_ES:
     PARENTTYPE: "Localización da páxina"
     PARENTTYPE_ROOT: "Páxina nivel alto"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Xestionar dereitos de acceso para o contido"
+    REMOVEDFROMDRAFTSHORT: "Eliminado do borrador"
     REMOVE_INSTALL_WARNING: "Coidado: Deberías eliminar install.php da instalación deste Silverstripe por razóns de seguridade."
     REORGANISE_DESCRIPTION: "Cambiar a estrutura do sitio"
     REORGANISE_HELP: "Reorganizar as páxinas na árbore do sitio a través de arrastrar e soltar."
@@ -144,6 +227,7 @@ gl_ES:
     TABCONTENT: "Contido Principal"
     TABDEPENDENT: "Páxinas dependentes"
     TOPLEVEL: "Contido do Sitio (Nivel Superior)"
+    TOPLEVELCREATORGROUPS: "Creadores de nivel superior"
     URLSegment: "Segmento URL"
     VIEWERGROUPS: "Visor Grupos"
     VIEW_ALL_DESCRIPTION: "Ver calquera páxina"
@@ -156,4 +240,6 @@ gl_ES:
     CANACCESS: "Podes acceder ao sitio arquivado nesta ligazón:"
     HAVEASKED: "Solicitaches ver o contido do sitio sobre"
   VirtualPage:
+    DESCRIPTION: "Visualizar o contido doutra páxina"
     HEADER: "Esta é unha páxina virtual"
+    SINGULARNAME: "Páxina Virtual"

--- a/lang/he_IL.yml
+++ b/lang/he_IL.yml
@@ -1,7 +1,41 @@
 he_IL:
+  AssetAdmin:
+    ADDFILES: "הוספת קבצים"
+    ActionAdd: "הוספת תיקייה"
+    AppCategoryArchive: ארכיון
+    AppCategoryAudio: שמע
+    AppCategoryDocument: מסמך
+    AppCategoryFlash: פלאש
+    AppCategoryImage: תמונה
+    AppCategoryVideo: וידאו
+    BackToFolder: "חזרה לתיקייה"
+    CREATED: תאריך
+    CurrentFolderOnly: "האם להגביל לתיקייה הנוכחית"
+    DetailsView: פרטים
+    FILES: קבצים
+    FILESYSTEMSYNC: "סנכרון קבצים"
+    FILESYSTEMSYNCTITLE: "עדכון רשומות מסד הנתונים של ה־CMS במערכת הקבצים. שימושי כאשר הועלו קבצים חדשים מחוץ ל־CMS, לדוגמה באמצעות FTP."
+    FROMTHEINTERNET: מהאינטרנט
+    FROMYOURCOMPUTER: "מהמחשב שלך"
+    Filetype: "סוג הקובץ"
+    ListView: "תצוגת רשימה"
+    MENUTITLE: קבצים
+    NEWFOLDER: "תיקייה חדשה"
+    SIZE: גודל
+    THUMBSDELETED: "{count} תמונות ממוזערות שלא היו בשימוש נמחקו"
+    TreeView: "תצוגת עץ"
+    Upload: העלאה
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "למחוק תיקיות"
+  AssetAdmin_Tools:
+    FILTER: מסנן
+  AssetAdmin_left_ss:
+    GO: לעבור
   AssetTableField:
     BACKLINKCOUNT: "נעשה שימוש בתאריך:"
     PAGES: עמוד/ים
+  BackLink_Button_ss:
+    Back: חזרה
   BrokenLinksReport:
     Any: כלשהם
     BROKENLINKS: "דיווח על קישורים שבורים"
@@ -27,8 +61,14 @@ he_IL:
   CMSAddPageController:
     Title: "הוספת עמוד"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "נמחקו %d עמודים מאתר טיוטה, %d שגיאות"
+    DELETED_PAGES: "נמחקו %d עמודים מאתר שפורסם, %d שגיאות"
+    DELETE_DRAFT_PAGES: "מחיקה מאתר טיוטה"
+    DELETE_PAGES: "מחיקה מאתר שפורסם"
     PUBLISHED_PAGES: "פורסמו %d עמודים, %d שגיאות"
     PUBLISH_PAGES: פרסום
+  CMSFileAddController:
+    MENUTITLE: קבצים
   CMSMain:
     ACCESS: "גישה לאגף '{title}'"
     ACCESS_HELP: "מתן האפשרות לצפות באגף המכיל את עץ העמודים והתוכן. ניתן לצפות ולערוך הרשאות באמצעות תיבות בחירה ייעודיות לכל עמוד, כמו גם „הרשאות התוכן“ הנפרדות."
@@ -37,6 +77,11 @@ he_IL:
     ChoosePageParentMode: "נא לבחור היכן ליצור עמוד זה"
     ChoosePageType: "נא לבחור בסוג העמוד"
     Create: יצירה
+    DELETE: "מחיקה מאתר הטיוטה"
+    DELETEFP: מחיקה
+    DESCREMOVED: "ו־{count} צאצאים"
+    EditTree: "עריכת העץ"
+    MENUTITLE: "עריכת העמוד"
     NEWPAGE: "{pagetype} חדש"
     PAGENOTEXISTS: "עמוד זה אינו קיים במערכת"
     PAGETYPEANYOPT: כלשהם
@@ -48,15 +93,23 @@ he_IL:
     REMOVEDPAGEFROMDRAFT: "'$s' הוסר מאתר הטיוטה"
     RESTORED: "'{title}' שוחזר בהצלחה"
     ROLLBACK: "שחזור לגרסה זו"
+    SAVE: שמירה
     TabContent: תוכן
     TabHistory: היסטורייה
     TabSettings: הגדרות
+  CMSMain_left_ss:
+    RESET: איפוס
   CMSPageAddController:
+    MENUTITLE: "הוספת עמוד"
     ParentMode_child: "תחת עמוד אחר"
     ParentMode_top: "רמה עליונה"
+  CMSPageEditController:
+    MENUTITLE: "עריכת עמוד"
   CMSPageHistoryController:
     COMPAREMODE: "מצב השוואה (יש לבחור שניים)"
     COMPAREVERSIONS: "השוואת גרסאות"
+    COMPARINGVERSION: "השוואה בין הגרסאות {version1} ו־{version2}."
+    MENUTITLE: היסטוריה
     REVERTTOTHISVERSION: "חזרה לגרסה זו"
     SHOWUNPUBLISHED: "הצגת גרסאות שלא פוסרמו"
     SHOWVERSION: "הצגת הגרסה"
@@ -68,7 +121,10 @@ he_IL:
     PUBLISHER: "פורסם על ידי"
     UNKNOWN: "לא ידוע"
     WHEN: מתי
+  CMSPageSettingsController:
+    MENUTITLE: "עריכת העמוד"
   CMSPagesController:
+    GalleryView: "תצוגת גלריה"
     ListView: "תצוגת רשימה"
     MENUTITLE: עמודים
     TreeView: "תצוגת עץ"
@@ -76,7 +132,10 @@ he_IL:
     FILTER: מסנן
   CMSSearch:
     FILTERDATEFROM: מ־
+    FILTERDATEHEADING: תאריך
     FILTERDATETO: עד
+  CMSSettingsController:
+    MENUTITLE: הגדרות
   CMSSiteTreeFilter_Search:
     Title: "כל העמודים"
   ContentControl:
@@ -85,6 +144,7 @@ he_IL:
     ARCHIVEDSITE: "הצגה מקדימה של הגרסה"
     ARCHIVEDSITEFROM: "אתר ארכיון מהתאריך"
     DRAFTSITE: "אתר טיוטה"
+    DRAFT_SITE_ACCESS_RESTRICTION: "עליך להיכנס עם ססמת המערכת כדי לצפות בדף טיוטה או בתוכן שמור. <a href=\"%s\">לחזרה לאתר יש ללחוץ כאן</a>"
     Email: דוא״ל
     INSTALL_SUCCESS: "ההתקנה הצליחה!"
     InstallFilesDeleted: "קובצי ההתקנה נמחקו בהצלחה."
@@ -128,30 +188,76 @@ he_IL:
     DEFAULTERRORPAGETITLE: "הדף המבוקש לא נמצא"
     DEFAULTSERVERERRORPAGECONTENT: "<p>אירעה תקלה בעת הטיפול בבקשתך, עמך הסליחה.</p>"
     DEFAULTSERVERERRORPAGETITLE: "שגיאת שרת"
+    DESCRIPTION: "תוכן מותאם אישית למקרי שגיאות שונים (לדוגמה: „העמוד לא נמצא“)"
+    ERRORFILEPROBLEM: "שגיאה בפתיחת הקובץ „{filename}“ לכתיבה. נא לבדוק את הרשאות הקובץ."
+    SINGULARNAME: "עמוד שגיאה"
+  Folder:
+    AddFolderButton: "הוספת תיקייות"
+    DELETEUNUSEDTHUMBNAILS: "מחיקת תמונות ממוזערות שאינן בשימוש"
+    UNUSEDFILESTITLE: "מחיקת קבצים"
+    UNUSEDTHUMBNAILSTITLE: "תמונות ממוזערות שאינן בשימוש"
+    UploadFilesButton: העלאה
+  LeftAndMain:
+    DELETED: נמחק.
+    PreviewButton: "תצוגה מקדימה"
+    SAVEDUP: נשמר.
+    SearchResults: "תוצאות החיפוש"
+  Permission:
+    CMS_ACCESS_CATEGORY: "גישה ל־CMS"
   Permissions:
     CONTENT_CATEGORY: "הרשאות התוכן"
     PERMISSIONS_CATEGORY: "תפקידים והרשאות גישה"
   RedirectorPage:
+    DESCRIPTION: "הפניות לעמוד פנימי אחר"
     HASBEENSETUP: "נוצר דף הפניה ללא יעד"
     HEADER: "העמוד הזה יוביל משתמשים לעמוד אחר"
     OTHERURL: "כתובת של אתר אחר"
     REDIRECTTO: "העברה אל"
     REDIRECTTOEXTERNAL: "אתר אחר"
     REDIRECTTOPAGE: "עמוד באתר שלך"
+    SINGULARNAME: "עמוד הפנייה"
     YOURPAGE: "עמוד באתר שלך"
+  ReportAdmin:
+    MENUTITLE: דוחות
+    ReportTitle: כותרת
+  ReportAdminForm:
+    FILTERBY: "סינון לפי"
   SearchForm:
     GO: לעבור
     SEARCH: חיפוש
     SearchResults: "תוצאות החיפוש"
   SideReport:
     BROKENFILES: "עמודים עם קבצים שבורים"
+    BROKENLINKS: "עמודים עם קישורים שבורים"
     BROKENREDIRECTORPAGES: "עמודי הפנייה שמצביעים לעמודים שנמחקו"
     BROKENVIRTUALPAGES: "עמודים וירטואליים שמצביעים לעמודים שנמחקו"
     BrokenLinksGroupTitle: "דוחות קישורים שבורים"
     ContentGroupTitle: "דוחות תוכן"
     EMPTYPAGES: "עמודים ריקים"
     LAST2WEEKS: "עמודים שנערכו בשבועיים האחרונים"
+    OtherGroupTitle: אחר
     ParameterLiveCheckbox: "בדיקת האתר החי"
+    REPEMPTY: "הדוח {title} ריק."
+  SilverStripeNavigatorLink:
+    ShareLink: "שיתוף הקישור"
+  SilverStripeNavigatorLinkl:
+    CloseLink: סגירה
+  SiteConfig:
+    DEFAULTTHEME: "(שימוש בערכת העיצוב מבררת המחדל)"
+    EDITHEADER: "מי יכול לערוך עמודים באתר זה?"
+    EDIT_PERMISSION: "ניהול תצורת האתר"
+    EDIT_PERMISSION_HELP: "היכולת לערוך הגדרות גישה גלובליות/הרשאות עמודי על."
+    PLURALNAME: "תצורות האתר"
+    SINGULARNAME: "תצורת האתר"
+    SITENAMEDEFAULT: "שם האתר שלך"
+    SITETAGLINE: "שורת מחץ/סלוגן"
+    SITETITLE: "כותרת האתר"
+    TABACCESS: גישה
+    TABMAIN: ראשי
+    TAGLINEDEFAULT: "שורת התיוג שלך כאן"
+    THEME: "ערכת עיצוב"
+    TOPLEVELCREATE: "מי יכול ליצור עמודים בראש האתר?"
+    VIEWHEADER: "מי יכול לצפות בעמודים באתר זה?"
   SiteTree:
     ACCESSANYONE: "כל אחד"
     ACCESSHEADER: "מי יכול לצפות בעמוד זה?"
@@ -159,6 +265,7 @@ he_IL:
     ACCESSONLYTHESE: "רק האנשים האלה (יש לבחור מהרשימה)"
     ADDEDTODRAFTHELP: "העמוד לא פורסם עדיין"
     ADDEDTODRAFTSHORT: טיוטה
+    ALLOWCOMMENTS: "האם מותר להוסיף תגובות לעמוד זה"
     APPEARSVIRTUALPAGES: "תוכן זה מופיע גם בעמודים הווירטואליים באגפים של {title}."
     BUTTONCANCELDRAFT: "ביטול שינויי הטיוטה"
     BUTTONCANCELDRAFTDESC: "למחוק את הטיוטה שלך ולהחזיר לעמוד הנוכחי שפורסם"
@@ -169,7 +276,10 @@ he_IL:
     DEFAULTABOUTTITLE: "על אודותינו"
     DEFAULTCONTACTTITLE: "יצירת קשר"
     DEFAULTHOMETITLE: "דף הבית"
+    DELETEDPAGEHELP: "העמוד אינו מפורסם עוד"
+    DELETEDPAGESHORT: נמחק
     DEPENDENT_NOTE: "העמודים הבאים תלויים בעמוד זה. בין אלו נכללים, עמודים וירטואליים, עמודי הפנייה ועמודים עם קישורי תוכן."
+    DESCRIPTION: "דף תוכן גנרי"
     DependtPageColumnLinkType: "סוג הקישור"
     DependtPageColumnURL: קישור
     EDITANYONE: "כל מי שיכול להיכנס ל־CMS"
@@ -201,17 +311,22 @@ he_IL:
     PARENTTYPE_SUBPAGE: "תת־עמוד תחת עמוד הורה"
     PERMISSION_GRANTACCESS_DESCRIPTION: "ניהול הרשאות גישה לתוכן"
     PERMISSION_GRANTACCESS_HELP: "מתן האפשרות להגדיר הגבלות ייעודיות לעמוד תחת האגף „עמודים“."
+    PLURALNAME: עמודים
     PageTypNotAllowedOnRoot: "סוג העמוד „{type}“ אינו מורשה ברמת העל"
     PageTypeNotAllowed: "סוג העמוד „{type}“ אינו מורשה כצאצא של עמוד הורה זה"
+    REMOVEDFROMDRAFTHELP: "העמוד לא פורסם, אך נמחק מהטיוטות"
+    REMOVEDFROMDRAFTSHORT: "הוסר מהטיוטות"
     REMOVE_INSTALL_WARNING: "אזהרה: עליך להסיר את install.php מהתקנת SilverStripe זו מטעמי אבטחה."
     REORGANISE_DESCRIPTION: "שינוי מבנה האתר"
     REORGANISE_HELP: "ניתן לסדר מחדש את העמודים בעץ האתר באמצעות גרירה והשלכה."
     SHOWINMENUS: "להציג בתפריטים?"
     SHOWINSEARCH: "לכלול בחיפוש?"
+    SINGULARNAME: עמוד
     TABBEHAVIOUR: התנהגות
     TABCONTENT: "תוכן ראשי"
     TABDEPENDENT: "עמודים תלויים"
     TOPLEVEL: "תוכן האתר (רמה עליונה)"
+    TOPLEVELCREATORGROUPS: "יוצרים ברמת על"
     URLSegment: "מקטע כתובת"
     VIEWERGROUPS: "קבוצות צופים"
     VIEW_ALL_DESCRIPTION: "צפייה בכל עמוד שהוא"
@@ -229,5 +344,7 @@ he_IL:
     CANACCESS: "ניתן להיכנס לארכיון האתר בקישור הזה:"
     HAVEASKED: "ביקשת לצפות בתוכן האתר שלנו תחת"
   VirtualPage:
+    DESCRIPTION: "הצגת תוכן של עמוד אחר"
     HEADER: "זהו עמוד וירטואלי"
     PageTypNotAllowedOnRoot: "סוג העמוד המקורי „{type}“ אינו מורשה ברמת העל של עמוד וירטואלי זה"
+    SINGULARNAME: "דף וירטואלי"

--- a/lang/hr.yml
+++ b/lang/hr.yml
@@ -1,10 +1,44 @@
 hr:
   AssetAdmin:
+    ADDFILES: "Dodaj datoteke"
+    ActionAdd: "Dodaj direktorij"
+    AppCategoryArchive: Arhiva
+    AppCategoryAudio: Zvuk
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Slika
+    AppCategoryVideo: Video
+    BackToFolder: "Povratak na direktorij"
+    CMSMENU_OLD: "Datoteke (stare)"
+    CREATED: Datum
+    CurrentFolderOnly: "Ograničiti na trenutni direktorij?"
+    DetailsView: Detalji
     ErrorItemPermissionDenied: "Izgleda kako nemate potrebna prava za dodati {ObjectTitle} na kampanju"
     ErrorNotFound: "{Type} nije pronađen"
+    FILES: Datoteke
+    FILESYSTEMSYNC: "Sinkroniziraj datoteke"
+    FILESYSTEMSYNCTITLE: "Ažurirajte CMS bazu podataka datoteka na sustavu datoteka. Korisno kada su nove datoteke prenesene izvan CMS, npr putem FTP-a."
+    FROMTHEINTERNET: "Sa interneta"
+    FROMYOURCOMPUTER: "Sa računala"
+    Filetype: "Tip datoteke"
+    ListView: "Prikaz popisa"
+    MENUTITLE: Datoteke
+    NEWFOLDER: "Novi direktorij"
+    SIZE: Veličina
+    THUMBSDELETED: "{count} neiskorištenih sličica su izbrisane"
+    TreeView: "Prikaz kao stablo"
+    Upload: Prenesi
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Obriši direktorije"
+  AssetAdmin_Tools:
+    FILTER: Filter
+  AssetAdmin_left_ss:
+    GO: Kreni
   AssetTableField:
     BACKLINKCOUNT: "Korišteno na:"
     PAGES: stranica(e)
+  BackLink_Button_ss:
+    Back: Nazad
   BrokenLinksReport:
     Any: "bilo koji"
     BROKENLINKS: "Izvješće prekinutih linkova"
@@ -33,12 +67,18 @@ hr:
     RESULT: "Obrisano %d stranica u statusu nacrt i objavljeno, i poslani u arhivu"
     TITLE: "Odjavi i arhiviraj"
   CMSBatchActions:
+    ARCHIVE: Arhiviraj
+    ARCHIVED_PAGES: "Arhivirano '%d' stranica"
+    DELETED_DRAFT_PAGES: "Obrisano %d stranica s nacrtne stranice, %d neuspješno"
+    DELETED_PAGES: "Obrisano %d stranica s objavljene stranice, %d neuspješno"
+    DELETE_DRAFT_PAGES: "Izbriši stranicu sa objavljene"
+    DELETE_PAGES: "Izbriši stranicu sa objavljene"
     PUBLISHED_PAGES: "Objavljeno %d stranica, %d neuspješno"
     PUBLISH_PAGES: Objavi
     RESTORE: Povrati
     RESTORED_PAGES: "Vraćeno '%d' stranica"
-    UNPUBLISHED_PAGES: "Neobjavljene %d stranice"
-    UNPUBLISH_PAGES: Odjavi
+  CMSFileAddController:
+    MENUTITLE: Datoteke
   CMSMain:
     ACCESS: "Pristup '{title}' sekciji"
     ACCESS_HELP: "Dozvoli pregledavati sekcije sadržanog stabla i sadržaja strancie. Dozvole za pregled i uređivanje mogu se mijenjati putem stranicama specifičnim padajućim izbornicima kao i posebnim \"Sadržajnim dozvolama\"."
@@ -51,24 +91,25 @@ hr:
     ChoosePageParentMode: "Odaberite gdje želite kreirati ovu stranicu"
     ChoosePageType: "Odaberi vrstu stranice"
     Create: Kreiraj
+    DELETE: "Obriši nacrt"
+    DELETEFP: Obriši
+    DESCREMOVED: "i {count} potomaka"
     DUPLICATED: "Dupliciran '{title}' uspješno"
     DUPLICATEDWITHCHILDREN: "Dupliciran '{title}'  i podstranice uspješno"
     EMAIL: Email
-    ListFiltered: "Prikazujem rezultate pretraživanja."
+    EditTree: "Uredi stablo stranice"
+    MENUTITLE: "Uredi stranicu"
     NEWPAGE: "Novi {pagetype}"
     PAGENOTEXISTS: "Stranica ne postoji"
-    PAGES: "Status stranice"
     PAGETYPEANYOPT: "Bilo koji"
-    PAGETYPEOPT: "Tip stranice"
     PUBALLCONFIRM: "Molim objavi svaku stranicu, kopirajući sadržaj"
     PUBALLFUN: "\"Objavi sve\""
-    PUBALLFUN2: "Pritiskom na ovaj gumb će učiniti isto kao i ide na svakoj stranici i pritiskom na \"objavi\". Namijenjen da se koristi nakon što je došlo do masivne promjene u sadržaju, kao kada je prvi put napravljena."
     PUBLISHED: "Uspješno objavljen '{title}'"
     PUBPAGES: "Gotovo: Objavljeno {count} stranica"
     PageAdded: "Uspješno kreirane stranice"
+    REMOVED: "Obrisan '{title}'{description} sa objavljene stranice"
     REMOVEDPAGE: "Uklonjen '{title}' sa objavljene stranice"
     REMOVEDPAGEFROMDRAFT: "Uklonjen '%s' sa nacrtne stranice"
-    RESTORE: "Povrati nacrt"
     RESTORED: "Vraćeno '{title}' uspješno"
     RESTORE_DESC: "Vrati arhiviranu verziju u nacrt"
     RESTORE_TO_ROOT: "Povrati nacrt na najviši nivo"
@@ -76,23 +117,27 @@ hr:
     ROLLBACK: "Vrati na ovu verziju"
     ROLLEDBACKPUBv2: "Vraćeno na objavljenu verziju"
     ROLLEDBACKVERSIONv2: "Vraćeno na verziju #%d."
+    SAVE: Spremi
     SAVED: "Uspješno spremljen '{title}'"
     SAVEDRAFT: "Spremiti nacrt"
     TabContent: Sadržaj
     TabHistory: Povijest
     TabSettings: Postavke
-    TreeFiltered: "Prikazujem rezultate pretraživanja."
-    TreeFilteredClear: Očisti
     UNPUBLISH_AND_ARCHIVE: "Odjavi i arhiviraj"
   CMSMain_left_ss:
-    APPLY_FILTER: Traži
     CLEAR_FILTER: Očisti
+    RESET: Resetiraj
   CMSPageAddController:
+    MENUTITLE: "Dodaj stranicu"
     ParentMode_child: "Ispod druge stranice"
     ParentMode_top: "Najviši nivo"
+  CMSPageEditController:
+    MENUTITLE: "Uredi stranicu"
   CMSPageHistoryController:
     COMPAREMODE: "Način usporedbe (odaberi dva)"
     COMPAREVERSIONS: "Usporedi verzije"
+    COMPARINGVERSION: "Uspoređujem verzije {version1} i {version2}."
+    MENUTITLE: Povijest
     REVERTTOTHISVERSION: "Vrati na ovu verziju"
     SHOWUNPUBLISHED: "Prikaži neobjavljene verzije"
     SHOWVERSION: "Prikaži verzije"
@@ -106,31 +151,26 @@ hr:
     PUBLISHER: Izdavač
     UNKNOWN: Nepoznato
     WHEN: Kada
+  CMSPageSettingsController:
+    MENUTITLE: "Uredi stranicu"
   CMSPagesController:
+    GalleryView: "Pregled kao galerija"
     ListView: "Pregled kao popis"
     MENUTITLE: Stranice
     TreeView: "Prikaz kao stablo"
-  CMSPagesController_ContentToolbar_ss:
-    MULTISELECT: "Grupne radnje"
   CMSPagesController_Tools_ss:
     FILTER: Filter
   CMSSIteTreeFilter_PublishedPages:
     Title: "Objavljene stranice"
   CMSSearch:
     FILTERDATEFROM: Od
+    FILTERDATEHEADING: Datum
     FILTERDATETO: Do
-    FILTERLABELTEXT: Traži
     PAGEFILTERDATEHEADING: "Zadnje uređeno"
-  CMSSiteTreeFilter_ChangedPages:
-    Title: "Izmjenjene stranice"
-  CMSSiteTreeFilter_DeletedPages:
-    Title: "Sve stranice, uključujući arhivirane"
+  CMSSettingsController:
+    MENUTITLE: Postavke
   CMSSiteTreeFilter_Search:
     Title: "Sve stranice"
-  CMSSiteTreeFilter_StatusDeletedPages:
-    Title: "Arhivirane stranice"
-  CMSSiteTreeFilter_StatusDraftPages:
-    Title: "Nacrtne stranice"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
     Title: "Objavljeno ali uklonito iz predloška"
   ContentControl:
@@ -141,6 +181,7 @@ hr:
     CMS: CMS
     DRAFT: Predložak
     DRAFTSITE: Predložak
+    DRAFT_SITE_ACCESS_RESTRICTION: "Mora biti prijavljeni u CMS da bi ste vidjeli neobjavljeni ili ahivirani sadržaj. <a href=\"%s\">Kliknite ovdje za povratak na objavljenu stranicu.</a>"
     Email: Email
     INSTALL_SUCCESS: "Instalacija uspješna!"
     InstallFilesDeleted: "Instalacijske datoteke su uspješno obrisane."
@@ -175,29 +216,45 @@ hr:
     415: "415 - nepodržan multimedijalni tip"
     416: "416 - opseg zahtjeva nije zadovoljavajući"
     417: "417 - očekivanje nije uspjelo"
-    422: "422 - ne mogu obraditi entitet"
-    429: "429 - previše zahtjeva"
     500: "500 - interna serverska greška"
     501: "501 - nije implementirano"
-    502: "502 - Loš pristupnik"
-    503: "503 - servis nedostupan"
-    504: "504 - Pristupnik pauziran"
-    505: "505 - HTTP verzija nije podržana"
     CODE: "Kod pogreške"
     DEFAULTERRORPAGECONTENT: "<p>Nažalost, čini se kako pokušavate pristupiti stranici koja ne postoji.</p><p>Molimo provjerite jeste li upisali točan URL i pokušajte ponovo.</p>"
     DEFAULTERRORPAGETITLE: "Stranica nije pronađena"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Nažalost, dogodio se problem prilikom rukovanja vašim zahtjevom.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Serverska greška"
+    DESCRIPTION: "Prilagođeni sadržaj za različite slučajeve grešaka (npr. \"Stranica nije pronađena\")"
+    ERRORFILEPROBLEM: "Greška otvaranja datoteke \"{filename}\" za pisanje. Molimo provjerite prava datoteke."
+    PLURALNAME: "Stranice greške"
+    SINGULARNAME: "Stranica greške"
+  File:
+    Title: Naslov
+  Folder:
+    AddFolderButton: "Dodaj direktorij"
+    DELETEUNUSEDTHUMBNAILS: "Obriši nekorištene sličice"
+    UNUSEDFILESTITLE: "Nekorištene datoteke"
+    UNUSEDTHUMBNAILSTITLE: "Nekorištene sličice"
+    UploadFilesButton: Prenesi
+  LeftAndMain:
+    DELETED: Obrisano.
+    PreviewButton: Pregled
+    SAVEDUP: Spremljeno
+    SearchResults: "Rezultati pretraživanja"
+  Permission:
+    CMS_ACCESS_CATEGORY: "CMS pristup"
   Permissions:
     CONTENT_CATEGORY: "Sadržajne dozvole"
     PERMISSIONS_CATEGORY: "Uloge i prava pristupa"
   RedirectorPage:
+    DESCRIPTION: "Preusmjerava na drugu internu stranicu"
     HASBEENSETUP: "Stranica za preusjeravanje nema postavljenog preusmjeravanja"
     HEADER: "Ova stranica preusmjeriti će korisnike na drugu stranicu"
     OTHERURL: "URL drugog weba"
+    PLURALNAME: "Preusmjeravajuće stranice"
     REDIRECTTO: "Preusmjeri na"
     REDIRECTTOEXTERNAL: "Drugi web"
     REDIRECTTOPAGE: "Stranicu na Vašom webu"
+    SINGULARNAME: "Preusmjeravajuća stranica"
     YOURPAGE: "Stranica na Vašem webu"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Pokreni
@@ -209,25 +266,33 @@ hr:
     OPERATION_REMOVE: "Ukloni označeno sa svih stanja (UPOZORENJE: to će uništiti sve označene stranice s nacrta i objavljeno)"
     SELECTALL: "označi sve"
     UNSELECTALL: "odznači sve"
-  SITETREE:
-    VIRTUALPAGEDRAFTWARNING: "Molimo objavite povezanu stranicu kako bi objavili virtualnu stranicu"
-    VIRTUALPAGEWARNING: "Molimo odaberite povezanu stranicu i spremite kako bi objavili ovu stranicu"
-    VIRTUALPAGEWARNINGSETTINGS: "Molimo odaberite povezanu stranicu u glavnom sadržajnom polju kako bi ste je objavili"
+  ReportAdmin:
+    MENUTITLE: Izvještaji
+    ReportTitle: Naslov
+  ReportAdminForm:
+    FILTERBY: "Filtriraj po"
   SearchForm:
     GO: Kreni
     SEARCH: Traži
     SearchResults: "Rezultati pretraživanja"
   SideReport:
     BROKENFILES: "Stranice s neispravnim datotekama"
+    BROKENLINKS: "Stranice s neispravnim linkovima"
     BROKENREDIRECTORPAGES: "Preusmjeravanje pokazuje na obrisane stranice"
     BROKENVIRTUALPAGES: "Virtualne stranice pokazuje na obrisane stranice"
     BrokenLinksGroupTitle: "Izvješće prekinutih linkova"
     ContentGroupTitle: "Sadržajni izvještaji"
     EMPTYPAGES: "Stranice bez sadržaja"
     LAST2WEEKS: "Stranice mijenjane u zadnja 2 tjedna"
+    OtherGroupTitle: Ostali
     ParameterLiveCheckbox: "Pregledaj objavljenu stranicu"
+    REPEMPTY: "{title} izvještaj je prazan."
   SilverStripeNavigator:
     ARCHIVED: Arhivirano
+  SilverStripeNavigatorLink:
+    ShareLink: "Podijeli link"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Zatvori
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Dodaj stranicu"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -248,12 +313,28 @@ hr:
     SINGULARNAME: "Preusmjeravajuća stranica"
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: "Obična sadržajna stranica"
-    PLURALNAME: Stranice
-    SINGULARNAME: Stranica
+    PLURALNAME: "Stabla stranice"
+    SINGULARNAME: "Stablo stranice"
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: "Prikazuje sadržaj druge stranice"
     PLURALNAME: "Virtualne stranice"
     SINGULARNAME: "Virtualna stranica"
+  SiteConfig:
+    DEFAULTTHEME: "(koristi predloženu temu)"
+    EDITHEADER: "Tko može uređivati stranice na ovom webu?"
+    EDIT_PERMISSION: "Upravljaj konfiguracijom weba"
+    EDIT_PERMISSION_HELP: "Mogućnost uređivanja globalnog pristupa postavki/top-nivo stranica dozvola."
+    PLURALNAME: "Konfiguracije weba"
+    SINGULARNAME: "Konfiguracija weba"
+    SITENAMEDEFAULT: "Naziv vašeg weba"
+    SITETAGLINE: "Slogan weba"
+    SITETITLE: "Naziv weba"
+    TABACCESS: Pristup
+    TABMAIN: Osnovno
+    TAGLINEDEFAULT: "vaš slogan ovdje"
+    THEME: Tema
+    TOPLEVELCREATE: "Tko može kreirati stranice u rootu?"
+    VIEWHEADER: "Tko može pregledavati stranice?"
   SiteTree:
     ACCESSANYONE: Svi
     ACCESSHEADER: "Tko može pregledavati ovu stranicu?"
@@ -261,9 +342,11 @@ hr:
     ACCESSONLYTHESE: "Samo ovi korisnici (odaberite s popisa)"
     ADDEDTODRAFTHELP: "Stranica nije objavljena"
     ADDEDTODRAFTSHORT: Predložak
+    ALLOWCOMMENTS: "Dozvoli komentare na stranici"
     APPEARSVIRTUALPAGES: "Ovaj sadržaj se pojavljuje na virtualnim stranicama u {title} sekcijama."
     ARCHIVEDPAGEHELP: "Stranica je uklonjena iz neobjavljenog i objavljenog stanja"
     ARCHIVEDPAGESHORT: Arhivirano
+    BUTTONARCHIVEDESC: "Odjavi i pošalji u arhivu"
     BUTTONCANCELDRAFT: "Otkaži promjene na radnoj verziji"
     BUTTONCANCELDRAFTDESC: "Obriši radnu verziju i vrati na trenutno objavljenu verziju stranice"
     BUTTONDELETEDESC: "Ukloni iz nacrta/objavljeno i pošalji u arhivu"
@@ -274,23 +357,19 @@ hr:
     BUTTONUNPUBLISHDESC: "Izbrišite ovu stranicu sa objavljene"
     Comments: Komentari
     Content: Sadržaj
-    DEFAULTABOUTCONTENT: "<p>Možete popuniti ovu stranicu s Vašim sadržajem, ili obrisati je i kreirati novu stranicu.</p>"
     DEFAULTABOUTTITLE: "O nama"
-    DEFAULTCONTACTCONTENT: "<p>Možete popuniti ovu stranicu s Vašim sadržajem, ili obrisati je i kreirati novu stranicu.</p>"
     DEFAULTCONTACTTITLE: Kontakt
     DEFAULTHOMECONTENT: "<p>Dobrodošli na SilverStripe! Ovo je zadana početna stranica. Možete je urediti otvarajući <a href=\"admin/\"> CMS</a>.</p><p>Možete pristupiti  <a href=\"http://docs.silverstripe.org\">razvojnoj dokumentaciji</a>, ili početi <a href=\"http://www.silverstripe.org/learn/lessons\">SilverStripe lekcije</a>.</p>"
     DEFAULTHOMETITLE: Početna
-    DEPENDENT_NOTE: "Sljedeće stranice zavise o ovoj stranici. To uključuje virtualne stranice, preusmjeravajuće stranice i stranice s sadržajnim linkovima."
+    DELETEDPAGEHELP: "Stranica više nije objavljena"
+    DELETEDPAGESHORT: Obrisano
+    DESCRIPTION: "Obična sadržajna stranica"
     DependtPageColumnLinkType: "Tip linka"
     DependtPageColumnURL: Link
     EDITANYONE: "Svi koji se mogu prijaviti  u CMS"
     EDITHEADER: "Tko može uređivati unutar CMSa?"
     EDITONLYTHESE: "Samo slijedeći korisnici (odaberite s popisa)"
-    EDITORGROUPS: "Urednička grupa"
     EDIT_ALL_DESCRIPTION: "Uredi bilo koju stranicu"
-    EDIT_ALL_HELP: "Mogućnost uređivanja bilo koje stranice, neovisno o postavkama na Pristup tabu. Zahtjeva \"Pristup na 'Stranice' sekciju\" dozvolu"
-    Editors: "Uredničke grupe"
-    GroupPlaceholder: "Klikni da obabereš grupu"
     HASBROKENLINKS: "Ova stranica ima pogrešne linkove"
     HTMLEDITORTITLE: Sadržaj
     INHERIT: "Naslijedi od matične stranice"
@@ -318,15 +397,20 @@ hr:
     PARENTTYPE_ROOT: Nadstranica
     PARENTTYPE_SUBPAGE: "Podstranica ispod matične stranice"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Upravljaj prava pristupa za sadržaj"
+    PLURALNAME: Stranice
+    REMOVEDFROMDRAFTHELP: "Stranica je objavljena, ali je obrisana s nacrta"
+    REMOVEDFROMDRAFTSHORT: "Uklonjen sa predložaka"
     REMOVE_INSTALL_WARNING: "Upozorenje: trebali bi ste ukloniti install.php sa ove SilverStripe instalacije zbog sigurnosnih razloga."
     REORGANISE_DESCRIPTION: "Promjeni strukturu stranice"
     REORGANISE_HELP: "Premjesti stranice u stablu stranice sa povuci i spusti metodom."
     SHOWINMENUS: "Pokaži u izbornicima?"
     SHOWINSEARCH: "Pokaži u tražilici?"
+    SINGULARNAME: Stranica
     TABBEHAVIOUR: Karakteristike
     TABCONTENT: Sadržaj
     TABDEPENDENT: "Zavisne stranice"
     TOPLEVEL: "Sadržaj stranice (Top Level)"
+    TOPLEVELCREATORGROUPS: "Kreatori najviši nivo"
     URLSegment: "Dio URLa"
     VIEWERGROUPS: "Grupe preglednika"
     VIEW_ALL_DESCRIPTION: "Pregled bilo koje stranice"
@@ -339,6 +423,8 @@ hr:
     many_many_ImageTracking: "Praćenje slika"
     many_many_LinkTracking: "Praćenje linkova"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Ova lista pokazuje sve stranice gdje je datoteka dodana kroz WYSIWYG editor."
+    EDIT: Uredi
     TITLE_INDEX: "#"
     TITLE_TYPE: Tip
     TITLE_USED_ON: "Korišteno na"
@@ -354,7 +440,10 @@ hr:
     HAVEASKED: "Zatražili ste sadržaj naše stranice "
   VirtualPage:
     CHOOSE: "Povezane stranice"
+    DESCRIPTION: "Prikazuje sadržaj druge stranice"
     EditLink: uredi
     HEADER: "Ovo je virtualna stranica"
     HEADERWITHLINK: "Ova virtualna stranica kopira sadržaj sa  \"{title}\" ({link})"
+    PLURALNAME: "Virtualne stranice"
     PageTypNotAllowedOnRoot: "Originalni tip stranice  \"{type}\" nije dozvoljen na prvom nivu ove virtualne stranice"
+    SINGULARNAME: "Virtualna stranica"

--- a/lang/hu.yml
+++ b/lang/hu.yml
@@ -1,7 +1,37 @@
 hu:
+  AssetAdmin:
+    ADDFILES: "Állomány hozzáadása"
+    ActionAdd: "Mappa hozzáadása"
+    AppCategoryArchive: Archív
+    AppCategoryAudio: Audió
+    AppCategoryDocument: Dokumentum
+    AppCategoryImage: Kép
+    AppCategoryVideo: Videó
+    BackToFolder: "Vissza a mappába"
+    CREATED: Dátum
+    CurrentFolderOnly: "Csak mappán belül?"
+    DetailsView: Részletek
+    FILES: Állományok
+    FROMTHEINTERNET: Internetről
+    FROMYOURCOMPUTER: Számítógépéről
+    Filetype: "Állomány típusa"
+    ListView: "Lista nézet"
+    MENUTITLE: Állományok
+    NEWFOLDER: "Új mappa"
+    SIZE: Méret
+    TreeView: "\"Fa\" nézet"
+    Upload: Feltöltés
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Mappák törlése"
+  AssetAdmin_Tools:
+    FILTER: Szűrő
+  AssetAdmin_left_ss:
+    GO: Mehet
   AssetTableField:
     BACKLINKCOUNT: "Felhasználva:"
     PAGES: oldal(ak)
+  BackLink_Button_ss:
+    Back: Vissza
   BrokenLinksReport:
     Any: Bármely
     BROKENLINKS: "Hibás linkek listája"
@@ -26,8 +56,13 @@ hu:
   CMSAddPageController:
     Title: "Oldal hozzáadása"
   CMSBatchActions:
+    DELETED_PAGES: "%d oldal törölve a publikáltak közül, %d hibás"
+    DELETE_DRAFT_PAGES: "Törlés a vázlatokból"
+    DELETE_PAGES: "Törlés a publikált oldalakból"
     PUBLISHED_PAGES: "%d oldal publikálva, %d hibás"
     PUBLISH_PAGES: Publikálni
+  CMSFileAddController:
+    MENUTITLE: Állományok
   CMSMain:
     AddNew: "Új oldal hozzáadása"
     AddNewButton: "Új hozzáadása"
@@ -35,8 +70,13 @@ hu:
     ChoosePageParentMode: "Adja meg az oldal létrehozásának helyét"
     ChoosePageType: "Válassza ki az oldal típusát"
     Create: Létrehozni
+    DELETE: "Vázlat törlése"
+    DELETEFP: Törlés
+    DESCREMOVED: "és {count} gyerek"
     DUPLICATED: "'{title}' sikeresen duplikálva"
     DUPLICATEDWITHCHILDREN: "'{title}' és oldalai sikeresen duplikálva"
+    EditTree: "Menüszerkeszet módosítása"
+    MENUTITLE: "Oldal szerkesztése"
     NEWPAGE: "Új {pagetype}"
     PAGENOTEXISTS: "Ez az oldal nem létezik."
     PAGETYPEANYOPT: Egyéb
@@ -44,22 +84,29 @@ hu:
     PUBALLFUN: "\"Összes publikálása\" funkció"
     PUBPAGES: "{count} oldalt publikált"
     PageAdded: "Oldal sikeresen létrehozva"
+    REMOVED: "'{title}{description}' törölve az éles oldalról"
     REMOVEDPAGE: "'{title}' törölve a publikált oldalról"
     REMOVEDPAGEFROMDRAFT: "'%s' törlése a piszkozatoldalról"
     RESTORED: "'{title}' sikeresen helyreállítva"
     ROLLBACK: "Visszaállítás ehhez a verzióhoz"
     ROLLEDBACKPUBv2: "Visszatérés a publikált verzióhoz."
     ROLLEDBACKVERSIONv2: "#%d verzió beállítva."
+    SAVE: Mentés
     SAVEDRAFT: "Piszkozat mentése"
     TabContent: Tartalom
     TabHistory: Történet
     TabSettings: Beállítások
   CMSPageAddController:
+    MENUTITLE: "Oldal hozzáadása"
     ParentMode_child: "Másik oldal alatt"
     ParentMode_top: "Felső szint"
+  CMSPageEditController:
+    MENUTITLE: "Oldal szerkesztése"
   CMSPageHistoryController:
     COMPAREMODE: "Összehasonlítás (select two)"
     COMPAREVERSIONS: "Verziók összehasonlítása"
+    COMPARINGVERSION: "{version1} és {version2} verziók összehaonlítása. "
+    MENUTITLE: Történet
     REVERTTOTHISVERSION: "Visszatérés erre a verzióra"
     SHOWUNPUBLISHED: "Publikálatlan verziók megjelenítése"
     SHOWVERSION: "Verzió megtekintése"
@@ -72,7 +119,10 @@ hu:
     PUBLISHER: Szerző
     UNKNOWN: Ismeretlen
     WHEN: Mikor
+  CMSPageSettingsController:
+    MENUTITLE: "Oldal szerkesztése"
   CMSPagesController:
+    GalleryView: "Galéria nézet"
     ListView: "Lista nézet"
     MENUTITLE: Oldalak
     TreeView: "Fa nézet"
@@ -80,7 +130,10 @@ hu:
     FILTER: Szűrő
   CMSSearch:
     FILTERDATEFROM: "-tól"
+    FILTERDATEHEADING: Dátum
     FILTERDATETO: "-ig"
+  CMSSettingsController:
+    MENUTITLE: Beállítások
   CMSSiteTreeFilter_Search:
     Title: "Összes oldal"
   ContentControl:
@@ -91,6 +144,7 @@ hu:
     CMS: Tartalomkezelő
     DRAFT: Piszkozat
     DRAFTSITE: "Vázlat oldal"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Be kell jelentkezned a CMS jelszavaddal, hogy megtekinthesd a piszkozatot vagy az archivált tartalmat. <a href=\"%s\">A publikált oldalra való visszatéréshez kattints ide.</a>"
     Email: E-mail
     INSTALL_SUCCESS: "Sikeres telepítés!"
     InstallFilesDeleted: "A telepítő állományok sikeresen tőrőlve lettek."
@@ -119,32 +173,74 @@ hu:
     CODE: Hibakód
     DEFAULTERRORPAGETITLE: "Az oldal nem található"
     DEFAULTSERVERERRORPAGETITLE: "Szerver hiba"
+    SINGULARNAME: "Hiba oldal"
+  Folder:
+    AddFolderButton: "Mappa hozzáadása"
+    DELETEUNUSEDTHUMBNAILS: "Nem használt bélyegképek törlése"
+    UNUSEDFILESTITLE: "Nem használt állományok"
+    UNUSEDTHUMBNAILSTITLE: "Nem használt bélyegképek"
+    UploadFilesButton: Feltöltés
+  LeftAndMain:
+    DELETED: Törölve.
+    PreviewButton: Előnézet
+    SAVEDUP: Elmentve.
+    SearchResults: Találatok
+  Permission:
+    CMS_ACCESS_CATEGORY: "CMS hozzáférés"
   Permissions:
     CONTENT_CATEGORY: "Tartalommal kapcsolatos jogosultságok"
     PERMISSIONS_CATEGORY: "Szerepkörök kés jogosultságok"
   RedirectorPage:
+    DESCRIPTION: "Átirányít belső oldalra"
     HASBEENSETUP: "Egy átirányító oldal került létrehozásra, anélkül hogy lenne hova átirányítania."
     HEADER: "Ez az oldal egy másik oldalra fogja írányítani a felhasználókat"
     OTHERURL: "Egy másik weboldal URL-je "
     REDIRECTTO: "Átirányítás ide:"
     REDIRECTTOEXTERNAL: "Egy másik weboldal"
     REDIRECTTOPAGE: "Egy oldal a weblapodon"
+    SINGULARNAME: "Átirányító oldal"
     YOURPAGE: "Oldal a weblapodon"
+  ReportAdmin:
+    MENUTITLE: Jelentések
+    ReportTitle: Cím
+  ReportAdminForm:
+    FILTERBY: Szűrés
   SearchForm:
     GO: Mehet
     SEARCH: Keresés
     SearchResults: Találatok
   SideReport:
     BROKENFILES: "Oldalak hibás fájl hivatkozásokkal"
+    BROKENLINKS: "Oldalak hibás hivatkozásokkal"
     BROKENREDIRECTORPAGES: "RedirectorPage-ek törölt oldalakra hivatkoznak"
     BROKENVIRTUALPAGES: "VirtualPages törölt oldalakra mutatnak"
     BrokenLinksGroupTitle: "Hibás linkek listája"
     ContentGroupTitle: "Tartalommal kapcsolatos riportok"
     EMPTYPAGES: "Üres oldalak"
     LAST2WEEKS: "Elmúlt 2 héten belül szerkesztett oldalak"
+    OtherGroupTitle: Más
     ParameterLiveCheckbox: "Éles oldal megtekintése"
+    REPEMPTY: "A {title} riport üres."
   SilverStripeNavigator:
     ARCHIVED: Archiválva
+  SilverStripeNavigatorLink:
+    ShareLink: "Hivatkozás megosztása"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Bezár
+  SiteConfig:
+    DEFAULTTHEME: "(Alap téma használata)"
+    EDITHEADER: "A webhely oldalai módosíthajtja"
+    EDIT_PERMISSION: "Webhely konfiguráció"
+    PLURALNAME: "Oldal konfigurációk"
+    SINGULARNAME: "Oldal konfiguráció"
+    SITENAMEDEFAULT: "Az oldal neve"
+    SITETAGLINE: "Webhely címsora"
+    SITETITLE: "Oldal címe"
+    TABACCESS: Hozzáférés
+    TABMAIN: Fő
+    THEME: Témák
+    TOPLEVELCREATE: "A webhely legfelső szintjén oldalakat hozhat létre"
+    VIEWHEADER: "A webhely oldalait olvashatják"
   SiteTree:
     ACCESSANYONE: Mindenki
     ACCESSHEADER: "Ki láthatja ezt az oldalt a weblapon?"
@@ -152,6 +248,7 @@ hu:
     ACCESSONLYTHESE: "Csak ezen emberek (válassz a listából)"
     ADDEDTODRAFTHELP: "Az oldal jelenleg még nincs publikálva."
     ADDEDTODRAFTSHORT: Vázlat
+    ALLOWCOMMENTS: "Megjegyzések engedélyezése ezen az oldalon?"
     BUTTONCANCELDRAFT: "Piszkozaton végzett változtatások visszavonása"
     BUTTONCANCELDRAFTDESC: "Piszkozat törlése, és vissztérés a jelenleg publikált oldalra"
     BUTTONPUBLISHED: Publikálva
@@ -164,6 +261,9 @@ hu:
     DEFAULTABOUTTITLE: Rólunk
     DEFAULTCONTACTTITLE: Kapcsolat
     DEFAULTHOMETITLE: Kezdőlap
+    DELETEDPAGEHELP: "Az oldal nincs publikálva"
+    DELETEDPAGESHORT: Törölve
+    DESCRIPTION: "Egyszerű oldal"
     DependtPageColumnLinkType: "Hivatkozás típusa"
     DependtPageColumnURL: Link
     EDITANYONE: "Bárki, aki be tud jelentkezni a CMS-be"
@@ -195,17 +295,22 @@ hu:
     PARENTTYPE_ROOT: "Felső szintű oldal"
     PARENTTYPE_SUBPAGE: Aloldal
     PERMISSION_GRANTACCESS_DESCRIPTION: "Tartalom hozzáférését szabályozza"
+    PLURALNAME: Oldalak
     PageTypNotAllowedOnRoot: "A \"{type}\" oldal nem helyezkedhet el a gyökér szintjén"
     PageTypeNotAllowed: "A \"{type}\" oldal nem helyezkedhet el a kiválasztott szülő alá"
+    REMOVEDFROMDRAFTHELP: "Az oldal publikálva lett, de törölve lett a vázlatok közül"
+    REMOVEDFROMDRAFTSHORT: "Törölve a vázlatokból"
     REMOVE_INSTALL_WARNING: "Figyelmeztetés: Törölje az install.php állományt a Silverstripe telepítéséből. "
     REORGANISE_DESCRIPTION: "Oldal szerkezetének megváltoztatása"
     REORGANISE_HELP: "Az oldalak sorrendje egérrel átrendezhető."
     SHOWINMENUS: "Látható legyen a menükben?"
     SHOWINSEARCH: "Látható legyen a keresésben?"
+    SINGULARNAME: Oldal
     TABBEHAVIOUR: Viselkedés
     TABCONTENT: Tartalom
     TABDEPENDENT: "Kapcsolodó oldalak"
     TOPLEVEL: "Oldaltartalom (legfelső szint)"
+    TOPLEVELCREATORGROUPS: "A legfelső szinten új elemeket létrehozhatnak"
     URLSegment: "URL szegmens"
     VIEWERGROUPS: "Olvasási joggal rendelkező csoportok"
     VIEW_ALL_DESCRIPTION: "Bármely oldal megtekintése"
@@ -230,3 +335,4 @@ hu:
     CHOOSE: "Hivatkozott oldal"
     EditLink: szerkeszt
     HEADER: "Ez egy virtuális oldal"
+    SINGULARNAME: "Virtuális oldal"

--- a/lang/id.yml
+++ b/lang/id.yml
@@ -1,7 +1,41 @@
 id:
+  AssetAdmin:
+    ADDFILES: "Tambah Berkas"
+    ActionAdd: "Tambah Folder"
+    AppCategoryArchive: Arsip
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Dokumen
+    AppCategoryFlash: Flash
+    AppCategoryImage: Gambar
+    AppCategoryVideo: Video
+    BackToFolder: "Kembali ke Folder"
+    CREATED: Tanggal
+    CurrentFolderOnly: "Batasi sesuai folder ini?"
+    DetailsView: Perincian
+    FILES: Berkas
+    FILESYSTEMSYNC: "Selaraskan berkas"
+    FILESYSTEMSYNCTITLE: "Perbarui entri database CMS untuk berkas-berkas pada sistem berkas (filesystem). Berguna saat berkas-berkas baru diunggah di luar sistem CMS, misalnya melalui FTP."
+    FROMTHEINTERNET: "Dari internet"
+    FROMYOURCOMPUTER: "Dari komputer Anda"
+    Filetype: "Jenis berkas"
+    ListView: "Tampilan Daftar"
+    MENUTITLE: Berkas
+    NEWFOLDER: FolderBaru
+    SIZE: Ukuran
+    THUMBSDELETED: "{count} thumbnail tak terpakai telah dihapus"
+    TreeView: "Tampilan Struktur"
+    Upload: Unggah
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Hapus Folder"
+  AssetAdmin_Tools:
+    FILTER: Saring
+  AssetAdmin_left_ss:
+    GO: Lanjut
   AssetTableField:
     BACKLINKCOUNT: "Dipakai pada:"
     PAGES: laman
+  BackLink_Button_ss:
+    Back: Kembali
   BrokenLinksReport:
     Any: Lain
     BROKENLINKS: "Laporan tautan rusak"
@@ -27,10 +61,18 @@ id:
   CMSAddPageController:
     Title: "Tambah laman"
   CMSBatchActions:
+    ARCHIVE: Arsip
+    ARCHIVED_PAGES: "Arsip %d halaman"
+    DELETED_DRAFT_PAGES: "%d laman berhasil dihapus dari draft, %d laman gagal dihapus"
+    DELETED_PAGES: "%d laman berhasil dihapus dari situs terbit, %d gagal"
+    DELETE_DRAFT_PAGES: "Hapus dari draf situs"
+    DELETE_PAGES: "Hapus dari situs terbit"
     PUBLISHED_PAGES: "Menerbitkan %d laman, %d gagal"
     PUBLISH_PAGES: Terbitkan
     RESTORE: Pulihkan
     RESTORED_PAGES: "Pulihkan %d halaman"
+  CMSFileAddController:
+    MENUTITLE: Berkas
   CMSMain:
     ACCESS: "Akses ke bagian '{title}'"
     ACCESS_HELP: "Perbolehkan menampilkan bagian dengan struktur laman dan konten. Perijinan menampilkan dan mengedit dapat diatur melalui pilihan terkait laman, sebagaimana \"Perijinan Konten\"."
@@ -41,8 +83,13 @@ id:
     ChoosePageParentMode: "Pilih lokasi untuk laman ini"
     ChoosePageType: "Pilih jenis laman"
     Create: Buat
+    DELETE: "Hapus dari situs draft"
+    DELETEFP: "Hapus dari situs yang telah diterbitkan"
+    DESCREMOVED: "dan {count} turunannya"
     DUPLICATED: "'{title}' berhasil diduplikasi"
     DUPLICATEDWITHCHILDREN: "'{title}' dan turunannya berhasil diduplikasi"
+    EditTree: "Edit Struktur"
+    MENUTITLE: "Edit Laman"
     NEWPAGE: "{pagetype} baru"
     PAGENOTEXISTS: "Laman ini tidak ada"
     PAGETYPEANYOPT: Lain
@@ -50,6 +97,7 @@ id:
     PUBALLFUN: "Fungsi \"Terbitkan Semua\""
     PUBPAGES: "Selesai: {count} laman terbit"
     PageAdded: "Laman berhasil dibuat"
+    REMOVED: "Dihapus '{title}'{description} dari situs langsung"
     REMOVEDPAGE: "Menghapus '{title}' dari situs terbit"
     REMOVEDPAGEFROMDRAFT: "Menghapus '%s' dari draf situs"
     RESTORED: "Pemulihan '{title}' sukses"
@@ -59,16 +107,24 @@ id:
     ROLLBACK: "Kembali ke versi ini"
     ROLLEDBACKPUBv2: "Kembali ke versi terbit"
     ROLLEDBACKVERSIONv2: "Kembali ke versi #%d."
+    SAVE: Simpan
     SAVEDRAFT: "Simpan draf"
     TabContent: Konten
     TabHistory: Sejarah
     TabSettings: Pengaturan
+  CMSMain_left_ss:
+    RESET: Reset
   CMSPageAddController:
+    MENUTITLE: "Tambah laman"
     ParentMode_child: "Di bawah laman lain"
     ParentMode_top: "Laman atas"
+  CMSPageEditController:
+    MENUTITLE: "Edit Laman"
   CMSPageHistoryController:
     COMPAREMODE: "Modus pembanding (pilih dua)"
     COMPAREVERSIONS: "Bandingkan Versi"
+    COMPARINGVERSION: "Bandingkan versi {version1} dan {version2}."
+    MENUTITLE: Sejarah
     REVERTTOTHISVERSION: "Kembali ke versi ini"
     SHOWUNPUBLISHED: "Tampilkan versi batalterbit"
     SHOWVERSION: "Tampilkan Versi"
@@ -81,7 +137,10 @@ id:
     PUBLISHER: Penerbit
     UNKNOWN: "Tidak diketahui"
     WHEN: Ketika
+  CMSPageSettingsController:
+    MENUTITLE: "Edit Laman"
   CMSPagesController:
+    GalleryView: "Tampilan Galeri"
     ListView: "Tampilan daftar"
     MENUTITLE: Laman
     TreeView: "Tampilan Struktur"
@@ -89,7 +148,10 @@ id:
     FILTER: Saring
   CMSSearch:
     FILTERDATEFROM: Dari
+    FILTERDATEHEADING: Tanggal
     FILTERDATETO: Ke
+  CMSSettingsController:
+    MENUTITLE: Pengaturan
   CMSSiteTreeFilter_Search:
     Title: "Semua laman"
   ContentControl:
@@ -100,6 +162,7 @@ id:
     CMS: CMS
     DRAFT: Draf
     DRAFTSITE: "Draf situs"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Anda harus login untuk menampilkan konten draft atau arsip. <a href=\"%s\">Klik di sini untuk kembali ke situs terbit.</a>"
     Email: Surel
     INSTALL_SUCCESS: "Penginstalan berhasil!"
     InstallFilesDeleted: "Berkas penginstalan telah berhasil dihapus."
@@ -147,17 +210,40 @@ id:
     DEFAULTERRORPAGETITLE: "Laman tidak ditemukan"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Maaf, ada masalah dalam penanganan permintaan Anda.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Server mengalami kesalahan"
+    DESCRIPTION: "Laman untuk berbagai kasus kesalahan (misalnya \"Laman tidak ditemukan\")"
+    ERRORFILEPROBLEM: "Gagal membuka berkas \"{filename}\" untuk penulisan data. Mohon periksa pengaturan akses tulis."
+    SINGULARNAME: "Laman Kesalahan"
+  Folder:
+    AddFolderButton: "Tambah map"
+    DELETEUNUSEDTHUMBNAILS: "Hapus thumbnail-thumbnail yang tidal dipakai"
+    UNUSEDFILESTITLE: "Berkas tidak terpakai"
+    UNUSEDTHUMBNAILSTITLE: "Thumbnail-thumbnail yang tidak dipakai"
+    UploadFilesButton: Unggah
+  LeftAndMain:
+    DELETED: Hapus
+    PreviewButton: Pratinjau
+    SAVEDUP: Disimpan
+    SearchResults: "Hasil pencarian"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Akses CMS"
   Permissions:
     CONTENT_CATEGORY: "Perijinan konten"
     PERMISSIONS_CATEGORY: "Peran dan akses perijinan"
   RedirectorPage:
+    DESCRIPTION: "Mengarahkan ke laman internal berbeda"
     HASBEENSETUP: "Sebuah laman pengarah telah dibuat tanpa arah yang dituju."
     HEADER: "Laman ini akan mengarahkan pengguna ke laman lain"
     OTHERURL: "URL situs web lain"
     REDIRECTTO: "Arahkan lagi ke"
     REDIRECTTOEXTERNAL: "Situs web yang lain"
     REDIRECTTOPAGE: "Laman pada situs Anda"
+    SINGULARNAME: "Laman Pengarah"
     YOURPAGE: "Laman pada situs Anda"
+  ReportAdmin:
+    MENUTITLE: Laporan
+    ReportTitle: Judul
+  ReportAdminForm:
+    FILTERBY: "Saring dengan"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Mohon terbitkan laman tertaut untuk menayangkan laman virtual"
     VIRTUALPAGEWARNING: "Mohon pilih laman tertaut dan simpan lebih dulu untuk menayangkan laman ini"
@@ -168,15 +254,38 @@ id:
     SearchResults: "Hasil Pencarian"
   SideReport:
     BROKENFILES: "Laman dengan berkas rusak"
+    BROKENLINKS: "Laman dengan tautan rusak"
     BROKENREDIRECTORPAGES: "LamanPengarah mengarah pada laman terhapus"
     BROKENVIRTUALPAGES: "LamanVirtual mengarah pada laman terhapus"
     BrokenLinksGroupTitle: "Laporan tautan-tautan rusak"
     ContentGroupTitle: "Laporan konten"
     EMPTYPAGES: "Laman tanpa konten"
     LAST2WEEKS: "Laman diedit dalam 2 minggu terakhir"
+    OtherGroupTitle: Lainnya
     ParameterLiveCheckbox: "Periksa situs live"
+    REPEMPTY: "Laporan {title} kosong."
   SilverStripeNavigator:
     ARCHIVED: Terarsip
+  SilverStripeNavigatorLink:
+    ShareLink: "Bagi tautan"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Tutup
+  SiteConfig:
+    DEFAULTTHEME: "(Gunakan tema standar)"
+    EDITHEADER: "Siapa yang boleh mengedit laman pada situs ini?"
+    EDIT_PERMISSION: "Mengelola pengaturan situs"
+    EDIT_PERMISSION_HELP: "Bolehkan mengedit pengaturan akses umum atau perijinan tingkat atas."
+    PLURALNAME: "Pengaturan Situs"
+    SINGULARNAME: "Pengaturan Situs"
+    SITENAMEDEFAULT: "Nama Situs"
+    SITETAGLINE: "Slogan Situs"
+    SITETITLE: "Judul Situs"
+    TABACCESS: Akses
+    TABMAIN: "Tab Utama"
+    TAGLINEDEFAULT: "slogan situsmu disini"
+    THEME: Tema
+    TOPLEVELCREATE: "Siapa yang dapat membuat laman utama yang baru?"
+    VIEWHEADER: "Siapa yang dapat menampilkan laman pada situs ini?"
   SiteTree:
     ACCESSANYONE: "Siapa saja"
     ACCESSHEADER: "Siapa yang dapat melihat laman ini?"
@@ -184,6 +293,7 @@ id:
     ACCESSONLYTHESE: "Hanya orang ini saja (pilih dari daftar)"
     ADDEDTODRAFTHELP: "Laman belum terbit"
     ADDEDTODRAFTSHORT: Darft
+    ALLOWCOMMENTS: "Bolehkan komentar pada laman ini?"
     APPEARSVIRTUALPAGES: "Konten ini akan tampil juga pada laman virtual di bagian {title}."
     BUTTONCANCELDRAFT: "Batalkan perubahan draft"
     BUTTONCANCELDRAFTDESC: "Hapus draft dan kembalikan ke laman terbit"
@@ -197,7 +307,10 @@ id:
     DEFAULTABOUTTITLE: "Tentang Kami"
     DEFAULTCONTACTTITLE: "Hubungi Kami"
     DEFAULTHOMETITLE: Beranda
+    DELETEDPAGEHELP: "Laman tidak lagi terbit"
+    DELETEDPAGESHORT: Hapus
     DEPENDENT_NOTE: "Laman-laman berikut ini bergantung pada laman ini. Termasuk laman virtual, laman pengarah, dan laman-laman dengan tautan konten."
+    DESCRIPTION: "Laman konten umum"
     DependtPageColumnLinkType: "Jenis tautan"
     DependtPageColumnURL: URL
     EDITANYONE: "Siapa saja yang dapat masuk ke dalam CMS"
@@ -235,17 +348,22 @@ id:
     PARENTTYPE_SUBPAGE: "Sub-laman di bawah laman induk"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Kelola hak akses untuk konten ini"
     PERMISSION_GRANTACCESS_HELP: "Perbolehkan pengaturan pencegahan akses ke laman tertentu di bagian \"Laman\"."
+    PLURALNAME: Laman
     PageTypNotAllowedOnRoot: "Jenis laman {type} tidak diperbolehkan di tingkat atas"
     PageTypeNotAllowed: "Jenis laman {type} tidak diperbolehkan menjadi turunan dari laman induk ini"
+    REMOVEDFROMDRAFTHELP: "Laman sudah terbit, tapi telah dihapus dari draft"
+    REMOVEDFROMDRAFTSHORT: "Dihapus dari draft"
     REMOVE_INSTALL_WARNING: "Peringatan: Anda perlu menghapus instal.php dari penginstalan SilverStripe ini untuk alasan keamanan."
     REORGANISE_DESCRIPTION: "Ubah stuktur situs"
     REORGANISE_HELP: "Atur ulang laman pada struktur situs dengan drag&drop."
     SHOWINMENUS: "Perlihatkan dalam menu?"
     SHOWINSEARCH: "Perlihatkan dalam pencarian"
+    SINGULARNAME: Laman
     TABBEHAVIOUR: Perilaku
     TABCONTENT: "Konten Utama"
     TABDEPENDENT: "Laman terkait"
     TOPLEVEL: "Konten Situs (Tingkat Atas)"
+    TOPLEVELCREATORGROUPS: "Pembuat tingkat atas"
     URLSegment: "Segmen URL"
     VIEWERGROUPS: "Kelompok Penampil"
     VIEW_ALL_DESCRIPTION: "Tampilkan semua laman"
@@ -270,7 +388,9 @@ id:
     HAVEASKED: "Anda telah meminta menampilkan konten situs ini pada"
   VirtualPage:
     CHOOSE: "Laman Tertaut"
+    DESCRIPTION: "Tampilkan konten laman lain"
     EditLink: edit
     HEADER: "Ini adalah laman virtual"
     HEADERWITHLINK: "Ini adalah laman virtual dengan konten salinan dari \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Laman asli jenis \"{type}\" tidak dibolehkan pada tingkat atas untuk laman virtual ini"
+    SINGULARNAME: "Laman Virtual"

--- a/lang/is.yml
+++ b/lang/is.yml
@@ -1,4 +1,8 @@
 is:
+  CMSMain:
+    DELETE: "Eyða úr drögum"
+    DELETEFP: "Eyða úr birtum síðum"
+    SAVE: Vista
   ContentController:
     LOGGEDINAS: "Innskráður sem"
     LOGIN: Innskrá
@@ -10,6 +14,10 @@ is:
     CODE: "Villu númer"
     DEFAULTERRORPAGECONTENT: "<p>Afsakið, það virðist vera að þú ert að reyna opna síðu sem er ekki til.</p><p>Vinsamlegast athugaðu hvort að slóðin sé rétt skrifuð og prófaðu aftur</p>"
     DEFAULTERRORPAGETITLE: "Síða fannst ekki"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Eyða ónotuðum smámyndum"
+    UNUSEDFILESTITLE: "Ónotaðar skrár"
+    UNUSEDTHUMBNAILSTITLE: "Ónotaðar smámyndir"
   RedirectorPage:
     HEADER: "Þessi síða mun áframsenda notendur á aðra síðu"
     OTHERURL: "Slóð á aðra heimasíðu"
@@ -21,11 +29,18 @@ is:
     GO: Framkvæma
     SEARCH: Leita
     SearchResults: "Leitar niðurstaða"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Loka
+  SiteConfig:
+    SITENAMEDEFAULT: "Nafn síðunnar"
+    SITETITLE: "Titill síðunnar"
+    THEME: Þema
   SiteTree:
     ACCESSANYONE: Allir
     ACCESSHEADER: "Hver má skoða þessa síðu á heimasíðunni minni?"
     ACCESSLOGGEDIN: "Innskráðir notendur"
     ACCESSONLYTHESE: "Aðeins þetta fólk (veldu úr listanum)"
+    ALLOWCOMMENTS: "Leyfa lesendum að skrifa athugasemdir á þessa síðu?"
     BUTTONCANCELDRAFT: "Hætta við breytingar á drögum"
     BUTTONCANCELDRAFTDESC: "Eyða drögunum þínum og fara aftur ál núverandi bitar síðu"
     BUTTONUNPUBLISH: "Taka úr birtingu"
@@ -55,3 +70,4 @@ is:
     has_one_Parent: "Yfir síða"
   VirtualPage:
     HEADER: "Þetta er sýndarsíða"
+    SINGULARNAME: "Sýndar síða"

--- a/lang/it.yml
+++ b/lang/it.yml
@@ -1,10 +1,44 @@
 it:
   AssetAdmin:
+    ADDFILES: "Aggiungi File"
+    ActionAdd: "Aggiungi cartella"
+    AppCategoryArchive: Archivia
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Documento
+    AppCategoryFlash: Flash
+    AppCategoryImage: Immagine
+    AppCategoryVideo: Video
+    BackToFolder: "Torna alla cartella"
+    CMSMENU_OLD: "Files (vecchio)"
+    CREATED: "Data creazione"
+    CurrentFolderOnly: "Limita alla cartella corrente?"
+    DetailsView: Dettagli
     ErrorItemPermissionDenied: "Sembra tu non abbia i necessari permessi per aggiungere {ObjectTitle} ad una campagna"
     ErrorNotFound: "Questo {Type} non può essere trovato"
+    FILES: Files
+    FILESYSTEMSYNC: "Sincronizza file"
+    FILESYSTEMSYNCTITLE: "Aggiorna il database dei file. Utile quando nuovi file sono stati caricati fuori dal CMS, es. via FTP."
+    FROMTHEINTERNET: "Da Internet"
+    FROMYOURCOMPUTER: "Dal tuo computer"
+    Filetype: "Tipo di file"
+    ListView: "Visualizzazione a lista"
+    MENUTITLE: Files
+    NEWFOLDER: NuovaCartella
+    SIZE: Dimensione
+    THUMBSDELETED: "{count} miniature inutilizzate sono state eliminate"
+    TreeView: "Visualizzazione a albero"
+    Upload: Carica
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Elimina cartelle"
+  AssetAdmin_Tools:
+    FILTER: Filtra
+  AssetAdmin_left_ss:
+    GO: Vai
   AssetTableField:
     BACKLINKCOUNT: "Usato in:"
     PAGES: pagina/e
+  BackLink_Button_ss:
+    Back: Indietro
   BrokenLinksReport:
     Any: Qualsiasi
     BROKENLINKS: "Rapporto link non funzionanti"
@@ -33,10 +67,18 @@ it:
     RESULT: "Eliminate %d pagine da bozza e live, e spedite all'archivio"
     TITLE: "Annulla la pubblicazione e archivia"
   CMSBatchActions:
+    ARCHIVE: Archiviare
+    ARCHIVED_PAGES: "%d pagine archiviate"
+    DELETED_DRAFT_PAGES: "Eliminate %d pagine dal sito bozza, %d non a buon fine"
+    DELETED_PAGES: "Eliminate %d pagine dal sito pubbico, %d non a buon fine"
+    DELETE_DRAFT_PAGES: "Elimina dal sito bozza"
+    DELETE_PAGES: "Eliminata dal sito pubblicato"
     PUBLISHED_PAGES: "Pubblicate %d pagine, %d non a buon fine"
     PUBLISH_PAGES: Pubblica
     RESTORE: Ripristina
     RESTORED_PAGES: "%d pagine ripristinate"
+  CMSFileAddController:
+    MENUTITLE: Files
   CMSMain:
     ACCESS: "Accesso alla sezione '{title}'"
     ACCESS_HELP: "Consente la visualizzazione della sezione con l'albero delle pagine e i contenuti. I permessi di visualizzazione e modifica possono essere gestiti attraverso menù a tendina specifici della pagina, come dai separati \"Permessi sui contenuti\"."
@@ -49,9 +91,14 @@ it:
     ChoosePageParentMode: "Scegli dove creare questa pagina"
     ChoosePageType: "Scegli tipo di pagina"
     Create: Crea
+    DELETE: "Elimina bozza"
+    DELETEFP: "Elimina dal sito pubblicato"
+    DESCREMOVED: "e {count} discendenti"
     DUPLICATED: "'{title}' duplicato correttamente"
     DUPLICATEDWITHCHILDREN: "'{title}' e figlie duplicate con successo"
     EMAIL: E-mail
+    EditTree: "Modifica albero"
+    MENUTITLE: "Modifica pagina"
     NEWPAGE: "Nuova {pagetype}"
     PAGENOTEXISTS: "Questa pagina non esiste"
     PAGETYPEANYOPT: Qualsiasi
@@ -60,6 +107,7 @@ it:
     PUBLISHED: "Pubblicata '{title}' con successo."
     PUBPAGES: "Fatto: Pubblicate {count} pagine"
     PageAdded: "Pagina creata con successo"
+    REMOVED: "'{title}' {description} rimosso dal sito pubblico"
     REMOVEDPAGE: "Eliminata '{title}' dal sito pubblicato"
     REMOVEDPAGEFROMDRAFT: "Eliminata '%s' dal sito bozza"
     RESTORED: "Ripristinata '{title}' con successo"
@@ -69,6 +117,7 @@ it:
     ROLLBACK: "Ripristina a questa versione"
     ROLLEDBACKPUBv2: "Ripristinata la versione pubblicata."
     ROLLEDBACKVERSIONv2: "Ripristinata la versione #%d."
+    SAVE: Salva
     SAVED: "'{title}' salvata correttamente."
     SAVEDRAFT: "Salva bozza"
     TabContent: Contenuto
@@ -77,12 +126,18 @@ it:
     UNPUBLISH_AND_ARCHIVE: "Annulla pubblicazione e archivia"
   CMSMain_left_ss:
     CLEAR_FILTER: Annulla
+    RESET: Azzera
   CMSPageAddController:
+    MENUTITLE: "Aggiungi pagina"
     ParentMode_child: "Sotto un'altra pagina"
     ParentMode_top: "Primo livello"
+  CMSPageEditController:
+    MENUTITLE: "Modifica pagina"
   CMSPageHistoryController:
     COMPAREMODE: "Modalità confronto (selezionane due)"
     COMPAREVERSIONS: "Confronta versioni"
+    COMPARINGVERSION: "Confronto versioni {version1} e {version2}."
+    MENUTITLE: Archivio
     REVERTTOTHISVERSION: "Ripristina a questa versione"
     SHOWUNPUBLISHED: "Mostra versioni nascoste"
     SHOWVERSION: "Mostra versione"
@@ -96,7 +151,10 @@ it:
     PUBLISHER: Editore
     UNKNOWN: Sconosciuto
     WHEN: Quando
+  CMSPageSettingsController:
+    MENUTITLE: "Modifica pagina"
   CMSPagesController:
+    GalleryView: "Visualizzazione a galleria"
     ListView: "Visualizzazione a lista"
     MENUTITLE: Pagine
     TreeView: "Visualizzazione a albero"
@@ -106,8 +164,11 @@ it:
     Title: "Pagine pubblicate"
   CMSSearch:
     FILTERDATEFROM: Da
+    FILTERDATEHEADING: Data
     FILTERDATETO: A
     PAGEFILTERDATEHEADING: "Ultima modifica"
+  CMSSettingsController:
+    MENUTITLE: Impostazioni
   CMSSiteTreeFilter_Search:
     Title: "Tutte le pagine"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -120,6 +181,7 @@ it:
     CMS: CMS
     DRAFT: Bozza
     DRAFTSITE: "Sito Bozza"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Devi autenticarti utilizzando la tua password per poter visualizzare bozze o contenuti archiviati. <a href=\"%s\">Clicca qui per tornare al sito pubblicato</a>"
     Email: Email
     INSTALL_SUCCESS: "Installazione conclusa con successo!"
     InstallFilesDeleted: "I file di installazione sono stati eliminati con successo."
@@ -167,16 +229,38 @@ it:
     DEFAULTERRORPAGETITLE: "Pagina non trovata"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Spiacenti, c'è stato un problema con la gestione della tua richiesta.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Errore server"
+    DESCRIPTION: "Contenuto personalizzato per differenti casi di errore (es. \"Pagina non trovata\")"
+    ERRORFILEPROBLEM: "Errore nell'apertura del file \"{filename}\" per la scrittura. Controlla i permessi del file."
+    PLURALNAME: "Pagine Errore"
+    SINGULARNAME: "Pagine errore"
+  File:
+    Title: Titolo
+  Folder:
+    AddFolderButton: "Aggiungi cartella"
+    DELETEUNUSEDTHUMBNAILS: "Elimina anteprime inutilizzate"
+    UNUSEDFILESTITLE: "File inutilizzati"
+    UNUSEDTHUMBNAILSTITLE: "Anteprime inutilizzate"
+    UploadFilesButton: Carica
+  LeftAndMain:
+    DELETED: Eliminata.
+    PreviewButton: Anteprima
+    SAVEDUP: Salvata.
+    SearchResults: "Risultati della ricerca"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Accesso CMS"
   Permissions:
     CONTENT_CATEGORY: "Permessi sui contenuti"
     PERMISSIONS_CATEGORY: "Ruoli e permessi d'accesso"
   RedirectorPage:
+    DESCRIPTION: "Redirige a un'altra pagina del sito"
     HASBEENSETUP: "Una pagina di redirezione è stata configurata nonostante non vi sia alcun indirizzo a cui farla puntare"
     HEADER: "Questa pagina redirigerà gli utenti su un'altra"
     OTHERURL: "Altro indirizzo del sito web"
+    PLURALNAME: "Pagine di redirezione"
     REDIRECTTO: "Redirigi a"
     REDIRECTTOEXTERNAL: "Un altro sito web"
     REDIRECTTOPAGE: "Una pagina sul tuo sito web"
+    SINGULARNAME: "Pagina di redirezione"
     YOURPAGE: "Pagina sul tuo sito web"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Esegui
@@ -188,6 +272,11 @@ it:
     OPERATION_REMOVE: "Rimuove le pagine selezionate da tutti gli stage (ATTENZIONE: Distruggerà le pagine selezionate sia da stage che da live)"
     SELECTALL: "seleziona tutto"
     UNSELECTALL: "deseleziona tutto"
+  ReportAdmin:
+    MENUTITLE: Rapporti
+    ReportTitle: Titolo
+  ReportAdminForm:
+    FILTERBY: "Filtra per"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Perfavore pubblica la pagina linkata per poter pubblicare la pagina virtuale."
     VIRTUALPAGEWARNING: "Perfavore scegli una pagina da linkare e salvala per poter pubblicare questa pagina."
@@ -198,15 +287,22 @@ it:
     SearchResults: "Risultati della ricerca"
   SideReport:
     BROKENFILES: "Pagine con file non funzionanti"
+    BROKENLINKS: "Pagine con link non funzionanti."
     BROKENREDIRECTORPAGES: "Pagina di redirezione che puntano a pagine eliminate"
     BROKENVIRTUALPAGES: "Pagine virtuali che puntano a pagine eliminate"
     BrokenLinksGroupTitle: "Rapporto link non funzionanti"
     ContentGroupTitle: "Rapporti sui contenuti"
     EMPTYPAGES: "Pagine vuote"
     LAST2WEEKS: "Pagine modificate nelle ultime 2 settimane"
+    OtherGroupTitle: Altro
     ParameterLiveCheckbox: "Verifica sito pubblicato"
+    REPEMPTY: "Il rapporto {title} è vuoto."
   SilverStripeNavigator:
     ARCHIVED: Archiviato
+  SilverStripeNavigatorLink:
+    ShareLink: "Link di condivisione"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Chiudi
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Aggiungi pagina"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -227,10 +323,28 @@ it:
     SINGULARNAME: "Pagina di reindirizzamento"
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: "Pagina di contenuto generico"
+    PLURALNAME: "Alberi del sito"
+    SINGULARNAME: "Albero del sito"
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: "Mostra il contenuto di un'altra pagina"
     PLURALNAME: "Pagine virtuali"
     SINGULARNAME: "Pagina virtuale"
+  SiteConfig:
+    DEFAULTTHEME: "(Usa il tema predefinito)"
+    EDITHEADER: "Chi può modificare le pagine in questo sito?"
+    EDIT_PERMISSION: "Gestisci la configurazione del sito"
+    EDIT_PERMISSION_HELP: "Capacità di modificare le impostazioni globali di accesso/permessi pagina primo livello"
+    PLURALNAME: "Configurazioni sito"
+    SINGULARNAME: "Configurazione sito"
+    SITENAMEDEFAULT: "Nome del sito"
+    SITETAGLINE: "Motto/Slogan del sito"
+    SITETITLE: "Titolo del sito"
+    TABACCESS: Accesso
+    TABMAIN: Principale
+    TAGLINEDEFAULT: "lo slogan qui"
+    THEME: Tema
+    TOPLEVELCREATE: "Chi può creare pagine di primo livello?"
+    VIEWHEADER: "Chi può vedere le pagine in questo sito?"
   SiteTree:
     ACCESSANYONE: Chiunque
     ACCESSHEADER: "Chi può vedere questa pagina?"
@@ -238,9 +352,11 @@ it:
     ACCESSONLYTHESE: "Solamente queste persone (scegli dalla lista)"
     ADDEDTODRAFTHELP: "La pagina non è stata ancora pubblicata"
     ADDEDTODRAFTSHORT: Bozza
+    ALLOWCOMMENTS: "Permetti commenti in questa pagina?"
     APPEARSVIRTUALPAGES: "Questo contenuto appare nelle pagine virtuali nelle sezioni {title}."
     ARCHIVEDPAGEHELP: "Pagina rimossa da bozza e live"
     ARCHIVEDPAGESHORT: Archiviato
+    BUTTONARCHIVEDESC: "Nascondere e mettere in archivio"
     BUTTONCANCELDRAFT: "Cancella le modifiche salvate in bozza"
     BUTTONCANCELDRAFTDESC: "Cancella la tua bozza e ritorna alla versione corrente della pagina pubblicata"
     BUTTONDELETEDESC: "Rimuove da bozza/live e manda all'archivio"
@@ -255,7 +371,10 @@ it:
     DEFAULTCONTACTTITLE: Contattaci
     DEFAULTHOMECONTENT: "<p>Benvenuto in SilverStripe! Questa è la home page di default. Puoi modificare questa pagina direttamente <a href=\"admin/\">dal CMS</a>.</p><p>Puoi accedere alla <a href=\"http://docs.silverstripe.org\">documentazione per gli sviluppatori</a> o partire dalle <a href=\"http://www.silverstripe.org/learn/lessons\">lezioni di SilverStripe</a>.</p>"
     DEFAULTHOMETITLE: Home
+    DELETEDPAGEHELP: "La pagina non è più pubblicata"
+    DELETEDPAGESHORT: Eliminata
     DEPENDENT_NOTE: "Le seguenti pagine dipendono da questa pagina. Queste includono pagine virtuali, pagine di redirezione e pagine con link nel contenuto."
+    DESCRIPTION: "Pagina con contenuto generico"
     DependtPageColumnLinkType: "Tipo di link"
     DependtPageColumnURL: URL
     EDITANYONE: "Chiunque può autenticarsi al CMS"
@@ -297,17 +416,22 @@ it:
     PARENTTYPE_SUBPAGE: "Pagina sotto una pagina madre"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Gestisci quali gruppi possono accedere o modificare certe pagine"
     PERMISSION_GRANTACCESS_HELP: "Consenti le impostazioni di restrizione d'accesso a pagine specifiche nella sezione \"Pagine\"."
+    PLURALNAME: Pagine
     PageTypNotAllowedOnRoot: "Il tipo di pagina \"{type}\" non è consentito al primo livello"
     PageTypeNotAllowed: "Il tipo di pagina \"{type}\" non è consentito come figlio di questa pagina madre"
+    REMOVEDFROMDRAFTHELP: "La pagina è pubblicata, ma è stata eliminata dal sito bozza"
+    REMOVEDFROMDRAFTSHORT: "Eliminato dal sito bozza"
     REMOVE_INSTALL_WARNING: "Attenzione: devi rimuovere install.php da questa installazione di SilverStripe per motivi di sicurezza."
     REORGANISE_DESCRIPTION: "Cambia struttura del sito"
     REORGANISE_HELP: "Riordina le pagine nell'albero del sito utilizzando il drag&drop."
     SHOWINMENUS: "Visualizza nei menu?"
     SHOWINSEARCH: "Visualizza in cerca?"
+    SINGULARNAME: Pagina
     TABBEHAVIOUR: Comportamento
     TABCONTENT: "Contenuto Principale"
     TABDEPENDENT: "Pagine dipendenti"
     TOPLEVEL: "Contenuto del sito (Livello alto)"
+    TOPLEVELCREATORGROUPS: "Creatori di primo livello"
     URLSegment: "Segmento URL"
     VIEWERGROUPS: "Gruppi di visualizzatori"
     VIEW_ALL_DESCRIPTION: "Visualizza qualsiasi pagina"
@@ -321,6 +445,8 @@ it:
     many_many_ImageTracking: "Monitoraggio immagine"
     many_many_LinkTracking: "Monitoraggio link"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Questo elenco mostra tutte le pagine dove il file è stato aggiunto con l'editor WYSIWYG."
+    EDIT: Modifica
     TITLE_INDEX: "#"
     TITLE_TYPE: Tipo
     TITLE_USED_ON: "Usato in"
@@ -336,7 +462,10 @@ it:
     HAVEASKED: "Hai chiesto di visualizzare il contenuto del nostro sito il"
   VirtualPage:
     CHOOSE: "Pagina collegata"
+    DESCRIPTION: "Visualizza il contenuto di un'altra pagina"
     EditLink: modifica
     HEADER: "Questa è una pagina virtuale"
     HEADERWITHLINK: "Questa è una pagina virtuale copiata da \"{title}\" ({link})"
+    PLURALNAME: "Pagine virtuali"
     PageTypNotAllowedOnRoot: "Il tipo di pagina originale \"{type}\" non è consentito al primo livello per questa pagina virtuale"
+    SINGULARNAME: "Pagina virtuale"

--- a/lang/ja.yml
+++ b/lang/ja.yml
@@ -1,7 +1,41 @@
 ja:
+  AssetAdmin:
+    ADDFILES: ファイルを追加
+    ActionAdd: フォルダを追加
+    AppCategoryArchive: アーカイブ
+    AppCategoryAudio: 音楽
+    AppCategoryDocument: 文書
+    AppCategoryFlash: Flash
+    AppCategoryImage: 画像
+    AppCategoryVideo: 動画
+    BackToFolder: フォルダへ戻る
+    CREATED: 日付
+    CurrentFolderOnly: このフォルダに限定しますか?
+    DetailsView: 詳細
+    FILES: ファイル
+    FILESYSTEMSYNC: 同期ファイル
+    FILESYSTEMSYNCTITLE: ファイルに関するCMSデータベースエントリーを更新する。例えば、FTPなどCMS以外を経由してファイルをアップロードした場合に便利です。
+    FROMTHEINTERNET: インターネットから
+    FROMYOURCOMPUTER: コンピュータから
+    Filetype: ファイルの種類
+    ListView: リスト表示
+    MENUTITLE: ファイル
+    NEWFOLDER: 新しいフォルダ
+    SIZE: サイズ
+    THUMBSDELETED: "{count}個の未使用のサムネイルを削除しました"
+    TreeView: ツリー表示
+    Upload: アップロード
+  AssetAdmin_DeleteBatchAction:
+    TITLE: フォルダを削除
+  AssetAdmin_Tools:
+    FILTER: フィルタ
+  AssetAdmin_left_ss:
+    GO: Go
   AssetTableField:
     BACKLINKCOUNT: 以下で使用される：
     PAGES: ページ
+  BackLink_Button_ss:
+    Back: 戻る
   BrokenLinksReport:
     Any: 何でも
     BROKENLINKS: 壊れたリンクのレポート
@@ -27,10 +61,18 @@ ja:
   CMSAddPageController:
     Title: ページを追加
   CMSBatchActions:
+    ARCHIVE: アーカイブ
+    ARCHIVED_PAGES: "%dページをアーカイブしました"
+    DELETED_DRAFT_PAGES: "%dページを下書きサイトから削除しましたが、%dページの削除に失敗しました。"
+    DELETED_PAGES: "%dページを公開サイトから削除しましたが、%dページの削除に失敗しました。"
+    DELETE_DRAFT_PAGES: 下書きサイトから削除
+    DELETE_PAGES: 公開サイトから削除
     PUBLISHED_PAGES: "%dページを公開しましたが、%dページの公開に失敗しました。"
     PUBLISH_PAGES: 公開
     RESTORE: 復元
     RESTORED_PAGES: "%dページを復元しました"
+  CMSFileAddController:
+    MENUTITLE: ファイル
   CMSMain:
     ACCESS: "'{title}' セクションにアクセス"
     ACCESS_HELP: ページツリーとコンテンツを含むセクションの閲覧を許可します。　表示および編集の権限は、ページの特定のドロップダウンだけでなく、独立した"コンテンツの権限"を介して処理することができます。
@@ -43,8 +85,13 @@ ja:
     ChoosePageParentMode: このページを作成する場所を選択
     ChoosePageType: ページの種類を選択
     Create: 作成
+    DELETE: ドラフトサイトから削除
+    DELETEFP: 公開サイトから削除
+    DESCREMOVED: "そして {count} 派生"
     DUPLICATED: "'{title}' の複製が完了しました"
     DUPLICATEDWITHCHILDREN: "'{title}' と子の複製が完了しました"
+    EditTree: ツリーを編集
+    MENUTITLE: ページを編集
     NEWPAGE: "新しい {pagetype}"
     PAGENOTEXISTS: このページは存在しません
     PAGETYPEANYOPT: 何でも
@@ -52,22 +99,31 @@ ja:
     PUBALLFUN: "\"すべてを公開\" 機能"
     PUBPAGES: "完了: {count}ページを公開しました"
     PageAdded: ページの作成に成功
+    REMOVED: "この配信サイトから '{title}'{description} を削除しました"
     REMOVEDPAGE: "'{title}'を公開されているサイトから削除しました"
     REMOVEDPAGEFROMDRAFT: "%sを下書きサイトから削除しました"
     RESTORED: "{title}を復旧しました"
     ROLLBACK: このバージョンへ戻す
     ROLLEDBACKPUBv2: 公開されたバージョンにロールバックされました。
     ROLLEDBACKVERSIONv2: "#%d. のバージョンにロールバック"
+    SAVE: 保存
     SAVEDRAFT: 下書きを保存
     TabContent: コンテンツ
     TabHistory: 履歴
     TabSettings: 設定
+  CMSMain_left_ss:
+    RESET: リセット
   CMSPageAddController:
+    MENUTITLE: ページを追加
     ParentMode_child: 他のページの下に作成
     ParentMode_top: 最上位層
+  CMSPageEditController:
+    MENUTITLE: ページの編集
   CMSPageHistoryController:
     COMPAREMODE: 比較モード（２つを選択）
     COMPAREVERSIONS: バージョンの比較
+    COMPARINGVERSION: "{version1}と{version2}を比較しています。"
+    MENUTITLE: 履歴
     REVERTTOTHISVERSION: このバージョンに戻す
     SHOWUNPUBLISHED: 公開されていないバージョンを表示
     SHOWVERSION: バージョンを表示
@@ -80,7 +136,10 @@ ja:
     PUBLISHER: パブリッシャー
     UNKNOWN: 不明
     WHEN: いつ
+  CMSPageSettingsController:
+    MENUTITLE: ページの編集
   CMSPagesController:
+    GalleryView: ギャラリー表示
     ListView: 一覧表示
     MENUTITLE: ページ
     TreeView: ツリー表示
@@ -90,8 +149,11 @@ ja:
     Title: 公開済みページ
   CMSSearch:
     FILTERDATEFROM: 開始日
+    FILTERDATEHEADING: 日付
     FILTERDATETO: 終了日
     PAGEFILTERDATEHEADING: 最後に編集された
+  CMSSettingsController:
+    MENUTITLE: 設定
   CMSSiteTreeFilter_Search:
     Title: 全ページ
   ContentControl:
@@ -102,6 +164,7 @@ ja:
     CMS: CMS
     DRAFT: 下書き
     DRAFTSITE: 下書きサイト
+    DRAFT_SITE_ACCESS_RESTRICTION: "草案かアーカイブされた内容を見るためにはログインしてください。<a href=\"%s\">公開サイトにもどるにはコチラをクリックしてください。</a>"
     Email: Eメール
     INSTALL_SUCCESS: インストールに成功！
     InstallFilesDeleted: インストール関連ファイルは正しく削除されました
@@ -149,17 +212,44 @@ ja:
     DEFAULTERRORPAGETITLE: ページが見つかりません
     DEFAULTSERVERERRORPAGECONTENT: <p>申し訳ございません。あなたのリクエストを処理中に問題が起きました。</p>
     DEFAULTSERVERERRORPAGETITLE: サーバーエラー
+    DESCRIPTION: "それぞれのエラーケースに対してカスタムコンテンツを表示する(例:\"ページがありません\")"
+    ERRORFILEPROBLEM: "書き込み用のファイル\"{filename}\"を開く際にエラーが発生しました。　ファイルの権限を確認してください。"
+    PLURALNAME: エラーページ
+    SINGULARNAME: エラーページ
+  File:
+    Title: タイトル
+  Folder:
+    AddFolderButton: フォルダの追加
+    DELETEUNUSEDTHUMBNAILS: 未使用のサムネイルを削除
+    UNUSEDFILESTITLE: 未使用のファイル
+    UNUSEDTHUMBNAILSTITLE: 未使用のサムネイル
+    UploadFilesButton: アップロード
+  LeftAndMain:
+    DELETED: 削除済
+    PreviewButton: プレビュー
+    SAVEDUP: 保存済
+    SearchResults: 検索結果
+  Permission:
+    CMS_ACCESS_CATEGORY: CMSへのアクセス
   Permissions:
     CONTENT_CATEGORY: コンテンツに関する権限
     PERMISSIONS_CATEGORY: 役割とアクセス権限
   RedirectorPage:
+    DESCRIPTION: 別の内部ページにリダイレクト
     HASBEENSETUP: 転送URLを含むページには、転送先がない状態で設定されています。
     HEADER: このページをユーザーを変更して他のページにしますか？
     OTHERURL: 他のウェブサイトのURL
+    PLURALNAME: リダイレクトページ
     REDIRECTTO: 変更は
     REDIRECTTOEXTERNAL: 他のウェブサイト
     REDIRECTTOPAGE: 貴方のウェブサイトを表示します
+    SINGULARNAME: リダイレクトページ
     YOURPAGE: 貴方のウェブサイトを表示します
+  ReportAdmin:
+    MENUTITLE: レポート
+    ReportTitle: タイトル
+  ReportAdminForm:
+    FILTERBY: によってフィルター
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: 仮想ページを公開するためにリンクしたページを公開してください
     VIRTUALPAGEWARNING: このページを公開するために、リンク先のページを選択して最初に保存してください
@@ -170,15 +260,38 @@ ja:
     SearchResults: 検索結果
   SideReport:
     BROKENFILES: 壊れているファイルがあるページ
+    BROKENLINKS: リンク切れのページ
     BROKENREDIRECTORPAGES: リダイレクトしたページが削除されています
     BROKENVIRTUALPAGES: 削除されたページを参照している仮想ページ
     BrokenLinksGroupTitle: 壊れているリンクのレポート
     ContentGroupTitle: コンテンツのレポート
     EMPTYPAGES: 空のページ
     LAST2WEEKS: 過去２週間以内に編集されたページ
+    OtherGroupTitle: その他
     ParameterLiveCheckbox: ライブ配信のサイトをチェックする
+    REPEMPTY: "{title}のレポートは空です"
   SilverStripeNavigator:
     ARCHIVED: アーカイブされた
+  SilverStripeNavigatorLink:
+    ShareLink: 共有リンク
+  SilverStripeNavigatorLinkl:
+    CloseLink: 閉じる
+  SiteConfig:
+    DEFAULTTHEME: (デフォルトのテーマを利用)
+    EDITHEADER: このサイト上でページを編集できる人
+    EDIT_PERMISSION: サイト設定の管理
+    EDIT_PERMISSION_HELP: グローバルアクセスの設定/トップレベルのページのアクセス許可を編集する機能。
+    PLURALNAME: サイトの設定
+    SINGULARNAME: サイトの設定
+    SITENAMEDEFAULT: サイト名
+    SITETAGLINE: サイトのキャッチコピー
+    SITETITLE: サイトタイトル
+    TABACCESS: アクセス権限
+    TABMAIN: メイン
+    TAGLINEDEFAULT: サイトのキャッチフレーズをここに入力
+    THEME: テーマ
+    TOPLEVELCREATE: サイトのルートにおいてページを作成できる人
+    VIEWHEADER: このサイト上でページを閲覧できる人
   SiteTree:
     ACCESSANYONE: 誰でも
     ACCESSHEADER: このページを閲覧できる人
@@ -186,8 +299,10 @@ ja:
     ACCESSONLYTHESE: "この人達だけ (リストから選択してください)"
     ADDEDTODRAFTHELP: ページはまだ公開されていません
     ADDEDTODRAFTSHORT: 下書き
+    ALLOWCOMMENTS: コメントを許可しますか？
     APPEARSVIRTUALPAGES: "このコンテンツは{title}として仮想ページにおいても表示されます。"
     ARCHIVEDPAGESHORT: アーカイブされました
+    BUTTONARCHIVEDESC: 非公開にし、アーカイブに送られました
     BUTTONCANCELDRAFT: 草稿の編集内容を取り消します
     BUTTONCANCELDRAFTDESC: 草稿と前回公開されたページを削除します
     BUTTONPUBLISHED: 公開された
@@ -200,7 +315,10 @@ ja:
     DEFAULTABOUTTITLE: 私たちについて
     DEFAULTCONTACTTITLE: 連絡はこちらまで
     DEFAULTHOMETITLE: ホーム
+    DELETEDPAGEHELP: このページは今は公開されていません。
+    DELETEDPAGESHORT: 削除済
     DEPENDENT_NOTE: 以下のページでは、このページに依存します。　これには仮想ページ、リダイレクタページ、コンテンツのリンクを持つページが含まれています。
+    DESCRIPTION: 通常のコンテンツページ
     DependtPageColumnLinkType: リンクの種類
     DependtPageColumnURL: URL
     EDITANYONE: 誰でもCMSにログインが可能
@@ -238,17 +356,22 @@ ja:
     PARENTTYPE_SUBPAGE: 親ページの下にあるサブページ
     PERMISSION_GRANTACCESS_DESCRIPTION: コンテンツへのアクセス権限を編集
     PERMISSION_GRANTACCESS_HELP: "\"ページ\"セクションでページ固有のアクセス制限の設定を許可します。"
+    PLURALNAME: ページ
     PageTypNotAllowedOnRoot: "ページタイプ\"{type}\"は最上位層のページになることができません"
     PageTypeNotAllowed: "ページタイプ\"{type}\"はこの親ページの子になることができません"
+    REMOVEDFROMDRAFTHELP: ページが公開されていますが、下書きから削除されています
+    REMOVEDFROMDRAFTSHORT: 下書きから削除されました
     REMOVE_INSTALL_WARNING: "警告: セキュリティ上の理由から、SilverStripeのインストール先にあるinstall.phpを削除してください。"
     REORGANISE_DESCRIPTION: サイト構造を変更
     REORGANISE_HELP: サイトツリー内のページをドラッグ・アンド・ドロップで再編集
     SHOWINMENUS: メニューに表示しますか？
     SHOWINSEARCH: 検索に表示しますか？
+    SINGULARNAME: ページ
     TABBEHAVIOUR: 動作
     TABCONTENT: コンテンツ
     TABDEPENDENT: 依存ページ
     TOPLEVEL: "サイトの内容 (最上位層)"
+    TOPLEVELCREATORGROUPS: 最上位層のページ作成者
     URLSegment: URLセグメント
     VIEWERGROUPS: ビューアのグループ
     VIEW_ALL_DESCRIPTION: すべてのページを閲覧
@@ -261,6 +384,8 @@ ja:
     many_many_BackLinkTracking: リンク元を追跡
     many_many_ImageTracking: 画像へのリンクを追跡
     many_many_LinkTracking: リンクを追跡
+  SiteTreeFileExtension:
+    EDIT: 編集
   SiteTreeURLSegmentField:
     EMPTY: URLのセグメントを入力または中止をクリックする
     HelpChars: 特殊文字は自動的に変換されたか取り除かれました
@@ -273,7 +398,10 @@ ja:
     HAVEASKED: あなたは私達のサイトのコンテンツを閲覧するように求められています
   VirtualPage:
     CHOOSE: リンクされたページ
+    DESCRIPTION: 別のページのコンテンツを表示
     EditLink: 編集
     HEADER: これがバーチャルページです
     HEADERWITHLINK: "これは \"{title}\" ({link}) からコンテンツをコピーしている仮想ページです"
+    PLURALNAME: 仮想ページ
     PageTypNotAllowedOnRoot: "この仮想ページに対して元のページの種類{type}はルートレベルに配置されることが許可されていません。"
+    SINGULARNAME: 仮想ページ

--- a/lang/ko.yml
+++ b/lang/ko.yml
@@ -1,7 +1,41 @@
 ko:
+  AssetAdmin:
+    ADDFILES: "파일 추가"
+    ActionAdd: "폴더 추가"
+    AppCategoryArchive: 저장소
+    AppCategoryAudio: 오디오
+    AppCategoryDocument: 문서
+    AppCategoryFlash: Flash
+    AppCategoryImage: 이미지
+    AppCategoryVideo: 동영상
+    BackToFolder: "폴더로 이동"
+    CREATED: 날짜
+    CurrentFolderOnly: "이 폴더에 한정하시겠습니까?"
+    DetailsView: 상세보기
+    FILES: 파일
+    FILESYSTEMSYNC: "동기화 파일"
+    FILESYSTEMSYNCTITLE: "파일에 대한 CMS 데이터베이스 항목을 업데이트합니다. 예로, FTP 등 CMS 이외를 통해 파일을 업로드 한 경우에 유용합니다."
+    FROMTHEINTERNET: 인터넷으로부터
+    FROMYOURCOMPUTER: 컴퓨터로부터
+    Filetype: "파일 형식"
+    ListView: 목록보기
+    MENUTITLE: 파일
+    NEWFOLDER: "새 폴더"
+    SIZE: 사이즈
+    THUMBSDELETED: "{count}개의 사용하지 않은 이미지를 제거했습니다"
+    TreeView: 트리보기
+    Upload: 업로드
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "폴더를 삭제"
+  AssetAdmin_Tools:
+    FILTER: 필터
+  AssetAdmin_left_ss:
+    GO: Go
   AssetTableField:
     BACKLINKCOUNT: "다음에서 사용중 "
     PAGES: 페이지
+  BackLink_Button_ss:
+    Back: 돌아가기
   BrokenLinksReport:
     Any: 아무거나
     BROKENLINKS: "깨진 링크 보고서"
@@ -27,8 +61,14 @@ ko:
   CMSAddPageController:
     Title: "페이지 추가"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "%d페이지를 초안 사이트에서 삭제했지만, %d페이지의 삭제에 실패했습니다."
+    DELETED_PAGES: "공개사이트로부터 %d페이지를 삭제,  %d페이지는 삭제하지 못했습니다."
+    DELETE_DRAFT_PAGES: "초안 사이트에서 삭제"
+    DELETE_PAGES: "공개 사이트에서 삭제"
     PUBLISHED_PAGES: "%d페이지를 공개하고, %d페이지는 공개에서 실패했습니다."
     PUBLISH_PAGES: 공개
+  CMSFileAddController:
+    MENUTITLE: 파일
   CMSMain:
     ACCESS: "'{title}' 섹션으로 이동"
     ACCESS_HELP: "페이지 트리 및 내용을 포함 섹션의 열람을 허용합니다. 표시 및 편집 권한은 페이지의 특정 드롭 다운뿐만 아니라 독립적 인 \"콘텐츠의 권한\"을 통해 처리 할 수 있습니다."
@@ -39,8 +79,13 @@ ko:
     ChoosePageParentMode: "이 페이지를 만들 위치를 선택"
     ChoosePageType: "페이지 유형을 선택"
     Create: "새로 만들기"
+    DELETE: "초안 삭제"
+    DELETEFP: 삭제
+    DESCREMOVED: "그리고 {count} 파생"
     DUPLICATED: "'{title}'의 복제가 완료되었습니다."
     DUPLICATEDWITHCHILDREN: "'{title}' 와 그 하위에대한 복제가 완료되었습니다"
+    EditTree: "트리를 편집"
+    MENUTITLE: "페이지 편집"
     NEWPAGE: "새로운 {pagetype}"
     PAGENOTEXISTS: "이 페이지는 존재하지 않습니다"
     PAGETYPEANYOPT: 아무거나
@@ -48,22 +93,31 @@ ko:
     PUBALLFUN: " \"모두 공개\"기능"
     PUBPAGES: "완료: {count} 페이지를 공개했습니다"
     PageAdded: "페이지를 만드는 데 성공"
+    REMOVED: "이 전달 사이트에서'{title}'{description}을 제거했습니다."
     REMOVEDPAGE: "'{title}'을 공개된 사이트에서 제거했습니다"
     REMOVEDPAGEFROMDRAFT: "%s 초안 사이트에서 제거했습니다"
     RESTORED: "{title}를 복구했습니다"
     ROLLBACK: "이 버전으로 복원"
     ROLLEDBACKPUBv2: "공개된 버전으로 롤백되었습니다."
     ROLLEDBACKVERSIONv2: "#%d. 버전으로 롤백"
+    SAVE: 저장
     SAVEDRAFT: "임시 저장"
     TabContent: 컨텐츠
     TabHistory: 기록
     TabSettings: 설정
+  CMSMain_left_ss:
+    RESET: 리셋
   CMSPageAddController:
+    MENUTITLE: "페이지 추가"
     ParentMode_child: "다른 페이지 아래에 작성"
     ParentMode_top: "최상위 계층"
+  CMSPageEditController:
+    MENUTITLE: "페이지 편집"
   CMSPageHistoryController:
     COMPAREMODE: "비교 모드 (2개 선택)"
     COMPAREVERSIONS: "버전 비교"
+    COMPARINGVERSION: "{version1}과 {version2}을 비교하고 있습니다."
+    MENUTITLE: 기록
     REVERTTOTHISVERSION: "이 버전으로 복원"
     SHOWUNPUBLISHED: "공개되지 않은 버전을 표시"
     SHOWVERSION: "버전을 표시"
@@ -76,7 +130,10 @@ ko:
     PUBLISHER: 게시자
     UNKNOWN: "알 수 없슴"
     WHEN: 언제
+  CMSPageSettingsController:
+    MENUTITLE: "페이지 편집"
   CMSPagesController:
+    GalleryView: 갤러리보기
     ListView: 목록보기
     MENUTITLE: 페이지
     TreeView: 트리보기
@@ -84,7 +141,10 @@ ko:
     FILTER: 필터
   CMSSearch:
     FILTERDATEFROM: 시작일
+    FILTERDATEHEADING: 날짜
     FILTERDATETO: 종료일
+  CMSSettingsController:
+    MENUTITLE: 설정
   CMSSiteTreeFilter_Search:
     Title: "전체 페이지"
   ContentControl:
@@ -95,6 +155,7 @@ ko:
     CMS: CMS
     DRAFT: 초안
     DRAFTSITE: "초안 사이트"
+    DRAFT_SITE_ACCESS_RESTRICTION: "초안 또는 보관된 내용을보기 위하여 로그인하십시오. <a href=\"%s\"> 공개 사이트로 돌아가려면 여기를 클릭하십시오. </a>"
     Email: 이메일
     INSTALL_SUCCESS: "설치에 성공!"
     InstallFilesDeleted: "설치 관련 파일이 성공적으로 삭제되었습니다"
@@ -142,17 +203,40 @@ ko:
     DEFAULTERRORPAGETITLE: "페이지를 찾을 수 없습니다"
     DEFAULTSERVERERRORPAGECONTENT: "<p> 죄송합니다. 귀하의 요청을 처리하는 동안 문제가 발생했습니다. </p>"
     DEFAULTSERVERERRORPAGETITLE: "서버 오류"
+    DESCRIPTION: "각각의 오류 사례에 대해 사용자 지정 콘텐츠를 표시 (예: \"페이지가 없습니다\")"
+    ERRORFILEPROBLEM: "쓰기용 파일 \"{filename}\"을 열때 오류가 발생했습니다. 파일 권한을 확인하십시오."
+    SINGULARNAME: "오류 페이지"
+  Folder:
+    AddFolderButton: "폴더 추가"
+    DELETEUNUSEDTHUMBNAILS: "사용하지 않는 썸네일을 삭제"
+    UNUSEDFILESTITLE: "사용하지 않는 파일"
+    UNUSEDTHUMBNAILSTITLE: "사용되지 않는 썸네일"
+    UploadFilesButton: 업로드
+  LeftAndMain:
+    DELETED: 삭제됨.
+    PreviewButton: 미리보기
+    SAVEDUP: 저장됨.
+    SearchResults: "검색 결과"
+  Permission:
+    CMS_ACCESS_CATEGORY: "CMS에 액세스"
   Permissions:
     CONTENT_CATEGORY: "콘텐츠에 관한 권한"
     PERMISSIONS_CATEGORY: "역할과 접근권한"
   RedirectorPage:
+    DESCRIPTION: "다른 내부 페이지로 리디렉션"
     HASBEENSETUP: "다른곳으로 리다이렉트되지않고 리다이렉터 페이지가 설치되었습니다."
     HEADER: "이 페이지는 다른 페이지로 사용자들을 이동시킵니다."
     OTHERURL: "다른 웹사이트 URL"
     REDIRECTTO: 변경
     REDIRECTTOEXTERNAL: "다른 웹사이트"
     REDIRECTTOPAGE: "당신의 웹사이트의 페이지"
+    SINGULARNAME: "리디렉션 페이지"
     YOURPAGE: "당신의 웹사이트의 페이지"
+  ReportAdmin:
+    MENUTITLE: 보고서
+    ReportTitle: 제목
+  ReportAdminForm:
+    FILTERBY: "에 의해 필터"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "가상 페이지를 게시하기 위해 링크된 페이지를 공개합니다"
     VIRTUALPAGEWARNING: "이 페이지를 게시하기 위해 링크된 페이지를 선택하여 먼저 저장하십시오"
@@ -163,15 +247,38 @@ ko:
     SearchResults: "검색 결과"
   SideReport:
     BROKENFILES: "손상된 파일이 있는 페이지"
+    BROKENLINKS: "깨진 링크를 가지고 있는 페이지"
     BROKENREDIRECTORPAGES: "리디렉션된 페이지가 삭제됩니다"
     BROKENVIRTUALPAGES: "삭제된 페이지를 참조하는 가상 페이지"
     BrokenLinksGroupTitle: "깨진 링크에 관한 보고서"
     ContentGroupTitle: "콘텐츠의 보고서"
     EMPTYPAGES: "빈 페이지"
     LAST2WEEKS: "지난 2 주 이내에 편집된 페이지"
+    OtherGroupTitle: 기타
     ParameterLiveCheckbox: "라이브 사이트를 확인"
+    REPEMPTY: "{title} 보고서에 내용이 없습니다."
   SilverStripeNavigator:
     ARCHIVED: 보관됨
+  SilverStripeNavigatorLink:
+    ShareLink: "공유 링크"
+  SilverStripeNavigatorLinkl:
+    CloseLink: 닫기
+  SiteConfig:
+    DEFAULTTHEME: "(기본 테마를 사용)"
+    EDITHEADER: "이 사이트에서 페이지를 편집 할 수있는 사람"
+    EDIT_PERMISSION: "사이트 설정 관리"
+    EDIT_PERMISSION_HELP: "글로벌 액세스 설정 / 최상위 페이지의 사용 권한을 편집하는 기능."
+    PLURALNAME: "사이트 설정"
+    SINGULARNAME: "사이트 설정"
+    SITENAMEDEFAULT: "사이트 이름"
+    SITETAGLINE: "사이트의 태그라인/슬로건"
+    SITETITLE: "사이트 제목"
+    TABACCESS: "액세스 권한"
+    TABMAIN: 메인
+    TAGLINEDEFAULT: "사이트의 태그라인을 여기에 입력"
+    THEME: 테마
+    TOPLEVELCREATE: "누가 사이트의 루트에서 페이지를 생성할 수 있나?"
+    VIEWHEADER: "누가 이 사이트에서 페이지를 볼 수 있나?"
   SiteTree:
     ACCESSANYONE: 누구나
     ACCESSHEADER: "누가 이 페이지를 볼 수 있나?"
@@ -179,6 +286,7 @@ ko:
     ACCESSONLYTHESE: "이 사람들만 (목록에서 선택하기)"
     ADDEDTODRAFTHELP: "페이지는 아직 공개되지 않습니다"
     ADDEDTODRAFTSHORT: 초안
+    ALLOWCOMMENTS: "이 페이지에대한 댓글을 허용합니까?"
     APPEARSVIRTUALPAGES: "이 내용은 {title}섹션들에서의 가상 페이지상에서도 또한 보여집니다."
     BUTTONCANCELDRAFT: "초안의 편집 내용을 취소합니다"
     BUTTONCANCELDRAFTDESC: "초안을 삭제하고 현재 공개된 페이지로 돌아갑니다."
@@ -192,7 +300,10 @@ ko:
     DEFAULTABOUTTITLE: "회사 소개"
     DEFAULTCONTACTTITLE: 연락처
     DEFAULTHOMETITLE: 홈
+    DELETEDPAGEHELP: "이 문서는 더이상 공개되지 않습니다."
+    DELETEDPAGESHORT: 삭제됨
     DEPENDENT_NOTE: "다음 페이지들은 이 페이지에 의존합니다. 여기에는 가상 페이지 리디렉터 페이지 콘텐츠 링크가있는 페이지가 포함되어 있습니다."
+    DESCRIPTION: "일반 콘텐츠 페이지"
     DependtPageColumnLinkType: "링크 종류"
     DependtPageColumnURL: URL
     EDITANYONE: "CMS로 로그인하는 사용자"
@@ -230,17 +341,22 @@ ko:
     PARENTTYPE_SUBPAGE: "상위 페이지의 하위 페이지"
     PERMISSION_GRANTACCESS_DESCRIPTION: "콘텐츠에 대한 액세스 권한을 편집"
     PERMISSION_GRANTACCESS_HELP: " \"페이지\"섹션에서 페이지 별 접근 제한 설정을 허용합니다."
+    PLURALNAME: 페이지
     PageTypNotAllowedOnRoot: "페이지 타입 \"{type}\"는 최상위 계층의 페이지가 될 수 없습니다"
     PageTypeNotAllowed: "페이지 타입 \"{type}\"은 상위 페이지의 하위페이지가 될 수 없습니다"
+    REMOVEDFROMDRAFTHELP: "페이지가 공개되어 있지만 초안에서 삭제됩니다"
+    REMOVEDFROMDRAFTSHORT: "초안에서 삭제되었습니다"
     REMOVE_INSTALL_WARNING: "경고: 보안상의 이유로, SilverStripe의 대상에있는 install.php를 제거하십시오."
     REORGANISE_DESCRIPTION: "사이트 구조 변경"
     REORGANISE_HELP: "사이트 트리의 페이지를 드래그 앤 드롭으로 재편집"
     SHOWINMENUS: "메뉴에 표시 하시겠습니까?"
     SHOWINSEARCH: "검색에 ​​표시 하시겠습니까?"
+    SINGULARNAME: 페이지
     TABBEHAVIOUR: 동작
     TABCONTENT: 콘텐츠
     TABDEPENDENT: "의존 페이지"
     TOPLEVEL: "사이트의 내용 (최상위 계층)"
+    TOPLEVELCREATORGROUPS: "최상위 계층의 페이지 작성자"
     URLSegment: "URL 세그먼트"
     VIEWERGROUPS: "뷰어 그룹"
     VIEW_ALL_DESCRIPTION: "모든 페이지보기"
@@ -265,7 +381,9 @@ ko:
     HAVEASKED: "당신은 우리의 사이트의 콘텐츠를 보려고 요청했습니다."
   VirtualPage:
     CHOOSE: "링크된 페이지"
+    DESCRIPTION: "다른 페이지의 내용보기"
     EditLink: 편집
     HEADER: "가상 페이지입니다"
     HEADERWITHLINK: "이것은 \"{title}\"({link})에서 콘텐츠를 복사하는 가상 페이지입니다"
     PageTypNotAllowedOnRoot: "이 가상 페이지에 대해 원본 페이지 형식 {type}는 루트 레벨에 배치되는 것을 허용하지 않습니다."
+    SINGULARNAME: "가상 페이지"

--- a/lang/lt.yml
+++ b/lang/lt.yml
@@ -1,7 +1,41 @@
 lt:
+  AssetAdmin:
+    ADDFILES: "Įkelti bylas"
+    ActionAdd: "Naujas katalogas"
+    AppCategoryArchive: Archyvas
+    AppCategoryAudio: Garsas
+    AppCategoryDocument: Dokumentas
+    AppCategoryFlash: "Flash byla"
+    AppCategoryImage: Paveikslėlis
+    AppCategoryVideo: "Video byla"
+    BackToFolder: "Atgal į katalogą"
+    CREATED: Data
+    CurrentFolderOnly: "Apriboti iki šio katalogo?"
+    DetailsView: "Detalesnė informacija"
+    FILES: Bylos
+    FILESYSTEMSYNC: "Sinchronizuoti bylas"
+    FILESYSTEMSYNCTITLE: "Atnaujinti TVS bylų sarašo duomenų bazę. Naudotina, kai naujos bylos buvo įkeltos naudojant trečios šalies programinę įrangą, pvz. FTP."
+    FROMTHEINTERNET: "Iš interneto"
+    FROMYOURCOMPUTER: "Iš jūsų kompiuterio"
+    Filetype: "Bylos tipas"
+    ListView: "Sąrašo rodinys"
+    MENUTITLE: Bylos
+    NEWFOLDER: "Naujas katalogas"
+    SIZE: Dydis
+    THUMBSDELETED: "Ištrinta {count} nenaudojamų paveikslėlių miniatiūrų."
+    TreeView: "Medžio rodinys"
+    Upload: Įkelti
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Ištrinti katalogus"
+  AssetAdmin_Tools:
+    FILTER: Filtras
+  AssetAdmin_left_ss:
+    GO: Vykdyti
   AssetTableField:
     BACKLINKCOUNT: "Naudojama:"
     PAGES: puslapis(-iai)
+  BackLink_Button_ss:
+    Back: Atgal
   BrokenLinksReport:
     Any: "Bet kurias"
     BROKENLINKS: "Sugadintų nuorodų ataskaita"
@@ -27,10 +61,18 @@ lt:
   CMSAddPageController:
     Title: "Pridėti puslapį"
   CMSBatchActions:
+    ARCHIVE: Archyvuoti
+    ARCHIVED_PAGES: "Suarchyvuoti %d puslapiai"
+    DELETED_DRAFT_PAGES: "Iš juodraštinės svetainės ištrinti %d puslapiai, %d klaidų."
+    DELETED_PAGES: "Iš publikuojamos svetainės ištrinti %d puslapiai, %d klaidų."
+    DELETE_DRAFT_PAGES: "Ištrinti iš juodraščių"
+    DELETE_PAGES: "Trinti iš publikuojamos svetainės"
     PUBLISHED_PAGES: "Publikuoti %d puslapiai, %d klaidų."
     PUBLISH_PAGES: Publikuoti
     RESTORE: Atstatyti
     RESTORED_PAGES: "Atstatyti %d puslapiai"
+  CMSFileAddController:
+    MENUTITLE: Bylos
   CMSMain:
     ACCESS: "Priėjimas prie '{title}' dalies"
     ACCESS_HELP: "Leisti peržiūrėti svetainės medžio ir turinio skiltį. Peržiūros, bei redagavimo leidimai gali būti pakeisti per iškrentančius pasirinkimus ir per atskirus \"Turinio leidimai\"."
@@ -43,8 +85,13 @@ lt:
     ChoosePageParentMode: "Pasirinkite kur sukurti šį puslapį"
     ChoosePageType: "Pasirinkite puslapio tipą"
     Create: Sukurti
+    DELETE: "Ištrinti juodraštį"
+    DELETEFP: Ištrinti
+    DESCREMOVED: "ir {count} jam priklausantys"
     DUPLICATED: "Puslapis '{title}' kopijuotas sėkmingai"
     DUPLICATEDWITHCHILDREN: "Puslapis '{title}' , bei jo vaikai kopijuoti sėkmingai"
+    EditTree: "Redaguoti medį"
+    MENUTITLE: "Redaguoti puslapį"
     NEWPAGE: "Naujas {pagetype}"
     PAGENOTEXISTS: "Šis puslapis neegzistuoja"
     PAGETYPEANYOPT: "Bet koks"
@@ -52,6 +99,7 @@ lt:
     PUBALLFUN: "\"Publikuoti viską\" funkcionalumas"
     PUBPAGES: "Įvykdyta: Publikuoti {count} puslapiai"
     PageAdded: "Puslapis sėkmingai sukurtas"
+    REMOVED: "Iš publikuojamos svetainės ištrintas '{title}'{description}"
     REMOVEDPAGE: "Iš publikuojamos svetainės pašalintas '{title}'"
     REMOVEDPAGEFROMDRAFT: "'%s' pašalintas iš juodraštinės svetainės"
     RESTORED: "'{title}' atstatytas sėkmingai"
@@ -61,16 +109,24 @@ lt:
     ROLLBACK: "Grįžti prie šios versijos"
     ROLLEDBACKPUBv2: "Sugrįžta prie publikuotos versijos."
     ROLLEDBACKVERSIONv2: "Sugrįžta prie  #%d versijos."
+    SAVE: Išsaugoti
     SAVEDRAFT: "Išsaugoti juodraštį"
     TabContent: Turinys
     TabHistory: Istorija
     TabSettings: Nustatymai
+  CMSMain_left_ss:
+    RESET: Atstatyti
   CMSPageAddController:
+    MENUTITLE: "Pridėti puslapį"
     ParentMode_child: "Po kitu puslapiu"
     ParentMode_top: "Aukščiausias lygmuo"
+  CMSPageEditController:
+    MENUTITLE: "Redaguoti puslapį"
   CMSPageHistoryController:
     COMPAREMODE: "Palyginimo režimas (pasirinkite du)"
     COMPAREVERSIONS: "Palyginti versijas"
+    COMPARINGVERSION: "Lyginamos versijos {version1} ir {version2}."
+    MENUTITLE: Istorija
     REVERTTOTHISVERSION: "Palikti šią versiją"
     SHOWUNPUBLISHED: "Rodyti nepublikuojamas versijas"
     SHOWVERSION: "Rodyti versiją"
@@ -83,7 +139,10 @@ lt:
     PUBLISHER: Publikavo
     UNKNOWN: Nežinoma
     WHEN: Kada
+  CMSPageSettingsController:
+    MENUTITLE: "Redaguoti puslapį"
   CMSPagesController:
+    GalleryView: "Galerijos rodinys"
     ListView: "Sąrašo rodinys"
     MENUTITLE: Puslapiai
     TreeView: "Medžio rodinys"
@@ -93,8 +152,11 @@ lt:
     Title: "Publikuoti puslapiai"
   CMSSearch:
     FILTERDATEFROM: Nuo
+    FILTERDATEHEADING: Data
     FILTERDATETO: Iki
     PAGEFILTERDATEHEADING: Redaguota
+  CMSSettingsController:
+    MENUTITLE: Nustatymai
   CMSSiteTreeFilter_Search:
     Title: "Visi puslapiai"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -107,6 +169,7 @@ lt:
     CMS: TVS
     DRAFT: Juodraštis
     DRAFTSITE: "Juodraštinė svetainė"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Jūs turite prisijungti su savo TVS slaptažodžiu, kad galėtumėte peržiūrėti juodraščio arba archyvo turinį.<a href=\"%s\">Spauskite čia, norėdami grįžti į svetainę</a>."
     Email: "E. paštas"
     INSTALL_SUCCESS: "Įdiegta sėkmingai!"
     InstallFilesDeleted: "Įdiegimo bylos pašalintos sėkmingai."
@@ -156,17 +219,42 @@ lt:
     DEFAULTERRORPAGETITLE: "Puslapis nerastas"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Apgailestaujame, tačiau apdorojant užklausą įvyko klaida.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Tarnybinės stoties klaida"
+    DESCRIPTION: "Specifinis turinys, įvairioms klaidoms apibūdinti (Pvz.: \"Puslapis nerastas\")"
+    ERRORFILEPROBLEM: "Klaida atveriant rašymui bylą \"{filename}\". Prašome patikrinti bylų leidimus."
+    SINGULARNAME: "Klaidos puslapis"
+  File:
+    Title: Pavadinimas
+  Folder:
+    AddFolderButton: "Naujas katalogas"
+    DELETEUNUSEDTHUMBNAILS: "Ištrinti nenaudojamas paveikslėlių miniatūras"
+    UNUSEDFILESTITLE: "Nenaudojamos bylos"
+    UNUSEDTHUMBNAILSTITLE: "Nenaudojamos paveikslėlių miniatiūros"
+    UploadFilesButton: Įkelti
+  LeftAndMain:
+    DELETED: Ištrinta.
+    PreviewButton: Peržiūra
+    SAVEDUP: Išsaugota.
+    SearchResults: "Paieškos rezultatai"
+  Permission:
+    CMS_ACCESS_CATEGORY: "TVS prieiga"
   Permissions:
     CONTENT_CATEGORY: "Turinio teisės"
     PERMISSIONS_CATEGORY: "Rolės ir priėjimo leidimai"
   RedirectorPage:
+    DESCRIPTION: "Nukreipia į kitą vidinį puslapį"
     HASBEENSETUP: "Nukreipimo puslapis neturintis nukreipimo."
     HEADER: "Šis puslapis nukreips lankytojus į kitą puslapį"
     OTHERURL: "Kitos svetainės URL adresas"
     REDIRECTTO: "Nukreipti į"
     REDIRECTTOEXTERNAL: "Kita svetainė"
     REDIRECTTOPAGE: "Puslapis Jūsų svetainėje"
+    SINGULARNAME: "Nukreipimo puslapis"
     YOURPAGE: "Puslapį Jūsų svetainėje"
+  ReportAdmin:
+    MENUTITLE: Ataskaitos
+    ReportTitle: Antraštė
+  ReportAdminForm:
+    FILTERBY: "Filtruoti pagal"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Norėdami publikuoti virtualų puslapį, turite publikuoti prijungtą puslapį."
     VIRTUALPAGEWARNING: "Norėdami publikuoti šį puslapį, turite pasirinkti prijungtą puslapį."
@@ -177,15 +265,38 @@ lt:
     SearchResults: "Paieškos rezultatai"
   SideReport:
     BROKENFILES: "Puslapiai su sugadintomis bylomis"
+    BROKENLINKS: "Puslapiai su neveikiančiomis nuorodomis"
     BROKENREDIRECTORPAGES: "Nukreipiantieji puslapiai, kurie nukreipia į ištrintus puslapius"
     BROKENVIRTUALPAGES: "Virtualūs puslapiai, vedantys į ištrintus puslapius"
     BrokenLinksGroupTitle: "Neveikiančių nuorodų ataskaitos"
     ContentGroupTitle: "Turinio ataskaitos"
     EMPTYPAGES: "Puslapiai be turinio"
     LAST2WEEKS: "Paskutines 2 savaites keisti puslapiai"
+    OtherGroupTitle: Kita
     ParameterLiveCheckbox: "Patikrinti publikuojamą svetainę"
+    REPEMPTY: "{title} ataskaita yra tuščia."
   SilverStripeNavigator:
     ARCHIVED: Archyvuota
+  SilverStripeNavigatorLink:
+    ShareLink: "Dalintis nuoroda"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Uždaryti
+  SiteConfig:
+    DEFAULTTHEME: "(Naudoti temą pagal nutylėjimą)"
+    EDITHEADER: "Kas gali redaguoti šį puslapį?"
+    EDIT_PERMISSION: "Tvarkyti svetainės parametrus"
+    EDIT_PERMISSION_HELP: "Galimybė tvarkyti globalias priėjimo ir aukščiausio lygio puslapio teises."
+    PLURALNAME: "Svetainės konfigūracijos"
+    SINGULARNAME: "Svetainės konfigūracija"
+    SITENAMEDEFAULT: "Jūsų Svetainės Pavadinimas"
+    SITETAGLINE: "Svetainės šūkis"
+    SITETITLE: "Svetainės pavadinimas"
+    TABACCESS: Prieiga
+    TABMAIN: Pagrindinis
+    TAGLINEDEFAULT: "Čia gali būti Jūsų šūkis"
+    THEME: Tema
+    TOPLEVELCREATE: "Kas gali kurti puslapius pagrindiniame svetainės lygmenyje?"
+    VIEWHEADER: "Kas gali matyti puslapius šioje svetainėje?"
   SiteTree:
     ACCESSANYONE: "Bet kas"
     ACCESSHEADER: "Kas gali matyti šį puslapį?"
@@ -193,9 +304,11 @@ lt:
     ACCESSONLYTHESE: "Tik šie žmonės (pasirinkite iš sąrašo)"
     ADDEDTODRAFTHELP: "Puslapis dar nebuvo publikuotas"
     ADDEDTODRAFTSHORT: Juodraštis
+    ALLOWCOMMENTS: "Ar leisti komentarus šiame puslapyje?"
     APPEARSVIRTUALPAGES: "Šis turinys taip pat matomas ir virtualiuose puslapiuose {title} dalyse."
     ARCHIVEDPAGEHELP: "Puslapis pašalintas iš juodraščių ir publikuotų puslapių"
     ARCHIVEDPAGESHORT: Archyvuota
+    BUTTONARCHIVEDESC: "Nebepublikuoti ir suarchyvuoti"
     BUTTONCANCELDRAFT: "Atšaukti juodraščio pakeitimus"
     BUTTONCANCELDRAFTDESC: "Ištrinti juodraštį ir grįžti prie šiuo metu publikuojamo puslapio"
     BUTTONPUBLISHED: Publikuota
@@ -209,7 +322,10 @@ lt:
     DEFAULTCONTACTTITLE: Kontaktai
     DEFAULTHOMECONTENT: "<p>Sveiki atvykę į SilverStripe! Tai yra pagrindinis puslapis. Jūs galite redaguoti šį puslapį atsidarę <a href=\"admin/\">TVS</a>. Dabar galite naudotis <a href=\"http://doc.silverstripe.com\">programuotojų dokumentacija</a>, arba pradėti nuo <a href = \"http://doc.silverstripe.com/doku.php?id=tutorials\">SilverStripe pamokų.</a></p>"
     DEFAULTHOMETITLE: Pradžia
+    DELETEDPAGEHELP: "Puslapis nebepublikuojamas"
+    DELETEDPAGESHORT: Ištrinti
     DEPENDENT_NOTE: "Šiam puslapiui priklauso šie puslapiai. Tai gali būti virtualūs, nukreipiantys puslapiai, bei puslapiai, rodantys kitų puslapių turinį."
+    DESCRIPTION: "Standartinio turinio puslapis"
     DependtPageColumnLinkType: "Nuorodos tipas"
     DependtPageColumnURL: "URL adresas"
     EDITANYONE: "Bet kuris prisijungęs prie TVS"
@@ -247,17 +363,22 @@ lt:
     PARENTTYPE_SUBPAGE: "Po kitu puslapiu"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Valdyti turinio redagavimo teises"
     PERMISSION_GRANTACCESS_HELP: "Leisti nustatyti puslapiui galiojančias specifines teises, \"Puslapiai\" skiltyje."
+    PLURALNAME: Puslapiai
     PageTypNotAllowedOnRoot: "Puslapio tipas \"{type}\" neleidžiamas šakniniame lygmenyje"
     PageTypeNotAllowed: "Puslapio tipas \"{type}\" neleidžiamas po pasirinktu puslapiu"
+    REMOVEDFROMDRAFTHELP: "Puslapis buvo publikuotas, tačiau buvo ištrintas iš juodraščių."
+    REMOVEDFROMDRAFTSHORT: "Pašalinta iš juodraščių"
     REMOVE_INSTALL_WARNING: "Perspėjimas: Saugumo sumetimais Jūs turėtumėte pašalinti install.php bylą iš SilverStripe."
     REORGANISE_DESCRIPTION: "Gali keisti svetainės struktūrą"
     REORGANISE_HELP: "Perrikiuoti puslapius naudojant Tempti/Mesti būdą."
     SHOWINMENUS: "Ar įtraukti į rodomą meniu?"
     SHOWINSEARCH: "Rodyti paieškoje?"
+    SINGULARNAME: Puslapis
     TABBEHAVIOUR: Elgsena
     TABCONTENT: "Pagrindinis turinys"
     TABDEPENDENT: "Priklausantys puslapiai"
     TOPLEVEL: "Svetainės turinys (aukščiausias lygmuo)"
+    TOPLEVELCREATORGROUPS: "Aukščiausio lygmens kūrėjai"
     URLSegment: "URL dalis"
     VIEWERGROUPS: "Lankytojų grupės"
     VIEW_ALL_DESCRIPTION: "Gali peržiūrėti bet kurį puslapį svetainėje, apeinant puslapio peržiūros teises"
@@ -270,6 +391,9 @@ lt:
     many_many_BackLinkTracking: "Atgalinis stebėjimas"
     many_many_ImageTracking: "Paveikslėlių sekimas"
     many_many_LinkTracking: "Nuorodos sekimas"
+  SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Šiame sąraše rodomi visi puslapiai, kurie turi per teksto redaktorių prisegtų bylų."
+    EDIT: Redaguoti
   SiteTreeURLSegmentField:
     EMPTY: "Prašome įvesti URL dalį arba spauskite atšaukti"
     HelpChars: "Specialūs simboliai automatiškai pakeičiami arba pašalinami."
@@ -282,7 +406,9 @@ lt:
     HAVEASKED: "Jūs norėjote peržiūrėti turinį mūsų svetainėje "
   VirtualPage:
     CHOOSE: "Prijungtas puslapis"
+    DESCRIPTION: "Rodo kito puslapio turinį"
     EditLink: redaguoti
     HEADER: "Tai yra virtualus puslapis"
     HEADERWITHLINK: "Tai yra virtualus puslapis su turiniu iš puslapio \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Norimas puslapio tipas \"{type}\" neleidžiamas šiam virtualiam puslapiui šakniniame lygmenyje."
+    SINGULARNAME: "Virtualus puslapis"

--- a/lang/lv.yml
+++ b/lang/lv.yml
@@ -1,4 +1,8 @@
 lv:
+  CMSMain:
+    DELETE: "Dzēst no melnrakstu vietnes"
+    DELETEFP: "Dzēst no publicētās vietnes"
+    SAVE: Saglabāt
   ContentControl:
     NOTEWONTBESHOWN: "Piezīme: šī ziņa nebūs redzama Jūsu apmeklētājiem"
   ContentController:
@@ -37,6 +41,10 @@ lv:
     CODE: "Kļūdas kods"
     DEFAULTERRORPAGECONTENT: "<p>Atvainojiet, šķiet, ka lapa kurai mēģinat piekļūt neeksistē.</p><p>Lūdzu pārliecinieties par pareizrakstību URL, kuram vēlaties piekļūt400.</p>"
     DEFAULTERRORPAGETITLE: "Lapa nav atrasta"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Dzēst neizmantotos sīktēlus"
+    UNUSEDFILESTITLE: "Neizmanotie faili"
+    UNUSEDTHUMBNAILSTITLE: "Neizmantotie sīktēli"
   Permissions:
     CONTENT_CATEGORY: "Satura atļaujas"
     PERMISSIONS_CATEGORY: "Lomu un piekļuves atļaujas"
@@ -52,11 +60,30 @@ lv:
     GO: Aiziet
     SEARCH: Meklēt
     SearchResults: "Meklēšanas rezultāti"
+  SilverStripeNavigatorLink:
+    ShareLink: "Koplietot saiti"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Aizvērt
+  SiteConfig:
+    DEFAULTTHEME: "(Lietot noklusēto tēmu)"
+    EDITHEADER: "Kurš var labot šīs vietnes lapas?"
+    EDIT_PERMISSION: "Pārvaldīt vietnes konfigurāciju"
+    EDIT_PERMISSION_HELP: "Iespēja labot globālus piekļuves uzstādījumus/augstākā līmeņa lapu atļaujas."
+    SITENAMEDEFAULT: "Jūsu vietnes nosaukums"
+    SITETAGLINE: "Vietnes apakšvirsraksts/sauklis"
+    SITETITLE: "Vietnes nosaukums"
+    TABACCESS: "Piekļuves tiesības"
+    TABMAIN: Sākums
+    TAGLINEDEFAULT: Apakšvirsraksts/sauklis
+    THEME: Tēma
+    TOPLEVELCREATE: "Kurš drīkst izveidot lapas vietnes saknes direktorijā?"
+    VIEWHEADER: "Kurš drīkst aplūkot lapas šajā vietnē?"
   SiteTree:
     ACCESSANYONE: Ikviens
     ACCESSHEADER: "Kas drīkst aplūkot šo lapu?"
     ACCESSLOGGEDIN: "Pieslēgušies lietotāji"
     ACCESSONLYTHESE: "Tikai šie lietotāji (izvēlieties no saraksta)"
+    ALLOWCOMMENTS: "Atļaut pievienot komentārus šai lapai ?"
     BUTTONCANCELDRAFT: "Atcelt melnraksta izmaiņas"
     BUTTONCANCELDRAFTDESC: "Dzēst melnrakstu un atstatīt uz šobrīd publicēto lapu"
     BUTTONUNPUBLISH: Nebpublicēt
@@ -99,6 +126,7 @@ lv:
     TABCONTENT: Saturs
     TABDEPENDENT: "Atkarīgās lapas"
     TOPLEVEL: "Vietnes Saturs (Augšējais līmenis)"
+    TOPLEVELCREATORGROUPS: "Augstākā līmeņa veidotāji"
     URLSegment: "URL Segments"
     VIEWERGROUPS: "Skatītāju grupas"
     VIEW_ALL_DESCRIPTION: "Skatī jebkuru lapu"
@@ -111,3 +139,4 @@ lv:
     many_many_LinkTracking: "Saišu izsekošana"
   VirtualPage:
     HEADER: "Šī ir virtuāla lapa"
+    SINGULARNAME: "Virtuālās lapa"

--- a/lang/mi.yml
+++ b/lang/mi.yml
@@ -1,7 +1,41 @@
 mi:
+  AssetAdmin:
+    ADDFILES: "Tāpiri Kōnae"
+    ActionAdd: "Tāpiri kōpaki"
+    AppCategoryArchive: Puranga
+    AppCategoryAudio: Ororongo
+    AppCategoryDocument: Tuhinga
+    AppCategoryFlash: Kohiko
+    AppCategoryImage: Atahanga
+    AppCategoryVideo: Ataata
+    BackToFolder: "Hoki ki te kōpaki"
+    CREATED: Rā
+    CurrentFolderOnly: "Me whakatiki ki te kōpaki o nāianei?"
+    DetailsView: "Ngā Taipitopito"
+    FILES: "Ngā Kōnae"
+    FILESYSTEMSYNC: "Tukutahi kōnae"
+    FILESYSTEMSYNCTITLE: "Whakahōutia ngā tāurunga pātengi raraunga CMS o ngā kōnae kei te pūnaha kōnae. He whaitake ina tukuna atu he kōnae hou mai i waho i te CMS, hei tauira, mā te FTP."
+    FROMTHEINTERNET: "Mai i te Ipurangi"
+    FROMYOURCOMPUTER: "Mai i tō rorohiko"
+    Filetype: "Momo kōnae"
+    ListView: "Tirohanga Rārangi"
+    MENUTITLE: "Ngā Kōnae"
+    NEWFOLDER: KōpakiHōu
+    SIZE: Rahi
+    THUMBSDELETED: " Kua mukua e {count} ngā karakōnui kāore i whakamahia"
+    TreeView: "Tirohanga Rākau"
+    Upload: Tukuatu
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Muku kōpaki"
+  AssetAdmin_Tools:
+    FILTER: Tātari
+  AssetAdmin_left_ss:
+    GO: Haere
   AssetTableField:
     BACKLINKCOUNT: "I whakamahia i:"
     PAGES: "te/ngā whārangi"
+  BackLink_Button_ss:
+    Back: Hoki
   BrokenLinksReport:
     Any: "Ko tētahi"
     BROKENLINKS: "Pūrongo hono whati"
@@ -27,8 +61,14 @@ mi:
   CMSAddPageController:
     Title: "Tāpiri whārangi"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "Kua mukua e %d ngā whārangi i te pae hukihuki, %d i rahua"
+    DELETED_PAGES: "Kua mukua e %d ngā whārangi i te pae kua whakaputaina , %d i rahua"
+    DELETE_DRAFT_PAGES: "Mukua i te pae hukihuki"
+    DELETE_PAGES: "Mukua i te pae kua whakaputaina"
     PUBLISHED_PAGES: "%d ngā whārangi kua whakaputaina, %d i rahua"
     PUBLISH_PAGES: Whakaputa
+  CMSFileAddController:
+    MENUTITLE: "Ngā Kōnae"
   CMSMain:
     ACCESS: "Uru ki te wāhanga '{title}' "
     ACCESS_HELP: "Tukua kia kitea te wāhanga kei roto te whārangi rākau me ngā ihirangi. Ka taea te whakahaere i te tiro me te whakatika whakaaetanga mā ngā takaiho tauwhāiti-whārangi, mā \"Ngā whakaaetanga ihirangi\" motuhake hoki."
@@ -38,8 +78,13 @@ mi:
     ChoosePageParentMode: "Kōwhiri ki hea hangaia ai tēnei whārangi"
     ChoosePageType: "Kōwhiria te momo whārangi"
     Create: Hanga
+    DELETE: "Mukua te hukihuki"
+    DELETEFP: Muku
+    DESCREMOVED: "me ngā uri {count}"
     DUPLICATED: "I momoho te tārite i '{title}'"
     DUPLICATEDWITHCHILDREN: "I momoho te tārite i '{title}' me ngā tamariki"
+    EditTree: "Whakatika Rākau"
+    MENUTITLE: "Whakatika Whārangi"
     NEWPAGE: "{pagetype} hou"
     PAGENOTEXISTS: "KIāore tēnei whārangi e tīari"
     PAGETYPEANYOPT: "Ko tētahi"
@@ -47,22 +92,31 @@ mi:
     PUBALLFUN: "Te taumahinga \"Whakaputaina Katoatia\""
     PUBPAGES: "Kua oti: I whakaputaina ngā whārangi {count}"
     PageAdded: "I momoho te hanga whārangi"
+    REMOVED: "I mukua te '{title}'{description} i te pae ora"
     REMOVEDPAGE: "I tango te '{title}' i te pae kua whakaputaina"
     REMOVEDPAGEFROMDRAFT: "I tangohia a '%s' i te pae hukihuki"
     RESTORED: "I momoho te whakaora i te '{title}'"
     ROLLBACK: "Hoki whakamuri ki tēnei putanga."
     ROLLEDBACKPUBv2: "I hoki ki te tauira kua whakaputaina."
     ROLLEDBACKVERSIONv2: "I hoki ki te tauira #%d."
+    SAVE: tiakina
     SAVEDRAFT: "Tiaki hukihuki"
     TabContent: "Ngā Ihirangi"
     TabHistory: Hītori
     TabSettings: "Ngā Tautuhinga"
+  CMSMain_left_ss:
+    RESET: "Tautuhi Anō"
   CMSPageAddController:
+    MENUTITLE: "Tāpiri whārangi"
     ParentMode_child: "Kei raro i tētahi atu whārangi"
     ParentMode_top: "Taumata matua"
+  CMSPageEditController:
+    MENUTITLE: "Whakatika Whārangi"
   CMSPageHistoryController:
     COMPAREMODE: "Whakataurite Aratau (tīpakohia kia rua)"
     COMPAREVERSIONS: "Whakatauritea Ngā Putanga"
+    COMPARINGVERSION: "Whakataurite ana i te putanga {version1} me te putanga {version2}."
+    MENUTITLE: Hītori
     REVERTTOTHISVERSION: "Hoki ki tēnei putanga"
     SHOWUNPUBLISHED: "Whakaaturia ngā putanga kāore i whakaputaina"
     SHOWVERSION: "Whakaatu Putanga"
@@ -75,7 +129,10 @@ mi:
     PUBLISHER: Pūwhakaputa
     UNKNOWN: "Tē Mōhiotia"
     WHEN: Inahea
+  CMSPageSettingsController:
+    MENUTITLE: "Whakatika Whārangi"
   CMSPagesController:
+    GalleryView: "Tirohanga Taiwhanga"
     ListView: "Tirohanga Rārangi"
     MENUTITLE: "Ngā Whārangi"
     TreeView: "Tirohanga Rākau"
@@ -83,7 +140,10 @@ mi:
     FILTER: Tātari
   CMSSearch:
     FILTERDATEFROM: "Mai i"
+    FILTERDATEHEADING: Rā
     FILTERDATETO: Ki
+  CMSSettingsController:
+    MENUTITLE: "Ngā Tautuhinga"
   CMSSiteTreeFilter_Search:
     Title: "Ngā Whārangi Katoa"
   ContentControl:
@@ -94,6 +154,7 @@ mi:
     CMS: CMS
     DRAFT: Hukihuki
     DRAFTSITE: "Pae Hukihuki"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Me takiuru mā tō kupuhipa CMS hei tiro i te hukihuki, ngā ihirangi putumōhio rānei.  <a href=\"%s\">Pāwhiri ki konei kia hoki ki te pae kua whakaputaina.</a>"
     Email: Īmēra
     INSTALL_SUCCESS: "Kua oti pai te tāuta!"
     InstallFilesDeleted: "Kua momoho te muku i ngā kōnae tāuta"
@@ -139,17 +200,40 @@ mi:
     DEFAULTERRORPAGETITLE: "Kāore i kitea te whārangi"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Aroha noa,kua rarua te tuku i tō tono.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Hapa tūmau"
+    DESCRIPTION: "Ngā ihirangi ritenga mō ngā take hapa rerekē (hei tauira. \"Kāore i kitea te whārangi\")"
+    ERRORFILEPROBLEM: "Kua hapa te whakatuwhera i te kōnae \"{filename}\" mō te tuhituhi. Tirohia ngā whakaaetanga kōnae."
+    SINGULARNAME: "Whārangi Hapa"
+  Folder:
+    AddFolderButton: "Tāpiri kōpaki"
+    DELETEUNUSEDTHUMBNAILS: "Mukua ngā karakōnui kāore i whakamahia"
+    UNUSEDFILESTITLE: "Ngā kōnae kāore i whakamahia"
+    UNUSEDTHUMBNAILSTITLE: "Ngā karakōnui kāore i whakamahia"
+    UploadFilesButton: Tukuatu
+  LeftAndMain:
+    DELETED: "Kua Mukua"
+    PreviewButton: Arokite
+    SAVEDUP: "Kua Tiakina"
+    SearchResults: "Ngā Hua Rapu"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Uru CMS"
   Permissions:
     CONTENT_CATEGORY: "Whakaaetanga ihirangi"
     PERMISSIONS_CATEGORY: "Ngā tūranga me ngā whakaaetanga uru"
   RedirectorPage:
+    DESCRIPTION: "Ka tuku anō ki tētahi whārangi ā-roto kē"
     HASBEENSETUP: "Kua tatū he whārangi tuku anō me te kore whai wāhi hei tuku anō."
     HEADER: "Ka tuku anō tēnei whārangi i ngā kaiwhakamahi ki whārangi kē"
     OTHERURL: "Tētahi atu PRO paetukutuku"
     REDIRECTTO: "Tukua anō ki"
     REDIRECTTOEXTERNAL: "Tētahi atu paetukutuku"
     REDIRECTTOPAGE: "Whārangi kei tō paetukutuku"
+    SINGULARNAME: "Whārangi Tuku Anō"
     YOURPAGE: "Whārangi kei tō paetukutuku"
+  ReportAdmin:
+    MENUTITLE: "Ngā Pūrongo"
+    ReportTitle: Taitara
+  ReportAdminForm:
+    FILTERBY: "Tātari mā te"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Whakaputaina te whārangi kua honoa kia whakaputa ai i te whārangi mariko"
     VIRTUALPAGEWARNING: "Kōwhiria he whārangi kua honoa kātahi anō ka tiaki kia whakaputa ai i tēnei whārangi"
@@ -160,15 +244,38 @@ mi:
     SearchResults: "Ngā Hua Rapu"
   SideReport:
     BROKENFILES: "Ngā whārangi me ngā kōnae whati"
+    BROKENLINKS: "Ngā whārangi me ngā hononga whati"
     BROKENREDIRECTORPAGES: "Ngā WhārangiTukuAnō e tohu ana ki ngā whārangi kua mukua"
     BROKENVIRTUALPAGES: "Ngā WhārangiMariko e tohu ana ki ngā whārangi kua mukua"
     BrokenLinksGroupTitle: "Ngā pūrongo hononga whati"
     ContentGroupTitle: "Ngā pūrongo ihirangi"
     EMPTYPAGES: "Ngā whārangi me te kore ihirangi"
     LAST2WEEKS: "Ngā whārangi i whakatikatia i ngā wiki e 2 kua hipa"
+    OtherGroupTitle: "Ētahi atu"
     ParameterLiveCheckbox: "Tirohia te pae ora"
+    REPEMPTY: "Kua piako te pūrongo {title}."
   SilverStripeNavigator:
     ARCHIVED: "I putumōhiotia"
+  SilverStripeNavigatorLink:
+    ShareLink: "Tiritiri hono"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Kati
+  SiteConfig:
+    DEFAULTTHEME: "(Whakamahia te kaupapa taunoa)"
+    EDITHEADER: "Mā wai ngā whārangi i tēnei pae e whakatika?"
+    EDIT_PERMISSION: "Whakahaeretia te whirihora pae"
+    EDIT_PERMISSION_HELP: "Āhei ki te whakatika i ngā tautuhinga uru aowhānui/ngā whakaaetanga whārangi taumata matua."
+    PLURALNAME: "Ngā Whirihoranga Pae"
+    SINGULARNAME: "Whirihoranga Pae"
+    SITENAMEDEFAULT: "Tō Ingoa Pae"
+    SITETAGLINE: "Rārangi Tautuhinga Pae/Peha"
+    SITETITLE: "Taitara pae"
+    TABACCESS: Uru
+    TABMAIN: Matua
+    TAGLINEDEFAULT: "tō rārangi tautuhinga ki konei"
+    THEME: Kaupapa
+    TOPLEVELCREATE: "Mā wai he whārangi i te pūtake o te pae e hanga?"
+    VIEWHEADER: "Mā wai ngā whārangi i tēnei pae e tiro?"
   SiteTree:
     ACCESSANYONE: "Tētahi tangata"
     ACCESSHEADER: "Mā wai tēnei whārangi e tiro?"
@@ -176,6 +283,7 @@ mi:
     ACCESSONLYTHESE: "Ko ēnei tāngata anake (kōwhiria i te rārangi)"
     ADDEDTODRAFTHELP: "Kāore anō kia whakaputaina te whārangi"
     ADDEDTODRAFTSHORT: Hukihuki
+    ALLOWCOMMENTS: "Ka tukuna ngā tākupu i tēnei whārangi?"
     APPEARSVIRTUALPAGES: "Ka kitea hoki ēnei ihirangi i ngā whārangi mariko kei ngā wāhanga  {title}."
     BUTTONCANCELDRAFT: "Whakakorea ngā huringa hukihuki"
     BUTTONCANCELDRAFTDESC: "Mukua tō hukihuki, ka hoki ki te whārangi kua whakaputaina ināianei"
@@ -189,7 +297,10 @@ mi:
     DEFAULTABOUTTITLE: "Mō Mātou"
     DEFAULTCONTACTTITLE: "Whakapā Mai"
     DEFAULTHOMETITLE: Kāinga
+    DELETEDPAGEHELP: "Kua kore e whakaputaina te whārangi"
+    DELETEDPAGESHORT: "Kua Mukua"
     DEPENDENT_NOTE: "Ka whakawhirinaki ngā whārangi e whai ana ki tēnei whārangi. Kei roto nei ngā whārangi matua, ngā whārangi tuku anō me ngā whārangi whai hono ihirangi."
+    DESCRIPTION: "Whārangi ihirangi ahuwhānui"
     DependtPageColumnLinkType: "Momo hono"
     DependtPageColumnURL: PRO
     EDITANYONE: "Ngā tāngata e āhei ana te takiuru ki te CMS"
@@ -227,17 +338,22 @@ mi:
     PARENTTYPE_SUBPAGE: "Whārangi-iti kei raro i te whārangi matua"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Whakahaeretia ngā motika uru mō ngā ihirangi"
     PERMISSION_GRANTACCESS_HELP: "Tukuna te tautuhi rāhuitanga uru ki ētahi whārangi tauwhāiti i te wāhanga \"Ngā Whārangi\""
+    PLURALNAME: "Ngā Whārangi"
     PageTypNotAllowedOnRoot: "Kāore e whakaaetia te momo whārangi \"{type}\" i te taumata pūtake"
     PageTypeNotAllowed: "Kāore e whakaaetia te momo whārangi \"{type}\" hei tamaiti a tēnei whārangi matua"
+    REMOVEDFROMDRAFTHELP: "Kua whakaputaina te whārangi, engari kua mukua i te hukihuki"
+    REMOVEDFROMDRAFTSHORT: "I tangohia i te hukihuki"
     REMOVE_INSTALL_WARNING: "Whakatūpato: Me tango te install.php i tēnei tāuta SilverStripe nā ngā take haumaru."
     REORGANISE_DESCRIPTION: "Hurihia te hanganga pae"
     REORGANISE_HELP: "Whakaraupapatia ngā whārangi i te rākau pae mā te tō me te taka."
     SHOWINMENUS: "Ka kitea i ngā tahua?"
     SHOWINSEARCH: "Ka kitea i te rapu?"
+    SINGULARNAME: Whārangi
     TABBEHAVIOUR: Whanonga
     TABCONTENT: "Ngā Ihirangi Matua"
     TABDEPENDENT: "Ngā whārangi hāngai"
     TOPLEVEL: "Ngā Ihirangi Pae (Taumata Matua)"
+    TOPLEVELCREATORGROUPS: "Kaihanga taumata matua"
     URLSegment: "Wāhanga PRO"
     VIEWERGROUPS: "Ngā Ropū Kaitirotiro"
     VIEW_ALL_DESCRIPTION: "Tirohia tētahi whārangi"
@@ -262,7 +378,9 @@ mi:
     HAVEASKED: "Kua tono mai kia tirohia e koe ngā ihirangi o tā mātou pae i"
   VirtualPage:
     CHOOSE: "Whārangi kua honoa"
+    DESCRIPTION: "Ka whakaatu i ngā ihirangi o tētahi atu whārangi"
     EditLink: Whakatika
     HEADER: "He whārangi mariko tēnei"
     HEADERWITHLINK: "He whārangi mariko tēnei e tārua ihirangi ana i \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Kāore e whakaaetia te momo whārangi taketake \"{type}\" i te taumata pūtake o tēnei whārangi mariko"
+    SINGULARNAME: "Whārangi Mariko"

--- a/lang/ms.yml
+++ b/lang/ms.yml
@@ -4,6 +4,10 @@ ms:
     CODE: "Kod kesilapan"
     DEFAULTERRORPAGECONTENT: "<p>Minta maaf, rupa-rupanya anda ingin mencapai halaman yang tidak wujud</p><p>Sila semak ejaan URL yang anda ingin mencapai dan cuba semula</p>"
     DEFAULTERRORPAGETITLE: "Halaman tidak wujud"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Hapuskan thumbnail yang tidak digunakan"
+    UNUSEDFILESTITLE: "Fail-fail yang tidak digunakan"
+    UNUSEDTHUMBNAILSTITLE: "Thumbnail yang tidak digunakan"
   RedirectorPage:
     HASBEENSETUP: "Mukasurat pengalih destinasi dihasilkan tanpa menyatakan destinasi alihan."
     HEADER: "Mukasurat ini akan mengalih pengguna ke mukasurat lain"
@@ -17,6 +21,7 @@ ms:
     ACCESSHEADER: "Siapa yang boleh melihat mukasurat ini?"
     ACCESSLOGGEDIN: "Pengguna berdaftar masuk"
     ACCESSONLYTHESE: "Hanya pengguna berikut (pilih dari senarai)"
+    ALLOWCOMMENTS: "Terima komen untuk mukasurat ini?"
     BUTTONCANCELDRAFT: "Batalkan perubahan ke atas draf"
     BUTTONCANCELDRAFTDESC: "Hapus draf dan kembalikan ke mukasurat asal yang telah diterbitkan"
     BUTTONUNPUBLISH: "Tidak diterbitkan"
@@ -44,3 +49,4 @@ ms:
     has_one_Parent: "Halaman Induk"
   VirtualPage:
     HEADER: "Ini adalah mukasurat maya"
+    SINGULARNAME: "Halaman Maya"

--- a/lang/nb.yml
+++ b/lang/nb.yml
@@ -1,7 +1,41 @@
 nb:
+  AssetAdmin:
+    ADDFILES: "Legg til filer"
+    ActionAdd: "Legg til mappe"
+    AppCategoryArchive: Arkiv
+    AppCategoryAudio: Lyd
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Bilde
+    AppCategoryVideo: Video
+    BackToFolder: "Tilbake til mappe"
+    CREATED: Dato
+    CurrentFolderOnly: "Begrens til nåværende mappe"
+    DetailsView: Detaljer
+    FILES: Filer
+    FILESYSTEMSYNC: "Synkroniser filer"
+    FILESYSTEMSYNCTITLE: "Oppdaterer publiseringssystemets database av filene på nettstedet. Nyttig når nye filer har blitt lastet opp utenfor publiseringssystemet, for eksempel gjennom FTP."
+    FROMTHEINTERNET: "Fra internett"
+    FROMYOURCOMPUTER: "Fra din PC"
+    Filetype: Filtype
+    ListView: Listevisning
+    MENUTITLE: Filer
+    NEWFOLDER: "Ny mappe"
+    SIZE: Størrelse
+    THUMBSDELETED: "{count} ubrukte miniatyrbilder har blitt slettet."
+    TreeView: Trevisning
+    Upload: "Last opp"
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Slett mapper"
+  AssetAdmin_Tools:
+    FILTER: Filter
+  AssetAdmin_left_ss:
+    GO: Utfør
   AssetTableField:
     BACKLINKCOUNT: "Brukt på:"
     PAGES: side(r)
+  BackLink_Button_ss:
+    Back: Tilbake
   BrokenLinksReport:
     Any: "Hvilken som helst"
     BROKENLINKS: "Rapport over ødelagte lenker"
@@ -27,10 +61,18 @@ nb:
   CMSAddPageController:
     Title: "Legg til side"
   CMSBatchActions:
+    ARCHIVE: Arkiv
+    ARCHIVED_PAGES: "Arkiverte %d sider"
+    DELETED_DRAFT_PAGES: "Slettet %d sider fra utkastnettstedet, %d feilet."
+    DELETED_PAGES: "Slettet %d sider fra det publiserte nettstedet, %d feilet."
+    DELETE_DRAFT_PAGES: "Slett fra utkastnettsted."
+    DELETE_PAGES: "Slett fra publisert side"
     PUBLISHED_PAGES: "Publiserte %d sider, %d feilet."
     PUBLISH_PAGES: Publiser
     RESTORE: Gjenopprett
     RESTORED_PAGES: "Gjenopprettet %d sider"
+  CMSFileAddController:
+    MENUTITLE: Filer
   CMSMain:
     ACCESS: "Adgang til seksjon for '{title}'"
     ACCESS_HELP: "Lar deg se seksjonen som inneholder sidetreet og annet innhold. Tillatelser for å vise og redigere kan behandles gjennom sidespesifikke nedtrekkslister, så vel som  separate \"Innholdstillatelser\"."
@@ -43,8 +85,13 @@ nb:
     ChoosePageParentMode: "Velg hvor du vil opprette siden"
     ChoosePageType: "Velg sidetype"
     Create: Opprett
+    DELETE: "Slett utkast"
+    DELETEFP: Slett
+    DESCREMOVED: "og {count} undersider."
     DUPLICATED: "Vellykket duplisering av \"{title}\"."
     DUPLICATEDWITHCHILDREN: "Vellykket duplisering av \"{title}\" og undersider."
+    EditTree: "Rediger treet"
+    MENUTITLE: "Rediger side"
     NEWPAGE: "Ny {pagetype}"
     PAGENOTEXISTS: "Siden eksisterer ikke"
     PAGETYPEANYOPT: "Hvilken som helst"
@@ -52,6 +99,7 @@ nb:
     PUBALLFUN: "Funksjonalitet for \"Publiser alle\""
     PUBPAGES: "Ferdig: Publiserte {count} sider."
     PageAdded: "Siden ble opprettet."
+    REMOVED: "Slettet \"{title}\" {description} fra publisert nettsted."
     REMOVEDPAGE: "Fjernet \"{title}\" fra det publiserte nettstedet"
     REMOVEDPAGEFROMDRAFT: "Fjernet '%s'  fra utkastnettstedet"
     RESTORED: "Vellykket gjenoppretting av \"{title}\"."
@@ -61,16 +109,24 @@ nb:
     ROLLBACK: "Tilbakestill til denne versjonen"
     ROLLEDBACKPUBv2: "Tilbakestilte til den publiserte versjonen."
     ROLLEDBACKVERSIONv2: "Tilbakestile til versjon #%d."
+    SAVE: Lagre
     SAVEDRAFT: "Lagre utkast"
     TabContent: Innhold
     TabHistory: Historikk
     TabSettings: Innstillinger
+  CMSMain_left_ss:
+    RESET: Tilbakestill
   CMSPageAddController:
+    MENUTITLE: "Legg til side"
     ParentMode_child: "Under en annen side"
     ParentMode_top: Toppnivå
+  CMSPageEditController:
+    MENUTITLE: "Rediger side"
   CMSPageHistoryController:
     COMPAREMODE: "Sammenlign modus (velg to)"
     COMPAREVERSIONS: "Sammenlign versjoner"
+    COMPARINGVERSION: "Sammenligner versjon {version1} og {version2}."
+    MENUTITLE: Historie
     REVERTTOTHISVERSION: "Tilbakestill til denne versjonen"
     SHOWUNPUBLISHED: "Vis upubliserte versjoner"
     SHOWVERSION: "Vis versjon"
@@ -83,7 +139,10 @@ nb:
     PUBLISHER: Utgiver
     UNKNOWN: Ukjent
     WHEN: Når
+  CMSPageSettingsController:
+    MENUTITLE: "Rediger siden"
   CMSPagesController:
+    GalleryView: Gallerivisning
     ListView: Listevisning
     MENUTITLE: Sider
     TreeView: Trevisning
@@ -93,7 +152,10 @@ nb:
     Title: "Publiserte sider"
   CMSSearch:
     FILTERDATEFROM: Fra
+    FILTERDATEHEADING: Dato
     FILTERDATETO: Til
+  CMSSettingsController:
+    MENUTITLE: Innstillinger
   CMSSiteTreeFilter_Search:
     Title: "Alle sider"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -106,6 +168,7 @@ nb:
     CMS: Publiseringssystem
     DRAFT: Utkast
     DRAFTSITE: Utkastnettsted
+    DRAFT_SITE_ACCESS_RESTRICTION: "Du må være logget inn i kontrollpanelet for å se utkast eller det arkiverte innholdet. <a href=\"%s\">Klikk her for å gå tilbake til den publiserte versjonen.</a>"
     Email: Epost
     INSTALL_SUCCESS: "Installasjonen var vellykket!"
     InstallFilesDeleted: "Vellykket sletting av installasjonsfilene."
@@ -153,17 +216,40 @@ nb:
     DEFAULTERRORPAGETITLE: "Siden ble ikke funnet"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Beklager, det oppstod et problem under utføringen.</p>"
     DEFAULTSERVERERRORPAGETITLE: Serverfeil
+    DESCRIPTION: "Egendefinert innhold for forskjellige feilsituasjoner (f.eks \"Siden ble ikke funnet\")"
+    ERRORFILEPROBLEM: "Feil ved åpning av filen \"{filename}\". Vennligst sjekk filtillatelser."
+    SINGULARNAME: Feilside
+  Folder:
+    AddFolderButton: "Legg til mappe"
+    DELETEUNUSEDTHUMBNAILS: "Slett miniatyrbilder som ikke er i bruk"
+    UNUSEDFILESTITLE: "Filer ikke i bruk"
+    UNUSEDTHUMBNAILSTITLE: "Miniatyrbilder ikke i bruk"
+    UploadFilesButton: "Last opp"
+  LeftAndMain:
+    DELETED: Slettet.
+    PreviewButton: Forhåndsvisning
+    SAVEDUP: Lagret.
+    SearchResults: Søkeresultater
+  Permission:
+    CMS_ACCESS_CATEGORY: "Tilgang til publiseringssystemet"
   Permissions:
     CONTENT_CATEGORY: Innholdstillatelser
     PERMISSIONS_CATEGORY: "Rolle- og tilgangstillatelser"
   RedirectorPage:
+    DESCRIPTION: "Omdirigerer til en annen intern side"
     HASBEENSETUP: "En omdirigeringssside har blitt satt opp uten et mål å omdirigere til."
     HEADER: "Denne siden vil omdirigere brukere til en annen side"
     OTHERURL: "Nettadresse til et annet nettsted"
     REDIRECTTO: "Omdiriger til"
     REDIRECTTOEXTERNAL: "Et annet nettsted"
     REDIRECTTOPAGE: "En side på nettstedet"
+    SINGULARNAME: Omdirigeringsside
     YOURPAGE: "Side på ditt nettsted"
+  ReportAdmin:
+    MENUTITLE: Rapporter
+    ReportTitle: Tittel
+  ReportAdminForm:
+    FILTERBY: "Filtrer på "
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Vennligst publiser den lenkede siden for å publisere den virtuelle siden"
     VIRTUALPAGEWARNING: "Vennligst velg en lenket side og lagre først for å publisere denne siden"
@@ -174,15 +260,38 @@ nb:
     SearchResults: Søkeresultater
   SideReport:
     BROKENFILES: "Sider med ødelagte lenker"
+    BROKENLINKS: "Sider med ødelagte lenker"
     BROKENREDIRECTORPAGES: "Omdirigeringssider som peker til slettede sider"
     BROKENVIRTUALPAGES: "Virtuelle sider som peker til slettede sider"
     BrokenLinksGroupTitle: "Rapport over ødelagte lenker"
     ContentGroupTitle: Innholdsrapporter
     EMPTYPAGES: "Sider uten innhold"
     LAST2WEEKS: "Sider endret i de siste 2 ukene"
+    OtherGroupTitle: Andre
     ParameterLiveCheckbox: "Sjekk aktivt nettsted"
+    REPEMPTY: "Rapporten for {title} er tom."
   SilverStripeNavigator:
     ARCHIVED: Arkivert
+  SilverStripeNavigatorLink:
+    ShareLink: "Del lenke"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Lukk
+  SiteConfig:
+    DEFAULTTHEME: "(Bruk standard utseende)"
+    EDITHEADER: "Hvem kan redigere sider på dette nettstedet?"
+    EDIT_PERMISSION: "Behandle nettstedskonfigurasjon"
+    EDIT_PERMISSION_HELP: "Lar deg endre globale adgangsinnstillinger og tillatelser for toppnivåsider."
+    PLURALNAME: Nettstedskonfigurasjoner
+    SINGULARNAME: Nettstedskonfigurasjon
+    SITENAMEDEFAULT: Nettstedsnavn
+    SITETAGLINE: "Slagord for nettstedet"
+    SITETITLE: "Tittel for nettstedet"
+    TABACCESS: Tilgang
+    TABMAIN: Hovedinnstillinger
+    TAGLINEDEFAULT: "slagordet ditt her"
+    THEME: Utseende
+    TOPLEVELCREATE: "Hvem kan opprette toppnivåsider på dette nettstedet?"
+    VIEWHEADER: "Hvem kan se sider på dette nettstedet?"
   SiteTree:
     ACCESSANYONE: Alle
     ACCESSHEADER: "Hvem kan se denne siden?"
@@ -190,9 +299,11 @@ nb:
     ACCESSONLYTHESE: "Bare disse personene (velg fra listen)"
     ADDEDTODRAFTHELP: "Siden har ikke blitt publisert ennå"
     ADDEDTODRAFTSHORT: Utkast
+    ALLOWCOMMENTS: "Tillat kommentarer på denne siden?"
     APPEARSVIRTUALPAGES: "Dette innholdet opptrer også i {title}-seksjonene til de virtuelle sidene."
     ARCHIVEDPAGEHELP: "Siden er publisert og fjernet fra utkast"
     ARCHIVEDPAGESHORT: Arkivert
+    BUTTONARCHIVEDESC: "Avpubliser og arkiver"
     BUTTONCANCELDRAFT: "Avbryt endringer i utkast"
     BUTTONCANCELDRAFTDESC: "Slett utkast og gå tilbake til publisert versjon av denne siden"
     BUTTONPUBLISHED: Publisert
@@ -206,7 +317,10 @@ nb:
     DEFAULTCONTACTTITLE: "Kontakt oss"
     DEFAULTHOMECONTENT: "<p>Velkommen til SilverStripe! Dette er standard-forsiden. Du kan redigere denne ved å gå til <a href=\"admin/\">publiseringssystemet</a>.</p><p>Du kan nå gå til <a href=\"http://docs.silverstripe.org\">dokumentasjonen for utviklere</a>, eller begynne med <a href=\"http://www.silverstripe.org/learn/lessons\">SilverStripe-leksjoner</a>.</p>"
     DEFAULTHOMETITLE: Hjem
+    DELETEDPAGEHELP: "Siden er ikke lenger publisert."
+    DELETEDPAGESHORT: Slettet
     DEPENDENT_NOTE: "De følgende sidene avhenger av denne siden. Dette inkluderer virtuelle sider, omdirigeringssider og sider med innholdslenker."
+    DESCRIPTION: "Generisk innholdsside"
     DependtPageColumnLinkType: Lenketype
     DependtPageColumnURL: URL
     EDITANYONE: "Alle som kan logge inn til kontrollpanelet"
@@ -244,17 +358,22 @@ nb:
     PARENTTYPE_SUBPAGE: Underside
     PERMISSION_GRANTACCESS_DESCRIPTION: "Kontroller hvilke grupper som har tilgang til eller kan endre sidene"
     PERMISSION_GRANTACCESS_HELP: "Tillat tilordning av restriksjoner på sidenivå i sideseksjonen."
+    PLURALNAME: Sider
     PageTypNotAllowedOnRoot: "Sidetypen \"{type}\" er ikke tillatt på toppnivå"
     PageTypeNotAllowed: "Sidetypen \"{type}\" er ikke tillatt som underside til denne siden."
+    REMOVEDFROMDRAFTHELP: "Siden er publisert, men har blitt slettet fra utkastet."
+    REMOVEDFROMDRAFTSHORT: "Fjernet fra utkast"
     REMOVE_INSTALL_WARNING: "Advarsel: Du bør fjerne installer.php fra SilverStripe-installasjonen av sikkerhetsgrunner."
     REORGANISE_DESCRIPTION: "Endre nettstedets struktur"
     REORGANISE_HELP: "Omorganiser sidene i sidetreet ved hjelp av dra-og-slipp."
     SHOWINMENUS: "Vis i menyer?"
     SHOWINSEARCH: "Vis i søk?"
+    SINGULARNAME: Side
     TABBEHAVIOUR: Adferd
     TABCONTENT: Innhold
     TABDEPENDENT: Undersider
     TOPLEVEL: "Nettstedets innhold (toppnivå)"
+    TOPLEVELCREATORGROUPS: Toppnivåopprettere
     URLSegment: Adressesegment
     VIEWERGROUPS: Publikumsgrupper
     VIEW_ALL_DESCRIPTION: "Se på hvilken som helst side"
@@ -267,6 +386,9 @@ nb:
     many_many_BackLinkTracking: Referansesporing
     many_many_ImageTracking: Bildesporing
     many_many_LinkTracking: Lenkesporing
+  SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Denne liste viser alle sider med filer lastet opp gjennom en WYSIWYG-editor."
+    EDIT: Rediger
   SiteTreeURLSegmentField:
     EMPTY: "Vennligst skriv inn adressesegment eller trykk avbryt."
     HelpChars: "Spesialtegn blir automatisk konvertert eller fjernet."
@@ -279,7 +401,9 @@ nb:
     HAVEASKED: "Du har bedt om å vise innholdet på nettstedet vårt på "
   VirtualPage:
     CHOOSE: "Lenket side"
+    DESCRIPTION: "Viser innholdet av en annen side"
     EditLink: rediger
     HEADER: "Dette er en virituell side"
     HEADERWITHLINK: "Dette er en virtuell side som kopierer innhold fra \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Originaltypen \"{type}\" er ikke tillatt på toppnivået for denne virtuelle siden."
+    SINGULARNAME: "Virtuell side"

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -1,7 +1,41 @@
 nl:
+  AssetAdmin:
+    ADDFILES: "Bestanden toevoegen"
+    ActionAdd: "Map toevoegen"
+    AppCategoryArchive: Archiveren
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Document
+    AppCategoryFlash: Flash
+    AppCategoryImage: Afbeelding
+    AppCategoryVideo: Video
+    BackToFolder: "Terug naar map"
+    CREATED: Datum
+    CurrentFolderOnly: "Tot de huidige map beperken?"
+    DetailsView: Details
+    FILES: Bestanden
+    FILESYSTEMSYNC: "Bestanden synchroniseren"
+    FILESYSTEMSYNCTITLE: "Zoek naar nieuwe of verwijderde bestanden op de schijf, om de database van het CMS bij te werken. Dit is nodig als er bestanden via FTP (of andere wijze) zijn toegevoegd."
+    FROMTHEINTERNET: "Van het internet"
+    FROMYOURCOMPUTER: "Vanaf computer"
+    Filetype: Bestandstype
+    ListView: Lijstweergave
+    MENUTITLE: Bestanden
+    NEWFOLDER: "Nieuwe map"
+    SIZE: Omvang
+    THUMBSDELETED: "{count} ongebruikte miniatuurafbeeldingen zijn verwijderd"
+    TreeView: Boomstructuur
+    Upload: Uploaden
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Verwijder mappen"
+  AssetAdmin_Tools:
+    FILTER: Filter
+  AssetAdmin_left_ss:
+    GO: Doen
   AssetTableField:
     BACKLINKCOUNT: "Gebruikt op:"
     PAGES: pagina(s)
+  BackLink_Button_ss:
+    Back: Terug
   BrokenLinksReport:
     Any: Alles
     BROKENLINKS: "Rapport van verbroken links"
@@ -27,9 +61,16 @@ nl:
   CMSAddPageController:
     Title: "Pagina toevoegen"
   CMSBatchActions:
+    ARCHIVE: Archief
+    DELETED_DRAFT_PAGES: "%d pagina's van de concept-site verwijderd, %d mislukt"
+    DELETED_PAGES: "%d pagina's van de gepubliceerde site verwijderd, %d mislukt"
+    DELETE_DRAFT_PAGES: "Verwijder van concept site"
+    DELETE_PAGES: "Verwijder van gepubliceerde site"
     PUBLISHED_PAGES: "%d pagina's gepubliceerd"
     PUBLISH_PAGES: Publiceer
     RESTORE: Herstel
+  CMSFileAddController:
+    MENUTITLE: Bestanden
   CMSMain:
     ACCESS: "Toegang tot het '{title}' gedeelte"
     ACCESS_HELP: "Bevoegdheid om paginastructuur en inhoud te bekijken. Bekijk- en bewerkingstoestemmingen kunnen worden toegekend met pagina-specifieke menu's en het aparte \"Inhoudsmachtigingen\"."
@@ -41,8 +82,13 @@ nl:
     ChoosePageParentMode: "Kies waar u deze pagina wilt aanmaken"
     ChoosePageType: "Kies een pagina type"
     Create: Aanmaken
+    DELETE: "Verwijder concept"
+    DELETEFP: Verwijder
+    DESCREMOVED: "en {count} onderliggende"
     DUPLICATED: "'{title}' met succes gedupliceerd"
     DUPLICATEDWITHCHILDREN: "'{title}' en onderliggende items met succes gedupliceerd"
+    EditTree: "Paginastructuur aanpassen"
+    MENUTITLE: "Wijzig pagina"
     NEWPAGE: "Nieuwe {pagetype}"
     PAGENOTEXISTS: "Deze pagina bestaat niet"
     PAGETYPEANYOPT: Elke
@@ -50,22 +96,31 @@ nl:
     PUBALLFUN: "\"Publiceer alles\" functionaliteit"
     PUBPAGES: "Gereed: {count} pagina's gepubliceerd"
     PageAdded: "Pagina met succes aangemaakt"
+    REMOVED: "'{title}'{description} verwijderd van de live site"
     REMOVEDPAGE: "'{title}' is van de gepubliceerde site verwijderd"
     REMOVEDPAGEFROMDRAFT: "'%s' is verwijderd uit de concept site"
     RESTORED: "'{title}' is met succes hersteld"
     ROLLBACK: "Terugdraaien naar deze versie"
     ROLLEDBACKPUBv2: "Teruggedraaid naar gepubliceerde versie."
     ROLLEDBACKVERSIONv2: "Teruggedraaid naar versie #%d."
+    SAVE: Opslaan
     SAVEDRAFT: "Concept opslaan"
     TabContent: Inhoud
     TabHistory: Geschiedenis
     TabSettings: Instellingen
+  CMSMain_left_ss:
+    RESET: Reset
   CMSPageAddController:
+    MENUTITLE: "Pagina toevoegen"
     ParentMode_child: "Onder een andere pagina"
     ParentMode_top: "Hoogste niveau"
+  CMSPageEditController:
+    MENUTITLE: "Wijzig pagina"
   CMSPageHistoryController:
     COMPAREMODE: "Vergelijken (selecteer 2)"
     COMPAREVERSIONS: "Vergelijk versies"
+    COMPARINGVERSION: "U vergelijkt versie {version1} en {version2}."
+    MENUTITLE: Geschiedenis
     REVERTTOTHISVERSION: "Deze versie terugzetten"
     SHOWUNPUBLISHED: "Toon nog niet gepubliceerde versies"
     SHOWVERSION: "Toon versie"
@@ -78,7 +133,10 @@ nl:
     PUBLISHER: Publiceerder
     UNKNOWN: Onbekend
     WHEN: Wanneer
+  CMSPageSettingsController:
+    MENUTITLE: "Wijzig pagina"
   CMSPagesController:
+    GalleryView: "Album weergave"
     ListView: Lijstweergave
     MENUTITLE: Pagina's
     TreeView: "Hierarchische weergave"
@@ -86,7 +144,10 @@ nl:
     FILTER: Filteren
   CMSSearch:
     FILTERDATEFROM: Van
+    FILTERDATEHEADING: Datum
     FILTERDATETO: Tot
+  CMSSettingsController:
+    MENUTITLE: Instellingen
   CMSSiteTreeFilter_Search:
     Title: "Alle pagina's"
   ContentControl:
@@ -97,6 +158,7 @@ nl:
     CMS: CMS
     DRAFT: Concept
     DRAFTSITE: "Concept site"
+    DRAFT_SITE_ACCESS_RESTRICTION: "U moet inloggen met uw CMS wachtwoord om die inhoud te kunnen zien. <a href=\"%s\">Klik hier</a> om terug te keren naar de gepubliceerde site."
     Email: E-mail
     INSTALL_SUCCESS: "Installatie voltooid!"
     InstallFilesDeleted: "De installatiebestanden zijn met succes verwijderd."
@@ -144,17 +206,42 @@ nl:
     DEFAULTERRORPAGETITLE: "Pagina niet gevonden"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Helaas, er was een probleem bij het verwerken van je verzoek.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Probleem met de server"
+    DESCRIPTION: "Aangepaste tekst voor verschillende foutmeldingen (bv. \"Pagina niet gevonden\")"
+    ERRORFILEPROBLEM: "Fout: \"{filename}\" kan niet geopend worden om te schrijven. Controleer alstublieft de bestandspermissies."
+    SINGULARNAME: Foutpagina
+  File:
+    Title: Titel
+  Folder:
+    AddFolderButton: "Map toevoegen"
+    DELETEUNUSEDTHUMBNAILS: "Verwijder ongebruikte miniatuurafbeeldingen"
+    UNUSEDFILESTITLE: "Ongebruikte bestanden"
+    UNUSEDTHUMBNAILSTITLE: "Ongebruikte miniatuurafbeeldingen"
+    UploadFilesButton: Uploaden
+  LeftAndMain:
+    DELETED: Verwijderd.
+    PreviewButton: "Voorbeeld bekijken"
+    SAVEDUP: Opgeslagen.
+    SearchResults: Zoekresultaten
+  Permission:
+    CMS_ACCESS_CATEGORY: "CMS toegang"
   Permissions:
     CONTENT_CATEGORY: Inhoudsrechten
     PERMISSIONS_CATEGORY: "Rollen en toegangsrechten"
   RedirectorPage:
+    DESCRIPTION: "Verwijst naar een andere pagina op deze site"
     HASBEENSETUP: "Er is een verwijspagina opgezet zonder ergens naar te verwijzen."
     HEADER: "Deze pagina zal gebruikers naar een andere pagina doorsturen (redirect)"
     OTHERURL: "Andere website URL"
     REDIRECTTO: "Doorverwijzen naar"
     REDIRECTTOEXTERNAL: "Een andere website"
     REDIRECTTOPAGE: "Een pagina op deze website"
+    SINGULARNAME: Verwijzingspagina
     YOURPAGE: "Pagina op deze website"
+  ReportAdmin:
+    MENUTITLE: Rapporten
+    ReportTitle: Titel
+  ReportAdminForm:
+    FILTERBY: "Filter op"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "U dient eerst de gekoppelde pagina te publiceren voordat u de virtuele pagina publiceert."
     VIRTUALPAGEWARNING: "U dient eerst een gekoppelde pagina te selecteren en op te slaan voordat u deze pagina kunt publiceren."
@@ -165,15 +252,22 @@ nl:
     SearchResults: Zoekresultaten
   SideReport:
     BROKENFILES: "Pagina's met verbroken bestanden"
+    BROKENLINKS: "Pagina's met verbroken links"
     BROKENREDIRECTORPAGES: "Verwijzingspagina's die naar verwijderde pagina's verwijzen"
     BROKENVIRTUALPAGES: "Virtuele pagina's die naar verwijderde pagina's verwijzen"
     BrokenLinksGroupTitle: "Rapport van verbroken links"
     ContentGroupTitle: Inhoudsrapporten
     EMPTYPAGES: "Lege pagina's"
     LAST2WEEKS: "Pagina's gewijzigd in de laatste twee weken"
+    OtherGroupTitle: Andere
     ParameterLiveCheckbox: "Controleer gepubliceerde site"
+    REPEMPTY: "Het {title} rapport is leeg."
   SilverStripeNavigator:
     ARCHIVED: Gearchiveerd
+  SilverStripeNavigatorLink:
+    ShareLink: "Deel een link"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Sluiten
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Pagina toevoegen"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -187,6 +281,22 @@ nl:
   SilverStripe\CMS\Model\VirtualPage:
     PLURALNAME: "Virtuele pagina's"
     SINGULARNAME: "Virtuele pagina"
+  SiteConfig:
+    DEFAULTTHEME: "(Gebruik standaard thema)"
+    EDITHEADER: "Wie kan pagina's op de site wijzigen?"
+    EDIT_PERMISSION: "Site configuratie beheren"
+    EDIT_PERMISSION_HELP: "Bevoegdheid om globale toegangsinstellingen/hoogste niveau pagina rechten te bewerken."
+    PLURALNAME: "Website instellingen"
+    SINGULARNAME: "Website instellingen"
+    SITENAMEDEFAULT: "Jouw Site Naam"
+    SITETAGLINE: "Site Slagzin/Slogan"
+    SITETITLE: "Site Titel"
+    TABACCESS: Toegang
+    TABMAIN: Hoofd
+    TAGLINEDEFAULT: "jouw slagzin hier"
+    THEME: Thema
+    TOPLEVELCREATE: "Wie kan pagina's op het hoogste niveau van de site aanmaken?"
+    VIEWHEADER: "Wie kan pagina's op de site bekijken?"
   SiteTree:
     ACCESSANYONE: Iedereen
     ACCESSHEADER: "Wie kan deze pagina bekijken?"
@@ -194,6 +304,7 @@ nl:
     ACCESSONLYTHESE: "Alleen deze gebruikers (kies uit de lijst)"
     ADDEDTODRAFTHELP: "Pagina is nog niet gepubliceerd"
     ADDEDTODRAFTSHORT: Concept
+    ALLOWCOMMENTS: "Commentaar toestaan op deze pagina?"
     APPEARSVIRTUALPAGES: "Deze inhoud verschijnt ook op de virtuele pagina's in de {title} gedeeltes."
     BUTTONCANCELDRAFT: "Annuleer veranderingen op dit concept"
     BUTTONCANCELDRAFTDESC: "Verwijder het concept en zet de gepubliceerde pagina terug"
@@ -207,7 +318,10 @@ nl:
     DEFAULTABOUTTITLE: "Over Ons"
     DEFAULTCONTACTTITLE: Contact
     DEFAULTHOMETITLE: Home
+    DELETEDPAGEHELP: "Deze pagina is niet langer gepubliceerd"
+    DELETEDPAGESHORT: Verwijderd
     DEPENDENT_NOTE: "De volgende pagina's zijn afhankelijk van deze pagina. Hieronder vallen virtuele pagina's, verwijzingspagina's en pagina's met links in hun inhoud."
+    DESCRIPTION: "Algemene inhoud pagina"
     DependtPageColumnLinkType: Linktype
     DependtPageColumnURL: URL
     EDITANYONE: "Iedereen die kan inloggen in het CMS"
@@ -245,17 +359,22 @@ nl:
     PARENTTYPE_SUBPAGE: "Subpagina onder een bovenliggende pagina"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Beheer toegangsrechten voor inhoud"
     PERMISSION_GRANTACCESS_HELP: "Bevoegdheid om pagina specifieke toegangsrechten in de \"Pagina's\" sectie te wijzigen."
+    PLURALNAME: Pagina's
     PageTypNotAllowedOnRoot: "Paginatype \"{type}\" is niet toegestaan op het hoogste niveau"
     PageTypeNotAllowed: "Pagina type \"{type}\" mag niet ondergeschikt zijn aan deze bovenliggende pagina"
+    REMOVEDFROMDRAFTHELP: "Deze pagina is gepubliceerd, maar verwijderd uit de concept site"
+    REMOVEDFROMDRAFTSHORT: "Verwijderd van de concept site"
     REMOVE_INSTALL_WARNING: "Let op: Het is veiliger om het bestand install.php uit deze SilverStripe installatie te verwijderen"
     REORGANISE_DESCRIPTION: "Site structuur wijzigen"
     REORGANISE_HELP: "Pas de volgorde van de pagina's aan door te verslepen."
     SHOWINMENUS: "Weergeven in menu's?"
     SHOWINSEARCH: "Weergeven in zoeken?"
+    SINGULARNAME: Pagina
     TABBEHAVIOUR: Gedrag
     TABCONTENT: Hoofdinhoud
     TABDEPENDENT: "Afhankelijke pagina's"
     TOPLEVEL: "Site inhoud (hoogste niveau)"
+    TOPLEVELCREATORGROUPS: "Hoogste niveau auteurs"
     URLSegment: "URL segment"
     VIEWERGROUPS: Bekijkersgroepen
     VIEW_ALL_DESCRIPTION: "Kan iedere pagina op de website bekijken, ongeacht de specifieke pagina instelling"
@@ -268,6 +387,8 @@ nl:
     many_many_BackLinkTracking: "Backlinks traceren"
     many_many_ImageTracking: "Afbeeldingen traceren"
     many_many_LinkTracking: "Links traceren"
+  SiteTreeFileExtension:
+    EDIT: Bewerken
   SiteTreeURLSegmentField:
     EMPTY: "Vul een URL segment in of klik op annuleren"
     HelpChars: "Speciale tekens worden automatische omgezet of verwijderd."
@@ -280,7 +401,10 @@ nl:
     HAVEASKED: "U heeft gevraagd de inhoud van onze site te bekijken op"
   VirtualPage:
     CHOOSE: "Gekoppelde pagina"
+    DESCRIPTION: "Geeft de inhoud van een andere pagina weer"
     EditLink: wijzigen
     HEADER: "Dit is een virtuele pagina"
     HEADERWITHLINK: "Dit is een virtuele pagina met de inhoud van \"{title}\" ({link})"
+    PLURALNAME: "Virtuele pagina's"
     PageTypNotAllowedOnRoot: "Voor deze virtuele pagina is het originele paginatype \"{type}\" niet toegestaan op het hoogste niveau."
+    SINGULARNAME: "Virtuele pagina"

--- a/lang/pl.yml
+++ b/lang/pl.yml
@@ -1,7 +1,41 @@
 pl:
+  AssetAdmin:
+    ADDFILES: "Dodaj pliki"
+    ActionAdd: "Dodaj katalog"
+    AppCategoryArchive: Archiwum
+    AppCategoryAudio: Dźwięk
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Obraz
+    AppCategoryVideo: Wideo
+    BackToFolder: "Wróć do katalogu"
+    CREATED: Data
+    CurrentFolderOnly: "Ograniczyć do bieżącego katalogu?"
+    DetailsView: Szczegóły
+    FILES: Pliki
+    FILESYSTEMSYNC: "Synchronizuj pliki"
+    FILESYSTEMSYNCTITLE: "Uaktualnia bazę plików. Przydatne, gdy nowe pliki zostały przesłane poza systemem CMS, np. przez FTP."
+    FROMTHEINTERNET: "Z internetu"
+    FROMYOURCOMPUTER: "Z komputera"
+    Filetype: "Typ pliku"
+    ListView: "Widok listy"
+    MENUTITLE: Pliki
+    NEWFOLDER: "Nowy katalog"
+    SIZE: Rozmiar
+    THUMBSDELETED: "{count} nieuzywane miniatury zostały usunięte"
+    TreeView: "Widok drzewa"
+    Upload: Prześlij
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Usuń foldery"
+  AssetAdmin_Tools:
+    FILTER: Filtr
+  AssetAdmin_left_ss:
+    GO: Przejdź
   AssetTableField:
     BACKLINKCOUNT: "Używany na:"
     PAGES: stron(y)
+  BackLink_Button_ss:
+    Back: Wstecz
   BrokenLinksReport:
     Any: Jakikolwiek
     BROKENLINKS: "Raport uszkodzonych linków"
@@ -27,10 +61,18 @@ pl:
   CMSAddPageController:
     Title: "Dodaj stronę"
   CMSBatchActions:
+    ARCHIVE: Archiwizuj
+    ARCHIVED_PAGES: "Zarchiwizowano %d stron"
+    DELETED_DRAFT_PAGES: "Usunięto %d stron ze szkiców, %d nie powiodło się"
+    DELETED_PAGES: "Usunięto %d stron z opublikowanych, %d nie powiodło się"
+    DELETE_DRAFT_PAGES: "Usuń ze szkicu witryny"
+    DELETE_PAGES: "Usuń z opublikowanej witryny"
     PUBLISHED_PAGES: "Opublikowano %d stron, %d się nie powiodło"
     PUBLISH_PAGES: Opublikuj
     RESTORE: Przywróć
     RESTORED_PAGES: "Przywrócono %d stron"
+  CMSFileAddController:
+    MENUTITLE: Pliki
   CMSMain:
     ACCESS: "Dostęp do sekcji '{title}'"
     ACCESS_HELP: "Zezwala na oglądanie sekcji zawierających drzewo stron oraz treść. Prawo Przeglądaj i edytuj może być obsługiwane przez pola wyboru dostępne na stronach oraz poprzez zakładkę uprawnień."
@@ -42,8 +84,13 @@ pl:
     ChoosePageParentMode: "Wybierz gdzie chcesz utworzyć tę stronę"
     ChoosePageType: "Wybierz rodzaj strony"
     Create: Utwórz
+    DELETE: "Usuń szkic"
+    DELETEFP: "Usuń z opublikowanej witryny"
+    DESCREMOVED: "i {count} potomków"
     DUPLICATED: "Duplikowanie '{title}' zakończone powodzeniem"
     DUPLICATEDWITHCHILDREN: "Duplikowanie '{title}' oraz podstron zakończone powodzeniem"
+    EditTree: "Edytuj drzewko"
+    MENUTITLE: "Edytuj stronę"
     NEWPAGE: "Nowa {pagetype}"
     PAGENOTEXISTS: "Ta strona nie istnieje"
     PAGETYPEANYOPT: Jakikolwiek
@@ -51,6 +98,7 @@ pl:
     PUBALLFUN: "\"Opublikuj wszystko\""
     PUBPAGES: "Zrobiono:  Opublikowano {count} stron"
     PageAdded: "Pomyślnie utworzono stronę"
+    REMOVED: "Usunięto '{title}'{description} z witryny"
     REMOVEDPAGE: "Usunięto '{title}' z opublikowanej witryny"
     REMOVEDPAGEFROMDRAFT: "'%s' usunięto ze szkiców"
     RESTORED: "Pomyślnie przywrócono '{title}'"
@@ -58,16 +106,24 @@ pl:
     ROLLBACK: "Wróć do tej wersji"
     ROLLEDBACKPUBv2: "Przywrócono opublikowaną wersję"
     ROLLEDBACKVERSIONv2: "Przywrócono wersję #%d."
+    SAVE: Zapisz
     SAVEDRAFT: "Zapisz szkic"
     TabContent: Zawartość
     TabHistory: Historia
     TabSettings: Opcje
+  CMSMain_left_ss:
+    RESET: Resetuj
   CMSPageAddController:
+    MENUTITLE: "Dodaj stronę"
     ParentMode_child: "Pod inną stroną"
     ParentMode_top: "Główny poziom"
+  CMSPageEditController:
+    MENUTITLE: "Edytuj stronę"
   CMSPageHistoryController:
     COMPAREMODE: "Tryb porównywania (wybierz dwie)"
     COMPAREVERSIONS: "Porównaj wersje"
+    COMPARINGVERSION: "Porównanie wersji {version1} i {version2}."
+    MENUTITLE: Historia
     REVERTTOTHISVERSION: "Wróć do tej wersji"
     SHOWUNPUBLISHED: "Pokaż nieopublikowane wersje"
     SHOWVERSION: "Pokaż wersję"
@@ -80,7 +136,10 @@ pl:
     PUBLISHER: Edytor
     UNKNOWN: Nieznany
     WHEN: Kiedy
+  CMSPageSettingsController:
+    MENUTITLE: "Edytuj stronę"
   CMSPagesController:
+    GalleryView: "Tryb galerii"
     ListView: "Widok listy"
     MENUTITLE: Strony
     TreeView: "Widok drzewa"
@@ -90,8 +149,11 @@ pl:
     Title: "Opublikowane strony"
   CMSSearch:
     FILTERDATEFROM: Od
+    FILTERDATEHEADING: Data
     FILTERDATETO: Do
     PAGEFILTERDATEHEADING: "Ostatnio edytowane"
+  CMSSettingsController:
+    MENUTITLE: Ustawienia
   CMSSiteTreeFilter_Search:
     Title: "Wszystkie strony"
   ContentControl:
@@ -102,6 +164,7 @@ pl:
     CMS: "System Zarządzania Treścią"
     DRAFT: Szkic
     DRAFTSITE: "Szkic witryny"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Musisz zalogować się za pomocą swojego hasła do CMSa, aby obejrzeć nieopublikowaną i zarchiwizowaną treść. <a href=\"%s\">Kliknij tutaj aby powrócić do opublikowanej strony.</a>"
     Email: "Adres e-mail"
     INSTALL_SUCCESS: "Instalacja przebiegła pomyślnie"
     InstallFilesDeleted: "Pliki instalacyjne zostały pomyślnie usunięte"
@@ -149,17 +212,42 @@ pl:
     DEFAULTERRORPAGETITLE: "Nie znaleziono strony"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Wystąpił problem z obsługą Twojego żądania.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Błąd serwera"
+    DESCRIPTION: "Własna zawartość dla różnych błędów (np. \"Strona nie została znaleziona\")"
+    ERRORFILEPROBLEM: "Błąd podczas otwierania pliku \"{filename}\". Proszę sprawdzić uprawnienia do plików."
+    SINGULARNAME: "Strona błędów"
+  File:
+    Title: Tytuł
+  Folder:
+    AddFolderButton: "Dodaj katalog"
+    DELETEUNUSEDTHUMBNAILS: "Usuń nieużywane miniatury"
+    UNUSEDFILESTITLE: "Nieużywane pliki"
+    UNUSEDTHUMBNAILSTITLE: "Nieużywane miniatury"
+    UploadFilesButton: Prześlij
+  LeftAndMain:
+    DELETED: Usunięty
+    PreviewButton: Podgląd
+    SAVEDUP: Zapisane
+    SearchResults: "Wyniki wyszukiwania"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Dostęp do CMS"
   Permissions:
     CONTENT_CATEGORY: "Uprawnienie edycji treści"
     PERMISSIONS_CATEGORY: "Uprawnienia ról i dostępu"
   RedirectorPage:
+    DESCRIPTION: "Przekierowuje do wskazanej wewnętrznej strony"
     HASBEENSETUP: "Strona przekierowująca została ustawiona bez celu, do którego ma przekierowywać."
     HEADER: "Ta strona przeniesie użytkowników na inną stronę"
     OTHERURL: "Adres URL innej strony"
     REDIRECTTO: "Przenieś do"
     REDIRECTTOEXTERNAL: "Inna strona"
     REDIRECTTOPAGE: "Strona na Twojej witrynie"
+    SINGULARNAME: "Strona przekierowująca"
     YOURPAGE: "Strona na Twojej witrynie"
+  ReportAdmin:
+    MENUTITLE: Raporty
+    ReportTitle: Tytuł
+  ReportAdminForm:
+    FILTERBY: "Filtruj po"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Aby opublikować stronę wirtualną opublikuj stronę powiązaną"
     VIRTUALPAGEWARNING: "Aby opublikować tą stronę najpierw wybierz stronę powiązaną i zapisz zmiany"
@@ -170,15 +258,38 @@ pl:
     SearchResults: "Wyniki wyszukiwania"
   SideReport:
     BROKENFILES: "Strony z uszkodzonymi plikami"
+    BROKENLINKS: "Strony z uszkodzonymi linkami"
     BROKENREDIRECTORPAGES: "Strony przekierowania wskazujące na usunięte strony"
     BROKENVIRTUALPAGES: "Wirtualne strony wskazujące na usunięte strony"
     BrokenLinksGroupTitle: "Raporty o uszkodzonych linkach"
     ContentGroupTitle: "Treść raportów"
     EMPTYPAGES: "Strony bez zawartości"
     LAST2WEEKS: "Strony edytowane w ciągu 2 ostatnich tygodni"
+    OtherGroupTitle: Inny
     ParameterLiveCheckbox: "Sprawdź witrynę"
+    REPEMPTY: "{title} raport jest pusty."
   SilverStripeNavigator:
     ARCHIVED: Zarchiwizowane
+  SilverStripeNavigatorLink:
+    ShareLink: "Podziel się linkiem"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Zamknij
+  SiteConfig:
+    DEFAULTTHEME: "(Użyj domyślnego szablonu)"
+    EDITHEADER: "Kto może edytować strony tego serwisu?"
+    EDIT_PERMISSION: "Zarządzanie konfiguracją serwisu"
+    EDIT_PERMISSION_HELP: "Możliwość edycji globalnych ustawień bezpieczeństwa/uprawnień do stron pierwszego poziomu."
+    PLURALNAME: "Konfiguracje strony"
+    SINGULARNAME: "Konfiguracja strony"
+    SITENAMEDEFAULT: "Nazwa twojego serwisu"
+    SITETAGLINE: "Slogan serwisu"
+    SITETITLE: "Tytuł serwisu"
+    TABACCESS: Dostęp
+    TABMAIN: Główny
+    TAGLINEDEFAULT: "wpisz swój slogan"
+    THEME: Szablon
+    TOPLEVELCREATE: "Kto może tworzyć strony w korzeniu serwisu?"
+    VIEWHEADER: "Kto może oglądać strony serwisu?"
   SiteTree:
     ACCESSANYONE: Ktokolwiek
     ACCESSHEADER: "Kto może zobaczyć tę stronę?"
@@ -186,6 +297,7 @@ pl:
     ACCESSONLYTHESE: "Tylko Ci ludzie (wybierz z listy)"
     ADDEDTODRAFTHELP: "Strona nie została jeszcze opublikowana"
     ADDEDTODRAFTSHORT: Szkic
+    ALLOWCOMMENTS: "Zezwolić na komentarze na stronie?"
     APPEARSVIRTUALPAGES: "Ta treść pojawia się również na wirtualnej stronie w sekcji {title}."
     ARCHIVEDPAGESHORT: Zarchiwizowane
     BUTTONCANCELDRAFT: "Anuluj wprowadzone zmiany"
@@ -200,7 +312,10 @@ pl:
     DEFAULTABOUTTITLE: "O nas"
     DEFAULTCONTACTTITLE: Kontakt
     DEFAULTHOMETITLE: "Strona główna"
+    DELETEDPAGEHELP: "Strona nie jest już opublikowana"
+    DELETEDPAGESHORT: Usunięty
     DEPENDENT_NOTE: "Poniższe strony są zależne od tej (łącznie z wirtualnymi stronami, stronami przekierowującymi oraz stronami z treścią)."
+    DESCRIPTION: "Zwykła strona"
     DependtPageColumnLinkType: "Typ linku"
     DependtPageColumnURL: "Adres internetowy"
     EDITANYONE: "Każdy to jest zalogowany w systemie CMS"
@@ -238,17 +353,22 @@ pl:
     PARENTTYPE_SUBPAGE: "Podstrona innej strony (wybierz poniżej)"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Zarządzaj prawami dostępu"
     PERMISSION_GRANTACCESS_HELP: "Zezwól na ustawienie wymagań dostępu dla konkretnej strony w sekcji \"Strony\"."
+    PLURALNAME: Strony
     PageTypNotAllowedOnRoot: "\"{type}\" nie jest dozwolona na głównym poziomie"
     PageTypeNotAllowed: "\"{type}\" nie jest dozwolona jako strona podrzędna dla tej strony"
+    REMOVEDFROMDRAFTHELP: "Strona jest opublikowana, ale została usunięta ze szkiców"
+    REMOVEDFROMDRAFTSHORT: "Usunięto ze szkiców"
     REMOVE_INSTALL_WARNING: "Uwaga: Powinieneś usunąć plik install.php z powodów bezpieczeństwa."
     REORGANISE_DESCRIPTION: "Zmień strukturę strony"
     REORGANISE_HELP: "Zmień kolejność stron na drzewie witryny wykorzystując przeciągnij i  upuść."
     SHOWINMENUS: "Pokazuj w menu?"
     SHOWINSEARCH: "Pokazuj w wyszukiwarce?"
+    SINGULARNAME: Strona
     TABBEHAVIOUR: Zachowanie
     TABCONTENT: Zawartość
     TABDEPENDENT: "Strony zależne"
     TOPLEVEL: "Zawartość witryny (główny poziom)"
+    TOPLEVELCREATORGROUPS: "Twórcy najwyższego szczebla"
     URLSegment: "Segment adresu URL"
     VIEWERGROUPS: "Grupy przeglądających"
     VIEW_ALL_DESCRIPTION: "Przeglądanie stron"
@@ -261,6 +381,8 @@ pl:
     many_many_BackLinkTracking: "Śledzenie backlinków"
     many_many_ImageTracking: "Śledzenie obrazków"
     many_many_LinkTracking: "Śledzenie linków"
+  SiteTreeFileExtension:
+    EDIT: Edytuj
   SiteTreeURLSegmentField:
     EMPTY: "Proszę podać część adresu lub kliknąć anuluj"
     HelpChars: "Znaki specjalne są automatycznie konwertowane lub usuwane."
@@ -273,7 +395,9 @@ pl:
     HAVEASKED: "Poprosiłeś o obejrzenie treści naszej strony na"
   VirtualPage:
     CHOOSE: "Linkowana strona"
+    DESCRIPTION: "Wyświetla zawartość innej strony"
     EditLink: edytuj
     HEADER: "To jest wirtualna strona"
     HEADERWITHLINK: "Strona wirtualna odzwierciedlająca treść \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "\"{type}\" nie jest dozwolona dla głównego poziomu wirtualnej strony"
+    SINGULARNAME: "Wirtualna Strona"

--- a/lang/pt.yml
+++ b/lang/pt.yml
@@ -1,7 +1,40 @@
 pt:
+  AssetAdmin:
+    ADDFILES: "Adicionar ficheiros"
+    ActionAdd: "Adicionar pasta"
+    AppCategoryArchive: Arquivar
+    AppCategoryDocument: Documento
+    AppCategoryFlash: "Inserir flash"
+    AppCategoryImage: Imagem
+    AppCategoryVideo: Vídeo
+    BackToFolder: "Voltar para a pasta"
+    CREATED: Data
+    CurrentFolderOnly: "Limitar à pasta actual?"
+    DetailsView: Detalhes
+    FILES: Ficheiros
+    FILESYSTEMSYNC: "Sincronizar ficheiros"
+    FILESYSTEMSYNCTITLE: "Actualize a base de dados de ficheiros do CMS. É recomendado quando são adicionados novos arquivos externamente, por exemplo, através de FTP."
+    FROMTHEINTERNET: "Da internet"
+    FROMYOURCOMPUTER: "Do computador"
+    Filetype: "Tipo de ficheiro"
+    ListView: "Vista em lista"
+    MENUTITLE: Ficheiros
+    NEWFOLDER: "Nova Pasta"
+    SIZE: Tamanho
+    THUMBSDELETED: "{count} miniaturas não utilizadas foram removidas"
+    TreeView: "Vista em árvore"
+    Upload: Enviar
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Apagar pastas"
+  AssetAdmin_Tools:
+    FILTER: Filtro
+  AssetAdmin_left_ss:
+    GO: Ir
   AssetTableField:
     BACKLINKCOUNT: "Usado em:"
     PAGES: página(s)
+  BackLink_Button_ss:
+    Back: Voltar
   BrokenLinksReport:
     Any: Qualquer
     BROKENLINKS: "Relatório de links inválidos"
@@ -26,8 +59,13 @@ pt:
   CMSAddPageController:
     Title: "Adicionar página"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "Apagadas %d páginas publicadas, %d falharam"
+    DELETED_PAGES: "Apagadas %d páginas publicadas, %d falharam"
+    DELETE_DRAFT_PAGES: "Apagar do site de rascunho"
     PUBLISHED_PAGES: "Publicadas %d páginas, %d falhas"
     PUBLISH_PAGES: Publicar
+  CMSFileAddController:
+    MENUTITLE: Ficheiros
   CMSMain:
     ACCESS: "Acesso à secção '{title}'"
     ACCESS_HELP: "Permitir a visualização da árvore de páginas e respectivos conteúdos. Ver e editar permissões que podem ser seleccionadas a partir de uma caixa de selecção, bem como os separadores de \"permissões de conteúdo\"."
@@ -37,8 +75,13 @@ pt:
     ChoosePageParentMode: "Escolha onde criar esta página"
     ChoosePageType: "Escolher tipo de página"
     Create: Criar
+    DELETE: "Apagar do site de rascunho"
+    DELETEFP: "Apagar do site publicado"
+    DESCREMOVED: "e {count} descendentes"
     DUPLICATED: "Página '{title}' duplicada com sucesso"
     DUPLICATEDWITHCHILDREN: "Página '{title}' e filhos duplicados com sucesso"
+    EditTree: "Editar árvore"
+    MENUTITLE: "Editar página"
     NEWPAGE: "Nova {pagetype}"
     PAGENOTEXISTS: "Esta página não existe"
     PAGETYPEANYOPT: Qualquer
@@ -52,16 +95,24 @@ pt:
     ROLLBACK: "Voltar para esta versão"
     ROLLEDBACKPUBv2: "Voltar para a versão publicada."
     ROLLEDBACKVERSIONv2: "Voltar para a versão #%d."
+    SAVE: Guardar
     SAVEDRAFT: "Guardar rascunho"
     TabContent: Conteúdo
     TabHistory: Histórico
     TabSettings: Configurações
+  CMSMain_left_ss:
+    RESET: Redefinir
   CMSPageAddController:
+    MENUTITLE: "Adicionar página"
     ParentMode_child: "Por cima de outra página"
     ParentMode_top: "Nível de topo"
+  CMSPageEditController:
+    MENUTITLE: "Editar página"
   CMSPageHistoryController:
     COMPAREMODE: "Modo de comparação (selecione duas)"
     COMPAREVERSIONS: "Comparar versões"
+    COMPARINGVERSION: "Comparando as versões {version1} e {version2}."
+    MENUTITLE: Histórico
     REVERTTOTHISVERSION: "Reverter para esta versão"
     SHOWUNPUBLISHED: "Mostrar versões não publicadas"
     SHOWVERSION: "Mostrar versão"
@@ -74,7 +125,10 @@ pt:
     PUBLISHER: Publicador
     UNKNOWN: Desconhecido
     WHEN: Quando
+  CMSPageSettingsController:
+    MENUTITLE: "Editar página"
   CMSPagesController:
+    GalleryView: "Vista de galeria"
     ListView: "Vista em lista"
     MENUTITLE: Páginas
     TreeView: "Vista em árvore"
@@ -82,7 +136,10 @@ pt:
     FILTER: Filtrar
   CMSSearch:
     FILTERDATEFROM: De
+    FILTERDATEHEADING: Data
     FILTERDATETO: Para
+  CMSSettingsController:
+    MENUTITLE: Configurações
   CMSSiteTreeFilter_Search:
     Title: "Todas as páginas"
   ContentControl:
@@ -92,6 +149,7 @@ pt:
     ARCHIVEDSITEFROM: "Arquivar o site de"
     CMS: "Gestor de Conteúdos"
     DRAFTSITE: "Site Rascunho"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Tem de se autenticar para ver o conteúdo de rascunho ou arquivado. <a href=\"%s\">Clique aqui para voltar ao site publicado</a>"
     INSTALL_SUCCESS: "Instalação concluída com sucesso"
     InstallFilesDeleted: "Ficheiros de instalação foram removidos com sucesso."
     InstallSecurityWarning: "Por razões de segurança deverá apagar os ficheiros de instalação, a menos que esteja a planear uma instalação futura (<em> requer acesso de administrador, ver acima </em>). O servidor apenas necessita de permissões de escrita na pasta \"assets\", poderá remover todos os acessos de escrita nas restantes pastas.<a href=\"{link}\" style=\"text-align: Clique aqui para apagar os ficheiros de instalação.</a>"
@@ -131,30 +189,76 @@ pt:
     DEFAULTERRORPAGETITLE: "Página não encontrada"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Desculpe, ocorreu um problema no processamento do seu pedido</p>"
     DEFAULTSERVERERRORPAGETITLE: "500 - Erro do servidor"
+    DESCRIPTION: "Conteúdo personalizado para as diferentes possibilidades de erro (ex. página não encontrada)"
+    ERRORFILEPROBLEM: "Erro ao escrever no ficheiro \"{filename}\". Por favor, verifique as permissões do ficheiro."
+    SINGULARNAME: "Página de erro"
+  Folder:
+    AddFolderButton: "Adicionar pasta"
+    DELETEUNUSEDTHUMBNAILS: "Apagar miniaturas não utilizadas"
+    UNUSEDFILESTITLE: "Ficheiros não utilizados"
+    UNUSEDTHUMBNAILSTITLE: "Miniaturas não utilizadas"
+    UploadFilesButton: Submeter
+  LeftAndMain:
+    DELETED: Apagada
+    PreviewButton: Pré-visualização
+    SAVEDUP: Guardado
+    SearchResults: "Resultados da pesquisa"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Acesso ao CMS"
   Permissions:
     CONTENT_CATEGORY: "Permissões de conteúdo"
     PERMISSIONS_CATEGORY: "Regras e permissões de acesso"
   RedirectorPage:
+    DESCRIPTION: "Redirecionar para outra página interna"
     HASBEENSETUP: "Uma página de redireccionamento foi criada sem nenhum destino."
     HEADER: "Esta página irá redireccionar os utilizadores para outra página"
     OTHERURL: "Outro Site"
     REDIRECTTO: "Redireccionar para"
     REDIRECTTOEXTERNAL: "Outro site"
     REDIRECTTOPAGE: "Uma página no seu site"
+    SINGULARNAME: "A página redirecciona para uma que não existe"
     YOURPAGE: "Página no seu site"
+  ReportAdmin:
+    MENUTITLE: Relatórios
+    ReportTitle: Título
+  ReportAdminForm:
+    FILTERBY: "Filtrar por"
   SearchForm:
     GO: Ir
     SEARCH: Procurar
     SearchResults: "Resultados da pesquisa"
   SideReport:
     BROKENFILES: "Páginas com ficheiros corrompidos"
+    BROKENLINKS: "Esta página contém links inválidos."
     BROKENREDIRECTORPAGES: "As páginas redireccionadas apontam para páginas apagadas"
     BROKENVIRTUALPAGES: "Página virtuais apontam para páginas apagadas"
     BrokenLinksGroupTitle: "Relatório de links inválidos"
     ContentGroupTitle: "Conteúdo dos relatórios"
     EMPTYPAGES: "Páginas sem conteúdo"
     LAST2WEEKS: "Páginas editadas nas 2 últimas semanas"
+    OtherGroupTitle: Outro
     ParameterLiveCheckbox: "Verificar site publicado"
+    REPEMPTY: "O relatório {title} encontra-se vazio."
+  SilverStripeNavigatorLink:
+    ShareLink: "Partilhar ligação"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Fechar
+  SiteConfig:
+    DEFAULTTHEME: "(Usar o tema por omissão)"
+    EDITHEADER: "Quem pode editar páginas neste site?"
+    EDIT_PERMISSION: "Gerir configuração do site"
+    EDIT_PERMISSION_HELP: "Capacidade de editar as configurações de acesso global / permissões da página."
+    PLURALNAME: "Configurações do site"
+    SINGULARNAME: "Configurações do site"
+    SITENAMEDEFAULT: "Nome do site"
+    SITETAGLINE: "Slogan do site"
+    SITETITLE: "Título do site"
+    TABACCESS: Acesso
+    TABMAIN: Principal
+    TAGLINEDEFAULT: "seu slogan aqui"
+    THEME: Tema
+    TOPLEVELCREATE: "Quem pode criar páginas na raiz do site?"
+    VIEWHEADER: "Quem pode ver páginas neste site?"
   SiteTree:
     ACCESSANYONE: Todos
     ACCESSHEADER: "Quem pode ver esta página no site?"
@@ -162,6 +266,7 @@ pt:
     ACCESSONLYTHESE: "Apenas estes (Seleccione da lista abaixo)"
     ADDEDTODRAFTHELP: "A página ainda não foi publicada"
     ADDEDTODRAFTSHORT: Rascunho
+    ALLOWCOMMENTS: "Permitir comentários nesta página?"
     APPEARSVIRTUALPAGES: "Este conteúdo também aparece nas páginas virtuais das secções {title}"
     BUTTONCANCELDRAFT: "Cancelar alterações do rascunho"
     BUTTONCANCELDRAFTDESC: "Apagar o seu rascunho e reverter para a versão publicada atualmente"
@@ -172,7 +277,10 @@ pt:
     DEFAULTABOUTTITLE: "Quem Somos"
     DEFAULTCONTACTTITLE: Contacte-nos
     DEFAULTHOMETITLE: "Página Principal"
+    DELETEDPAGEHELP: "A página nunca mais será publicada"
+    DELETEDPAGESHORT: Apagada
     DEPENDENT_NOTE: "As páginas seguintes dependem desta página. Isto inclui páginas virtuais, páginas redireccionadas e páginas com links de conteúdo."
+    DESCRIPTION: "Página de conteúdo genérico"
     DependtPageColumnLinkType: "Tipo de ligação"
     EDITANYONE: "Todos que possam efectuar a autenticação no CMS"
     EDITHEADER: "Quem pode editar esta página no CMS?"
@@ -201,17 +309,22 @@ pt:
     PARENTTYPE_ROOT: "Página de topo"
     PARENTTYPE_SUBPAGE: "Página Parente"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Gestão de permissões de acesso para o conteúdo"
+    PLURALNAME: Páginas
     PageTypNotAllowedOnRoot: "Páginas do tipo \"{type}\" não tem permissões para serem criadas a este nível."
     PageTypeNotAllowed: "A página do tipo \"{type}\" não é permitida como filho deste tipo de página"
+    REMOVEDFROMDRAFTHELP: "A página está publicada mas foi removida dos rascunhos"
+    REMOVEDFROMDRAFTSHORT: "Removido do rascunho"
     REMOVE_INSTALL_WARNING: "Aviso: Por razões de segurança, deverá apagar o ficheiro \"install.php\" da raiz do seu servidor."
     REORGANISE_DESCRIPTION: "Alterar estrutura do site"
     REORGANISE_HELP: "Rearranjar páginas na árvore do site com drag&drop"
     SHOWINMENUS: "Mostrar no Menu?"
     SHOWINSEARCH: "Mostrar nas pesquisas?"
+    SINGULARNAME: Página
     TABBEHAVIOUR: Comportamento
     TABCONTENT: Conteúdo
     TABDEPENDENT: "Páginas Dependentes"
     TOPLEVEL: "Conteúdo do Site (Nível Superior)"
+    TOPLEVELCREATORGROUPS: "Nível de topo"
     URLSegment: "Segmento de URL"
     VIEWERGROUPS: "Ver grupos "
     VIEW_DRAFT_CONTENT: "Ver o conteúdo de rascunho"
@@ -230,7 +343,9 @@ pt:
     HAVEASKED: "Pediu para ver o conteúdo do nosso site na"
   VirtualPage:
     CHOOSE: "Página associada"
+    DESCRIPTION: "Apresentar o conteúdo de outra página"
     EditLink: editar
     HEADER: "Esta é uma página virtual"
     HEADERWITHLINK: "Esta é uma página virtual com o conteúdo copiado da página \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Páginas do tipo \"{type}\" não tem permissões para serem criadas a este nível."
+    SINGULARNAME: "Página Virtual"

--- a/lang/pt_BR.yml
+++ b/lang/pt_BR.yml
@@ -1,10 +1,17 @@
 pt_BR:
+  AssetAdmin:
+    NEWFOLDER: "Nova Pasta"
+  AssetAdmin_left_ss:
+    GO: Ir
   CMSMain:
+    DELETE: "Excluir do site de rascunho"
+    DELETEFP: "Excluir do site ativo"
     PAGENOTEXISTS: "Esta página não existe"
     PUBALLCONFIRM: "Por favor publique todas as páginas no site, copiando content stage to live"
     PUBALLFUN: "Funcionalidade \"Publicar Tudo\""
     REMOVEDPAGEFROMDRAFT: "Removido '%s'  do site de rascunho"
     ROLLBACK: "Reverter para esta versão"
+    SAVE: Salvar
   CMSPagesController:
     MENUTITLE: Páginas
   ErrorPage:
@@ -34,6 +41,10 @@ pt_BR:
     CODE: "Código do erro"
     DEFAULTERRORPAGECONTENT: "<p>desculpe, mas parece que você esta tentando acessar uma página que não existe.</p><p>Por favor, verifique se você digitou a URL corretamente e tente novamente</p>"
     DEFAULTERRORPAGETITLE: "Página não encontrada"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Excluir miniaturas não utilizadas"
+    UNUSEDFILESTITLE: "Arquivos não utilizados"
+    UNUSEDTHUMBNAILSTITLE: "Miniaturas não utilizadas"
   RedirectorPage:
     HASBEENSETUP: "Uma página de redireccionamento foi criada sem nenhum destino específicado"
     HEADER: "Esta página redireccionará os utilizadores para outra página"
@@ -53,6 +64,7 @@ pt_BR:
     ACCESSHEADER: "Quem pode ver esta página?"
     ACCESSLOGGEDIN: "Utilizadores que tenham feito log-in"
     ACCESSONLYTHESE: "Somente estas pessoas (escolha da lista)"
+    ALLOWCOMMENTS: "Permitir comentários sobre esta página?"
     BUTTONCANCELDRAFT: "Cancelar alterações no rascunho"
     BUTTONCANCELDRAFTDESC: "Apague o seu rascunho e reverta para o site currrentement publicado"
     BUTTONUNPUBLISH: "Anular publicação"
@@ -77,6 +89,7 @@ pt_BR:
     PARENTID: "Página pai"
     PARENTTYPE: "Lugar da página"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Controla os grupos que podem acessar ou editar determinadas páginas"
+    PLURALNAME: Páginas
     SHOWINMENUS: "Mostrar nos menus?"
     SHOWINSEARCH: "Uncluir na procura?"
     TABBEHAVIOUR: Comportamento
@@ -93,3 +106,4 @@ pt_BR:
     HAVEASKED: "Você pediu para ver o conteúdo do nosso site em"
   VirtualPage:
     HEADER: "Esta é uma página virtual"
+    SINGULARNAME: "Página virtual"

--- a/lang/ro.yml
+++ b/lang/ro.yml
@@ -1,7 +1,41 @@
 ro:
+  AssetAdmin:
+    ADDFILES: "Adăugați fișiere"
+    ActionAdd: "Adăugați dosarul"
+    AppCategoryArchive: Arhivă
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Document
+    AppCategoryFlash: Flash
+    AppCategoryImage: Imagine
+    AppCategoryVideo: Video
+    BackToFolder: "Înapoi la dosar"
+    CREATED: Dată
+    CurrentFolderOnly: "Limitare la directorul curent?"
+    DetailsView: Detalii
+    FILES: Fişiere
+    FILESYSTEMSYNC: "Sincronizare fişiere"
+    FILESYSTEMSYNCTITLE: "Actualizează intrările din baza de date a fișierelor CMS-ului. Util când nu s-au upload-uit fișiere prin intermediul CMS-ului, de ex. prin FTP."
+    FROMTHEINTERNET: "Din internet"
+    FROMYOURCOMPUTER: "De pe calculator"
+    Filetype: "Tip fişier"
+    ListView: "Vizualizare listă"
+    MENUTITLE: Fişiere
+    NEWFOLDER: "Dosar nou"
+    SIZE: Mărime
+    THUMBSDELETED: "{count} pictograme nefolosite au fost șterse"
+    TreeView: "Vizualizare arborescentă"
+    Upload: Upload
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Ştergere dosare"
+  AssetAdmin_Tools:
+    FILTER: Filtru
+  AssetAdmin_left_ss:
+    GO: Start
   AssetTableField:
     BACKLINKCOUNT: "Folosit la"
     PAGES: pagină(pagini)
+  BackLink_Button_ss:
+    Back: Înapoi
   BrokenLinksReport:
     Any: Oricare
     BROKENLINKS: "Raport cu link-uri nefuncţionale"
@@ -27,8 +61,14 @@ ro:
   CMSAddPageController:
     Title: "Adăugare pagină"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "Au fost şterse %d pagini de pe site-ul ciornă, %d erori"
+    DELETED_PAGES: "Au fost şterse %d pagini de pe site-ul live, %d erori"
+    DELETE_DRAFT_PAGES: "Ştergere de pe site-ul ciornă"
+    DELETE_PAGES: "Ştergere de pe site-ul live"
     PUBLISHED_PAGES: "%d pagini publicate, %d erori"
     PUBLISH_PAGES: Publicare
+  CMSFileAddController:
+    MENUTITLE: Fișiere
   CMSMain:
     ACCESS: "Acces la secţiunea '{title}' "
     ACCESS_HELP: "Permite vizualizarea secțiunii cu arborele de pagini și conținut. Permisiunile de vizualizare și editare pot fi setate specific prin meniul vertical din pagini sau separat în \"Permisiuni de conținut\". "
@@ -38,8 +78,13 @@ ro:
     ChoosePageParentMode: "Alegeți unde veţi crea această pagină"
     ChoosePageType: "Alegeţi tipul de pagină"
     Create: Creaţi
+    DELETE: "Ştergere ciornă"
+    DELETEFP: Ştergere
+    DESCREMOVED: "și {count} descendenți"
     DUPLICATED: "'{title}' duplicat cu succes"
     DUPLICATEDWITHCHILDREN: "'{title}' și descendenții săi duplicați cu succes"
+    EditTree: "Editare structură arbore"
+    MENUTITLE: "Editează pagina"
     NEWPAGE: "{pagetype} nouă"
     PAGENOTEXISTS: "Această pagină nu există"
     PAGETYPEANYOPT: Oricare
@@ -47,22 +92,31 @@ ro:
     PUBALLFUN: "Funcționalitatea \"Publică Tot\" "
     PUBPAGES: "Finalizat: Publicate {count} pagini"
     PageAdded: "Pagină creată cu succes"
+    REMOVED: "Șterge '{title}'{description} din site-ul live"
     REMOVEDPAGE: "Înlătură '{title}' din site-ul publicat"
     REMOVEDPAGEFROMDRAFT: "Înlătură '%s' din site-ul ciornă"
     RESTORED: "Restaurare '{title}' cu succes"
     ROLLBACK: "Revenire la versiunea aceasta"
     ROLLEDBACKPUBv2: "Revenire la versiunea publicată"
     ROLLEDBACKVERSIONv2: "Revenire la versiunea #%d"
+    SAVE: Salvează
     SAVEDRAFT: "Salvează ciornă"
     TabContent: Conținut
     TabHistory: Istorie
     TabSettings: Setări
+  CMSMain_left_ss:
+    RESET: Resetează
   CMSPageAddController:
+    MENUTITLE: "Adaugă pagină"
     ParentMode_child: "Sub altă pagină"
     ParentMode_top: "Nivel top"
+  CMSPageEditController:
+    MENUTITLE: "Editează Pagina"
   CMSPageHistoryController:
     COMPAREMODE: "Mod comparare (selectează 2)"
     COMPAREVERSIONS: "Compară Versiunile"
+    COMPARINGVERSION: "Comparație versiuni {version1} și {version2}."
+    MENUTITLE: Istorie
     REVERTTOTHISVERSION: "Revernire la versiune"
     SHOWUNPUBLISHED: "Afișează versiunile nepublicate"
     SHOWVERSION: "Afișează Versiune"
@@ -75,7 +129,10 @@ ro:
     PUBLISHER: Redactor
     UNKNOWN: Necunoscut
     WHEN: Când
+  CMSPageSettingsController:
+    MENUTITLE: "Editare pagină"
   CMSPagesController:
+    GalleryView: "View Galerie"
     ListView: "View listă"
     MENUTITLE: Pagini
     TreeView: "View Arbore"
@@ -83,7 +140,10 @@ ro:
     FILTER: Filtru
   CMSSearch:
     FILTERDATEFROM: "De la"
+    FILTERDATEHEADING: Data
     FILTERDATETO: La
+  CMSSettingsController:
+    MENUTITLE: Setări
   CMSSiteTreeFilter_Search:
     Title: "Toate paginile"
   ContentControl:
@@ -94,6 +154,7 @@ ro:
     CMS: CMS
     DRAFT: Cironă
     DRAFTSITE: "Site ciornă"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Trebuie să vă logați cu parola dumneavoastră CMS pentru a vizualiza ciorna sau conținutul arhivat. <a href=\"%s\">Click aici pentru a te întoarce la site-ul publicat.</a>"
     Email: Email
     INSTALL_SUCCESS: "Instalare cu succes!"
     InstallFilesDeleted: "Fișierele de instalarea au fost șterse cu succes."
@@ -139,17 +200,40 @@ ro:
     DEFAULTERRORPAGETITLE: "Pagină negasită"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Ne pare rău, s-a petrecut o problemă la procesarea solicitării dumeavoastre.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Eroare de server"
+    DESCRIPTION: "Conșinut preferențial pentru diferitele cazuri (ex. \"Pagină negăsită\")"
+    ERRORFILEPROBLEM: "Eroare la deschiderea fișierului \"{filename}\" pentru scriere. Vă rugăm verificași permisiunile."
+    SINGULARNAME: "Pagină de eroare"
+  Folder:
+    AddFolderButton: "Adaugă director"
+    DELETEUNUSEDTHUMBNAILS: "Șterger pictograme nefolosite"
+    UNUSEDFILESTITLE: "Fișiere nefolosite"
+    UNUSEDTHUMBNAILSTITLE: "Pictograme nefolosite"
+    UploadFilesButton: Upload
+  LeftAndMain:
+    DELETED: Șters.
+    PreviewButton: Previzualizare
+    SAVEDUP: Salvat.
+    SearchResults: "Rezultate căutare"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Acces CMS"
   Permissions:
     CONTENT_CATEGORY: "Permisiuni de conținut"
     PERMISSIONS_CATEGORY: "Permisiuni de rol și acces"
   RedirectorPage:
+    DESCRIPTION: "Redirecționează către o pagină internă diferită"
     HASBEENSETUP: "O pagină referitoare a fost creată fără a direcționa către ceva"
     HEADER: "Pagina v-a redirecționa utilizatorii către altă pagină"
     OTHERURL: "URL-ul altui website"
     REDIRECTTO: "Redirecționare către"
     REDIRECTTOEXTERNAL: "Alt website"
     REDIRECTTOPAGE: "O pagină de pe website-ul dumneavoastră"
+    SINGULARNAME: "Pagină referitoare"
     YOURPAGE: "Pagină de pe website-ul dumneavoastră"
+  ReportAdmin:
+    MENUTITLE: Rapoarte
+    ReportTitle: Titlu
+  ReportAdminForm:
+    FILTERBY: "Filtrează după"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Vă rugăm selectați o pagină referențiată pentru a publica pagina virtuală"
     VIRTUALPAGEWARNING: "Vă rugăm selectați o pagină referențiată și salvați înainte pentru a publica pagina"
@@ -160,15 +244,38 @@ ro:
     SearchResults: "Rezultate căutare"
   SideReport:
     BROKENFILES: "Pagini cu fișiere incorecte"
+    BROKENLINKS: "Pagini cu "
     BROKENREDIRECTORPAGES: "Pagini referitoare indică spre pagini șterse"
     BROKENVIRTUALPAGES: "Pagini virtuale indică spre pagini șterse"
     BrokenLinksGroupTitle: "Raport referințe nefuncționale"
     ContentGroupTitle: "Rapoarte conținut"
     EMPTYPAGES: "Pagini fără conținut"
     LAST2WEEKS: "Pagini editate în ultimele 2 săptămâni"
+    OtherGroupTitle: Altele
     ParameterLiveCheckbox: "Verifică site live"
+    REPEMPTY: "Raportul {title} este gol "
   SilverStripeNavigator:
     ARCHIVED: Arhivă
+  SilverStripeNavigatorLink:
+    ShareLink: "Distribuie link"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Închide
+  SiteConfig:
+    DEFAULTTHEME: "(Folosește tema default)"
+    EDITHEADER: "Cine poate edita pagini pe acest site?"
+    EDIT_PERMISSION: "Administrează configurații site"
+    EDIT_PERMISSION_HELP: "Abilitatea de a edita setări de acces general/permisiuni de pagini nivel-top"
+    PLURALNAME: "Configurații Site"
+    SINGULARNAME: "Configurare Site"
+    SITENAMEDEFAULT: "Numele Site-ului Tău"
+    SITETAGLINE: "Slogan Site"
+    SITETITLE: "Titlul Site-ului"
+    TABACCESS: Acces
+    TABMAIN: Principal
+    TAGLINEDEFAULT: "sloganul tău aici"
+    THEME: Tema
+    TOPLEVELCREATE: "Cine poate crea pagini în rădăcina site-ului?"
+    VIEWHEADER: "Cine poate vizualiza paginile acestui site?"
   SiteTree:
     ACCESSANYONE: Oricine
     ACCESSHEADER: "Cine poate vizualiza această pagină pe site-ul meu?"
@@ -176,6 +283,7 @@ ro:
     ACCESSONLYTHESE: "Doar aceste persoane (selectează din listă)"
     ADDEDTODRAFTHELP: "Pagina nu a fost încă publicată"
     ADDEDTODRAFTSHORT: Ciornă
+    ALLOWCOMMENTS: "Acceptă comentarii în aceasta pagină? "
     APPEARSVIRTUALPAGES: "Conținutul apare și în pagini virtuale în secțiuni {title}"
     BUTTONCANCELDRAFT: "Anulează modificări ciornă"
     BUTTONCANCELDRAFTDESC: "Șterge ciorna și revenire la pagina publicată curent "
@@ -189,7 +297,10 @@ ro:
     DEFAULTABOUTTITLE: "Despre Noi"
     DEFAULTCONTACTTITLE: Contactați-ne
     DEFAULTHOMETITLE: Acasă
+    DELETEDPAGEHELP: "Pagina nu mai este publicată"
+    DELETEDPAGESHORT: Șters
     DEPENDENT_NOTE: "Următoarele pagini depind de această pagină. Include și pagini virtuale, pagini redirecționate, și pagini cu link-uri către conținut."
+    DESCRIPTION: "Pagina cu conținut generic "
     DependtPageColumnLinkType: "Tip referintă"
     DependtPageColumnURL: URL
     EDITANYONE: "Oricine se poate logina pe CMS"
@@ -227,17 +338,22 @@ ro:
     PARENTTYPE_SUBPAGE: "Subpagini de sub pagina părinte"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Administrează drepturi de acces la conținut"
     PERMISSION_GRANTACCESS_HELP: "Permite setări de restricționare specifice per pagină în secțiunea \"Pagini\"."
+    PLURALNAME: Pagini
     PageTypNotAllowedOnRoot: "Tipul paginii \"{type}\" nu este permis pe nivelul rădăcină"
     PageTypeNotAllowed: "Tipul pagini \"{type}\" nu este permis ca și copil pentru pagina părinte"
+    REMOVEDFROMDRAFTHELP: "Pagina este publicată, dar a fost ștearsă din ciornă"
+    REMOVEDFROMDRAFTSHORT: "Șterge din ciornă"
     REMOVE_INSTALL_WARNING: "Avertisment: Ar trebuii șters fișierul install.php din Instanța Silverstripe din motive de securitate. "
     REORGANISE_DESCRIPTION: "Schimbă structură site"
     REORGANISE_HELP: "Rearanjează paginile în arborele site-ului prin drag&drop"
     SHOWINMENUS: "Afişează in meniu?"
     SHOWINSEARCH: "Afisează în căutare"
+    SINGULARNAME: Pagină
     TABBEHAVIOUR: Comportament
     TABCONTENT: "Conţinut principal"
     TABDEPENDENT: "Pagini dependente"
     TOPLEVEL: "Conținut Site (Nivel Top)"
+    TOPLEVELCREATORGROUPS: "Creatorii de nivel Top"
     URLSegment: "Segment URL"
     VIEWERGROUPS: "Grupuri Observatori"
     VIEW_ALL_DESCRIPTION: "Vizualizează orice pagină"
@@ -262,7 +378,9 @@ ro:
     HAVEASKED: "Ați cerut să vizualizați conținutul site-ului la"
   VirtualPage:
     CHOOSE: "Pagina referință"
+    DESCRIPTION: "Afișează conținutul altei pagini"
     EditLink: editare
     HEADER: "Aceasta este o pagină virtuală "
     HEADERWITHLINK: "Aceasta este o pagina virtuală care copiază conținut din \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Tipul original al pagini \"{type}\" nu este permis pe nivelul rădăcină pentru pagina virtuală"
+    SINGULARNAME: "Pagina Virtuala"

--- a/lang/ru.yml
+++ b/lang/ru.yml
@@ -1,7 +1,42 @@
 ru:
+  AssetAdmin:
+    ADDFILES: "Добавить файлы"
+    ActionAdd: "Добавить папку"
+    AppCategoryArchive: Архив
+    AppCategoryAudio: Аудио
+    AppCategoryDocument: Документ
+    AppCategoryFlash: Flash
+    AppCategoryImage: Изображение
+    AppCategoryVideo: Видео
+    BackToFolder: "Вернуться к папке"
+    CMSMENU_OLD: "Файлы (прошлые)"
+    CREATED: Дата
+    CurrentFolderOnly: "Только в этой папке?"
+    DetailsView: Подробности
+    FILES: Файлы
+    FILESYSTEMSYNC: Синхронизировать
+    FILESYSTEMSYNCTITLE: "Обновление базы данных файловой системы. Стоит использовать, если новые файлы были загружены без использования CMS, например, через FTP."
+    FROMTHEINTERNET: "Из интернета"
+    FROMYOURCOMPUTER: "С вашего компьютера"
+    Filetype: "Тип файла"
+    ListView: "В виде списка"
+    MENUTITLE: Файлы
+    NEWFOLDER: "Новая папка"
+    SIZE: Размер
+    THUMBSDELETED: "{count} неиспользуемых миниатюр удалено"
+    TreeView: "В виде дерева"
+    Upload: Загрузить
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Удалить папки"
+  AssetAdmin_Tools:
+    FILTER: Фильтр
+  AssetAdmin_left_ss:
+    GO: Выбрать
   AssetTableField:
     BACKLINKCOUNT: "Используется на:"
     PAGES: страниц(а)
+  BackLink_Button_ss:
+    Back: Назад
   BrokenLinksReport:
     Any: Все
     BROKENLINKS: "Отчет об ошибочных ссылках"
@@ -27,10 +62,18 @@ ru:
   CMSAddPageController:
     Title: "Добавить страницу"
   CMSBatchActions:
+    ARCHIVE: Архив
+    ARCHIVED_PAGES: "Зархивировано %d страниц "
+    DELETED_DRAFT_PAGES: "%d страниц удалено с чернового сайта, %d ошибок"
+    DELETED_PAGES: "%d страниц удалено с опубликованного сайта, %d ошибок"
+    DELETE_DRAFT_PAGES: "Удалить из чернового сайта"
+    DELETE_PAGES: "Удалить из опубликованной версии сайта"
     PUBLISHED_PAGES: "Опубликовано %d страниц, %d ошибок"
     PUBLISH_PAGES: Опубликовать
     RESTORE: Восстановить
     RESTORED_PAGES: "Восстановлено %d страниц"
+  CMSFileAddController:
+    MENUTITLE: Файлы
   CMSMain:
     ACCESS: "Доступ к разделу '{title}'"
     ACCESS_HELP: "Возможность просматривать раздел, содержащий дерево страниц и контент. Настройка прав просмотра и редактирования производится через выпадающие меню на отдельных страницах, а также через \"Права доступа к содержимому\"."
@@ -43,8 +86,13 @@ ru:
     ChoosePageParentMode: "Выберите, расположение страницы"
     ChoosePageType: "Выберите тип страницы"
     Create: Создать
+    DELETE: "Удалить черновик"
+    DELETEFP: Удалить
+    DESCREMOVED: "и {count} страниц нижнего уровня"
     DUPLICATED: "Копия '{title}' создана"
     DUPLICATEDWITHCHILDREN: "Копия '{title}' и дочерних элементов создана"
+    EditTree: "Редактировать дерево"
+    MENUTITLE: "Править страницу"
     NEWPAGE: "Новая {pagetype}"
     PAGENOTEXISTS: "Страница не существует"
     PAGETYPEANYOPT: Любой
@@ -53,6 +101,7 @@ ru:
     PUBLISHED: "'{title}' опубликован"
     PUBPAGES: "Готово: опубликовано {count} страниц"
     PageAdded: "Страница успешно создана"
+    REMOVED: "Страница '{title}'{description} удалена с опубликованного сайта"
     REMOVEDPAGE: "Страница '{title}' удалена с опубликованного сайта"
     REMOVEDPAGEFROMDRAFT: "Страница '%s' удалена с чернового сайта"
     RESTORED: "'{title}' успешно восстановлен"
@@ -62,17 +111,25 @@ ru:
     ROLLBACK: "Вернуться к этой версии"
     ROLLEDBACKPUBv2: "Восстановлена опубликованная версия."
     ROLLEDBACKVERSIONv2: "Версия #%d восстановлена."
+    SAVE: Сохранить
     SAVED: "'{title}' сохранен"
     SAVEDRAFT: "Сохранить черновик"
     TabContent: Содержимое
     TabHistory: История
     TabSettings: Настройки
+  CMSMain_left_ss:
+    RESET: Восстановить
   CMSPageAddController:
+    MENUTITLE: "Добавить страницу"
     ParentMode_child: "Под другой страницей"
     ParentMode_top: "Корневая страница"
+  CMSPageEditController:
+    MENUTITLE: "Редактировать страницу"
   CMSPageHistoryController:
     COMPAREMODE: "Режим сравнения двух страниц"
     COMPAREVERSIONS: "Сравнить версии"
+    COMPARINGVERSION: "Сравнение версий {version1} и {version2}."
+    MENUTITLE: История
     REVERTTOTHISVERSION: "Вернуться на эту версию"
     SHOWUNPUBLISHED: "Показать неопубликованные версии"
     SHOWVERSION: "Показать версию"
@@ -86,7 +143,10 @@ ru:
     PUBLISHER: Издатель
     UNKNOWN: Неизвестно
     WHEN: Когда
+  CMSPageSettingsController:
+    MENUTITLE: "Править страницу"
   CMSPagesController:
+    GalleryView: "В виде галереи"
     ListView: "Обзор списка"
     MENUTITLE: Страницы
     TreeView: "Обзор дерева"
@@ -96,8 +156,11 @@ ru:
     Title: "Опубликованные страницы"
   CMSSearch:
     FILTERDATEFROM: От
+    FILTERDATEHEADING: Дата
     FILTERDATETO: До
     PAGEFILTERDATEHEADING: "Последнее изменение"
+  CMSSettingsController:
+    MENUTITLE: Настройки
   CMSSiteTreeFilter_Search:
     Title: "Все страницы"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -110,6 +173,7 @@ ru:
     CMS: CMS
     DRAFT: Черновик
     DRAFTSITE: "Черновой сайт"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Для просмотра чернового или архивного содержимого вам необходимо войти в систему со своим именем пользователя и паролем. <a href=\"%s\">Щелкните здесь, чтобы вернуться на опубликованный сайт.</a>"
     Email: Email
     INSTALL_SUCCESS: "Инсталляция прошла успешно!"
     InstallFilesDeleted: "Инсталляционные файлы были успешно удалены."
@@ -157,16 +221,38 @@ ru:
     DEFAULTERRORPAGETITLE: "Страница не найдена"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Не удалось обработать запрос.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Ошибка сервера"
+    DESCRIPTION: "Пользовательские страницы ошибок (например, \"Страница не найдена\")"
+    ERRORFILEPROBLEM: "Ошибка при открытии файла \"{filename}\" для записи. Пожалуйста, проверьте права доступа к файлам."
+    PLURALNAME: "Страницы ошибок"
+    SINGULARNAME: "Страница ошибки"
+  File:
+    Title: Название
+  Folder:
+    AddFolderButton: "Добавить папку"
+    DELETEUNUSEDTHUMBNAILS: "Удалить неиспользуемые миниатюры"
+    UNUSEDFILESTITLE: "Неиспользуемые файлы"
+    UNUSEDTHUMBNAILSTITLE: "Неиспользуемые миниатюры"
+    UploadFilesButton: Загрузить
+  LeftAndMain:
+    DELETED: Удалено.
+    PreviewButton: Просмотр
+    SAVEDUP: Сохранено.
+    SearchResults: "Результаты поиска"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Доступ к CMS"
   Permissions:
     CONTENT_CATEGORY: "Права доступа к содержимому"
     PERMISSIONS_CATEGORY: "Роли и права доступа"
   RedirectorPage:
+    DESCRIPTION: "Перенаправление на другую внутреннюю страницу"
     HASBEENSETUP: "Страница перенаправления установлена без указания места перенаправления."
     HEADER: "Эта страница будет перенаправлять пользователей на другую страницу"
     OTHERURL: "URL другого сайта"
+    PLURALNAME: "Страницы перенаправления"
     REDIRECTTO: "Перенаправлять на"
     REDIRECTTOEXTERNAL: "Другой сайт"
     REDIRECTTOPAGE: "Страницу вашего сайта"
+    SINGULARNAME: "Страница перенаправления"
     YOURPAGE: "Страница вашего сайта"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Старт
@@ -178,6 +264,11 @@ ru:
     OPERATION_REMOVE: "Удалить все версии выбранного (ВНИМАНИЕ: Это действие удалит все выбранные страниц из черновиков и с опубликованного сайта)"
     SELECTALL: "выбрать все"
     UNSELECTALL: "снять выделение со всех"
+  ReportAdmin:
+    MENUTITLE: Отчеты
+    ReportTitle: Название
+  ReportAdminForm:
+    FILTERBY: "Фильтровать по"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Для опубликования виртуальной страницы опубликуйте связанную страницу"
     VIRTUALPAGEWARNING: "Для опубликования этой страницы выберите связанную страницу и сохраните изменения"
@@ -188,15 +279,22 @@ ru:
     SearchResults: "Результаты поиска"
   SideReport:
     BROKENFILES: "Страницы с ошибочными файлами"
+    BROKENLINKS: "Страницы с ошибочными ссылками"
     BROKENREDIRECTORPAGES: "Страницы перенаправления, указывающие на удаленные страницы"
     BROKENVIRTUALPAGES: "Виртуальные страницы, указывающие на удаленные страницы"
     BrokenLinksGroupTitle: "Отчеты об ошибочных ссылках"
     ContentGroupTitle: "Отчеты по контенту"
     EMPTYPAGES: "Пустые страницы"
     LAST2WEEKS: "Страницы, которые редактировались в последние 2 недели"
+    OtherGroupTitle: Другие
     ParameterLiveCheckbox: "Проверить опубликованный сайт"
+    REPEMPTY: "Отчет {title} пуст."
   SilverStripeNavigator:
     ARCHIVED: Архивные
+  SilverStripeNavigatorLink:
+    ShareLink: "Поделиться ссылкой"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Закрыть
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Добавить страницу"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -217,10 +315,28 @@ ru:
     SINGULARNAME: "Страница перенаправления"
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: "Обычная страница"
+    PLURALNAME: "Древа Страниц"
+    SINGULARNAME: "Древо Страниц"
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: "Отображает содержимое другой страницы"
     PLURALNAME: "Виртуальные Страницы"
     SINGULARNAME: "Виртуальная Страница"
+  SiteConfig:
+    DEFAULTTHEME: "(Использовать тему по умолчанию)"
+    EDITHEADER: "Кто может редактировать страницы на этом сайте?"
+    EDIT_PERMISSION: "Управление конфигурацией сайта"
+    EDIT_PERMISSION_HELP: "Возможность редактировать глобальные настройки доступа/права доступа к страницам верхнего уровня."
+    PLURALNAME: "Конфигурации сайта"
+    SINGULARNAME: "Конфигурация сайта"
+    SITENAMEDEFAULT: "Название сайта"
+    SITETAGLINE: "Подзаголовок сайта / слоган"
+    SITETITLE: "Заголовок сайта"
+    TABACCESS: Доступ
+    TABMAIN: Главная
+    TAGLINEDEFAULT: "ваш слоган здесь"
+    THEME: Тема
+    TOPLEVELCREATE: "Кто может создавать страницы верхнего уровня на этом сайте?"
+    VIEWHEADER: "Кто может просматривать страницы на этом сайте?"
   SiteTree:
     ACCESSANYONE: Все
     ACCESSHEADER: "Кто может просматривать эту страницу на моем сайте?"
@@ -228,9 +344,11 @@ ru:
     ACCESSONLYTHESE: "Только эти пользователи (выберите из списка)"
     ADDEDTODRAFTHELP: "Эта страница еще не опубликована"
     ADDEDTODRAFTSHORT: Черновик
+    ALLOWCOMMENTS: "Разрешить комментарии для этой страницы?"
     APPEARSVIRTUALPAGES: "Это содержимое также отображается на виртуальных страницах в разделе {title}."
     ARCHIVEDPAGEHELP: "Страница удалена с опубликованного сайта и из черновиков"
     ARCHIVEDPAGESHORT: Зархивировано
+    BUTTONARCHIVEDESC: "Отменить публикацию и отправить в архив"
     BUTTONCANCELDRAFT: "Отменить изменения черновика"
     BUTTONCANCELDRAFTDESC: "Удалить черновик и вернуться к уже опубликованной странице"
     BUTTONPUBLISHED: Опубликовано
@@ -244,7 +362,10 @@ ru:
     DEFAULTCONTACTTITLE: Контакты
     DEFAULTHOMECONTENT: "<p>Добро пожаловать в SilverStripe! Это стандартная домашняя страница. Вы можете изменить её перейдя по ссылке в <a href=\"admin/\">the CMS</a>.</p><p>Документация для разработчиков доступна <a href=\"http://docs.silverstripe.org\">здесь</a>, видео-уроки по SilverStripe находятся <a href=\"http://www.silverstripe.org/learn/lessons\">здесь</a>.</p>"
     DEFAULTHOMETITLE: Главная
+    DELETEDPAGEHELP: "Страница больше не является опубликованной"
+    DELETEDPAGESHORT: Удалено
     DEPENDENT_NOTE: "С этой страницей связаны следующие зависимые страницы (сюда относятся виртуальные страницы, страницы перенаправления и страницы со ссылками на контент)."
+    DESCRIPTION: "Обычная страница"
     DependtPageColumnLinkType: "Тип ссылки"
     DependtPageColumnURL: URL
     EDITANYONE: "Все, у кого есть доступ к системе (CMS)"
@@ -284,17 +405,22 @@ ru:
     PARENTTYPE_SUBPAGE: "Подстраница под родительской страницей"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Управление правами доступа к содержимому"
     PERMISSION_GRANTACCESS_HELP: "Возможность устанавливать ограничения доступа в разделе \"Страницы\" для каждой страницы отдельно."
+    PLURALNAME: Страницы
     PageTypNotAllowedOnRoot: "Страницы типа \"{type}\" не могут быть корневыми"
     PageTypeNotAllowed: "Страницы типа \"{type}\" недопустимы для этой родительской страницы в качестве дочерних"
+    REMOVEDFROMDRAFTHELP: "Страница опубликована, но была удалена из черновой версии"
+    REMOVEDFROMDRAFTSHORT: "Удалено из черновика"
     REMOVE_INSTALL_WARNING: "Внимание: по соображениям безопасности рекомендуется удалить файл install.php из данной инсталляции SilverStripe."
     REORGANISE_DESCRIPTION: "Изменение структуры сайта"
     REORGANISE_HELP: "Изменение порядка страниц в древовидной структуре сайта посредством drag&drop."
     SHOWINMENUS: "Показывать в меню?"
     SHOWINSEARCH: "Показывать в поиске?"
+    SINGULARNAME: Страница
     TABBEHAVIOUR: Настройки
     TABCONTENT: Содержимое
     TABDEPENDENT: "Зависимые страницы"
     TOPLEVEL: "Содержимое сайта (верхний уровень)"
+    TOPLEVELCREATORGROUPS: "Авторы верхнего уровня"
     URLSegment: "Адрес страницы"
     VIEWERGROUPS: "Группы чтения"
     VIEW_ALL_DESCRIPTION: "Просмотр любой страницы"
@@ -308,6 +434,8 @@ ru:
     many_many_ImageTracking: "Отслеживание изображений"
     many_many_LinkTracking: "Отслеживание ссылок"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "В этом списке находятся все страницы где есть файл добавленный с помощью визуального редактора."
+    EDIT: Изменить
     TITLE_INDEX: №
     TITLE_TYPE: Тип
     TITLE_USED_ON: "Используется на"
@@ -323,7 +451,10 @@ ru:
     HAVEASKED: "Вы запросили просмотр содержимого нашего сайта за"
   VirtualPage:
     CHOOSE: "Связанная страница"
+    DESCRIPTION: "Отображение содержимого другой страницы"
     EditLink: редактировать
     HEADER: "Это виртуальная страница"
     HEADERWITHLINK: "Это виртуальная страница, копирующая содержимое из \"{title}\" ({link})"
+    PLURALNAME: "Виртуальные страницы"
     PageTypNotAllowedOnRoot: "Страницы типа \"{type}\" недопустимы в качестве корневых для этой виртуальной страницы"
+    SINGULARNAME: "Виртуальная страница"

--- a/lang/si.yml
+++ b/lang/si.yml
@@ -1,10 +1,16 @@
 si:
+  AssetAdmin:
+    NEWFOLDER: "අලත් ගොනුවක්"
+  AssetAdmin_left_ss:
+    GO: යන්න
   CMSMain:
+    DELETE: "කටු අඩවියෙන් මකන්න"
     PAGENOTEXISTS: "මෙම  පිටුව තවදුරටත් නොපවතී"
     PUBALLCONFIRM: "අඩවියේ ඇති සියලු පිටු, වේදිකාවට පිටපත් කර ප්රසිද්ධ කරන්න"
     PUBALLFUN: "සියලු ක්රම වේද ප්රසිද්ධ කරන ලදී"
     REMOVEDPAGEFROMDRAFT: "කටු අඩවියෙන් '%s' මකන ලදී"
     ROLLBACK: "මෙම සංස්රනය ඉවත් කරනන්න"
+    SAVE: "සේවි කරන්න"
   ErrorPage:
     400: "400 - දුර්වල ඉල්ළීමක්"
     401: "401 - බල රහිත"
@@ -19,6 +25,8 @@ si:
     CODE: "වැරදි කේතය"
     DEFAULTERRORPAGECONTENT: "<p>කණගාටුයි,ඔබ නොමැති පිටුවකට යාමට උත්සාහ කරයි. </p><p>ඔබට යාමට අවශ්ය URL එකෙහි අක්ෂර පරීක්ෂා කර නැවත උත්සාහ කරන්න.</p>"
     DEFAULTERRORPAGETITLE: "පිටුව නොලැබුනි"
+  Folder:
+    UNUSEDFILESTITLE: "භාවිතා නොකළ ගොනු"
   RedirectorPage:
     HASBEENSETUP: "යොමු කිරීමේ පිටුව කිසිවකට යොමු නොකරයි"
     HEADER: "මෙම පිටුව පරිබෝඡකයන් වෙනත් යොමු කරයි"
@@ -35,6 +43,7 @@ si:
     ACCESSHEADER: "මෙම පිටුව බැලිය හැකි අය"
     ACCESSLOGGEDIN: "ප්රවිෂ්ටව සිටින පරිශීලකයින්"
     ACCESSONLYTHESE: "මේ අය පමනක් (ලයිස්තුවෙන් තෝරන්න)"
+    ALLOWCOMMENTS: "විචාර කිරීමට හැක"
     BUTTONCANCELDRAFT: "කටු වෙනස් කිරීම් අවලංගු කරන්න"
     BUTTONCANCELDRAFTDESC: "කටු සටහන මකා, දැනට ප්රසිද්ධ පිටුවට ඵකතු කරන්න"
     BUTTONUNPUBLISH: "අප්රසිද්ධ කරන්න"
@@ -64,3 +73,4 @@ si:
     HAVEASKED: "ඹබට අපගේ වෙබ් අඩවිය නිරීක්ශනය කරන ලෙස ඉල්ලා ඇත"
   VirtualPage:
     HEADER: "මෙය මනඃකල්පිත පිටුවකි"
+    SINGULARNAME: "මනඃකල්පිත පිටුව"

--- a/lang/sk.yml
+++ b/lang/sk.yml
@@ -1,10 +1,44 @@
 sk:
   AssetAdmin:
+    ADDFILES: "Pridať súbory"
+    ActionAdd: "Pridať priečinok"
+    AppCategoryArchive: Archív
+    AppCategoryAudio: Zvuk
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Obrázok
+    AppCategoryVideo: Video
+    BackToFolder: "Späť na priečinok"
+    CMSMENU_OLD: "Súbory (staré)"
+    CREATED: Dátum
+    CurrentFolderOnly: "Obmedziť na aktuálny priečinok?"
+    DetailsView: Detaily
     ErrorItemPermissionDenied: "Zdá sa, že nemáte potrebné oprávnenia na pridanie {ObjectTitle} ku kampani."
     ErrorNotFound: "{Type} nemožno nájsť"
+    FILES: Súbory
+    FILESYSTEMSYNC: "Synchronizovať súbory"
+    FILESYSTEMSYNCTITLE: "Aktualizuje záznamy súborov databázy CMS na súborovom systéme. Užitočné, keď sú nové súbory nahrané mimo CMS, napr cez FTP."
+    FROMTHEINTERNET: "Z internetu"
+    FROMYOURCOMPUTER: "Z vášho počitača"
+    Filetype: "Typ súboru"
+    ListView: "Zobraziť zoznam"
+    MENUTITLE: Súbory
+    NEWFOLDER: "Nový priečinok"
+    SIZE: Veľkosť
+    THUMBSDELETED: "{count} nepoužitých miniatúr bolo smazaných"
+    TreeView: "Zobraziť strom"
+    Upload: Nahrať
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Vymazať priečinky"
+  AssetAdmin_Tools:
+    FILTER: Filtrovať
+  AssetAdmin_left_ss:
+    GO: Choď
   AssetTableField:
     BACKLINKCOUNT: "Použité na:"
     PAGES: stránka(y)
+  BackLink_Button_ss:
+    Back: Späť
   BrokenLinksReport:
     Any: Akákoľvek
     BROKENLINKS: "Výkaz porušených odkazov"
@@ -33,12 +67,20 @@ sk:
     RESULT: "Vymazaných %d stránok z konceptu a publikovania a presunuté do archívu."
     TITLE: "Nezverejniť a archivovať"
   CMSBatchActions:
+    ARCHIVE: Archivovať
+    ARCHIVED_PAGES: "Archivované %d stranky"
+    DELETED_DRAFT_PAGES: "Smazaných %d stránok z konceptu webu, %d zlyhaní"
+    DELETED_PAGES: "Smazaných %d stránok z verejného webu, %d zlyhaní"
+    DELETE_DRAFT_PAGES: "Vymazať z návhrového webu"
+    DELETE_PAGES: "Vymazať z verejného webu"
     PUBLISHED_PAGES: "Publikovaných %d stránok, %d zlyhaní"
     PUBLISH_PAGES: Zverejniť
     RESTORE: Obnoviť
     RESTORED_PAGES: "Obnovených %d stránok"
     UNPUBLISHED_PAGES: "Nezverejnených %d stránok"
     UNPUBLISH_PAGES: Nezverejniť
+  CMSFileAddController:
+    MENUTITLE: Súbory
   CMSMain:
     ACCESS: "Pristup k '{title}' sekcii"
     ACCESS_HELP: "Povoliť prezeranie sekcie obsahujúcu strom stránok a obsah. Práva na prezeranie a úpravu môžu byť nastavené cez výber, ako aj jednotlivo  \"Práva obsahu\"."
@@ -51,10 +93,15 @@ sk:
     ChoosePageParentMode: "Vyberte, kde vytvoriť túto stránku"
     ChoosePageType: "Vyberte typ stránky"
     Create: Vytvoriť
+    DELETE: "Vymazať koncept"
+    DELETEFP: "Vymazať z publikovaného webu"
+    DESCREMOVED: "a {count} potomkov"
     DUPLICATED: "Duplikované '{title}' úspešne"
     DUPLICATEDWITHCHILDREN: "Duplikované '{title}' a potomkovia úspešne"
     EMAIL: E-mail
+    EditTree: "Editovať strom"
     ListFiltered: "Zobrazenie výsledkov vyhľadávania."
+    MENUTITLE: "Upraviť stránku"
     NEWPAGE: "Nová {pagetype}"
     PAGENOTEXISTS: "Táto stránka neexistuje."
     PAGES: "Stav stránky"
@@ -66,6 +113,7 @@ sk:
     PUBLISHED: "Uverejnené \"{title}\" úspešne."
     PUBPAGES: "Hotovo: Publikované {count} stránky"
     PageAdded: "Stránka vytvorená úspešne"
+    REMOVED: "Zmazané '{title}'{description} z webu"
     REMOVEDPAGE: "Zmazané '{title}' z verejného webu"
     REMOVEDPAGEFROMDRAFT: "Odstránené '%s' z konceptu webu"
     RESTORE: "Obnoviť koncept"
@@ -76,6 +124,7 @@ sk:
     ROLLBACK: "Návrat späť na túto verziu"
     ROLLEDBACKPUBv2: "Vrátené späť na zverejnenú verziu."
     ROLLEDBACKVERSIONv2: "Vrátené späť na verziu #%d."
+    SAVE: Uložiť
     SAVED: "Uložené '{title}' úspešne."
     SAVEDRAFT: "Uložiť koncept"
     TabContent: Obsah
@@ -87,12 +136,18 @@ sk:
   CMSMain_left_ss:
     APPLY_FILTER: Hľadať
     CLEAR_FILTER: Vyčistiť
+    RESET: Reset
   CMSPageAddController:
+    MENUTITLE: "Pridať stránku"
     ParentMode_child: "Pod inú stránku"
     ParentMode_top: "Najvyššia úroveň"
+  CMSPageEditController:
+    MENUTITLE: "Upraviť stránku"
   CMSPageHistoryController:
     COMPAREMODE: "Mód porovnania (vyberte dva)"
     COMPAREVERSIONS: "Porovnať verzie"
+    COMPARINGVERSION: "Porovnie verzií {version1} a {version2}."
+    MENUTITLE: História
     REVERTTOTHISVERSION: "Vrátiť sa k tejto verzii"
     SHOWUNPUBLISHED: "Zobraziť nepublikované verzie"
     SHOWVERSION: "Zobraziť verziu"
@@ -106,7 +161,10 @@ sk:
     PUBLISHER: Vydavateľ
     UNKNOWN: Neznáma
     WHEN: Keď
+  CMSPageSettingsController:
+    MENUTITLE: "Editovať stránku"
   CMSPagesController:
+    GalleryView: "Zobraziť galériu"
     ListView: "Zobraziť zoznam"
     MENUTITLE: Stránky
     TreeView: "Zobraziť strom"
@@ -118,9 +176,12 @@ sk:
     Title: "Zverejnené stránky"
   CMSSearch:
     FILTERDATEFROM: Od
+    FILTERDATEHEADING: Dátum
     FILTERDATETO: Do
     FILTERLABELTEXT: Hľadať
     PAGEFILTERDATEHEADING: "Posledne zmenené"
+  CMSSettingsController:
+    MENUTITLE: Nastavenia
   CMSSiteTreeFilter_ChangedPages:
     Title: "Zmenené stránky"
   CMSSiteTreeFilter_DeletedPages:
@@ -141,6 +202,7 @@ sk:
     CMS: CMS
     DRAFT: Koncept
     DRAFTSITE: "Koncept webu"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Pre zobrazenie návrhov alebo archivovaného obsahu sa musíte prihlásiť so svojím CMS heslom. <a href=\"%s\">Pre návrat na publikovaný web kliknite Tu.</a>"
     Email: E-mail
     INSTALL_SUCCESS: "Inštalácia úspešná!"
     InstallFilesDeleted: "Inštalačné súbory boli odstranené úspešne."
@@ -186,18 +248,40 @@ sk:
     CODE: "Chybový kód"
     DEFAULTERRORPAGECONTENT: "<p>Prepáčte, vyzerá to tak, že sa snažíte otvoriť stránku, ktorá neexistuje.</p><p> Skontrolujte napísanú URL, prosím.</p>"
     DEFAULTERRORPAGETITLE: "Stránka nenájdená"
-    DEFAULTSERVERERRORPAGECONTENT: "<p>Prepáčte, nastal problém s manipuláciou vašej požiadavky.</p>"
+    DEFAULTSERVERERRORPAGECONTENT: "<p>Prepáčte, ale bol problém s manipuláciou vášho požiadavku.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Chyba servera"
+    DESCRIPTION: "Vlastný obsah pre rôzne prípady chýb (napr. \"Stránka nenájdená\")"
+    ERRORFILEPROBLEM: "Chyba otvorenia súboru \"{filename}\" pre zápis. Skontrolujte oprávnenia súboru, prosím."
+    PLURALNAME: "Chybové stránky"
+    SINGULARNAME: "Chybová stránka"
+  File:
+    Title: Názov
+  Folder:
+    AddFolderButton: "Pridať priečinok"
+    DELETEUNUSEDTHUMBNAILS: "Vymazať nepoužité miniatúry"
+    UNUSEDFILESTITLE: "Nepoužité súbory"
+    UNUSEDTHUMBNAILSTITLE: "Nepoužité miniatúry"
+    UploadFilesButton: Nahrať
+  LeftAndMain:
+    DELETED: Zmazané.
+    PreviewButton: Zobrazenie
+    SAVEDUP: Uložené.
+    SearchResults: "Výsledky vyhľadávania"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Prístup do CMS"
   Permissions:
     CONTENT_CATEGORY: "Práva k obsahu"
     PERMISSIONS_CATEGORY: "Úlohy a prístupové práva"
   RedirectorPage:
+    DESCRIPTION: "Presmeruje na inú internú stránku"
     HASBEENSETUP: "Stránka na presmerovanie bola nastavená bez cieľa."
     HEADER: "Táto stránka presmeruje používateľov na inú stránku"
     OTHERURL: "Iné web URL."
+    PLURALNAME: "Presmerovacie stránky"
     REDIRECTTO: "Presmerovať na"
     REDIRECTTOEXTERNAL: "Iná web stránka"
     REDIRECTTOPAGE: "Stránka na vašom webe"
+    SINGULARNAME: "Presmerovacia stránka"
     YOURPAGE: "Stránka na vašom webe"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Bež
@@ -209,6 +293,11 @@ sk:
     OPERATION_REMOVE: "Odstrániť označené zo všetkých stupňov (Upozornenie: Budú zničené všetky označené stránky z konceptu a publikovania)"
     SELECTALL: "označiť všetko"
     UNSELECTALL: "odznačiť všetko"
+  ReportAdmin:
+    MENUTITLE: Výkazy
+    ReportTitle: Titulok
+  ReportAdminForm:
+    FILTERBY: "Filtrovať podľa"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Zverejnite prosím odkazovanú stránku pre zverejnenie virtuálnej stránky"
     VIRTUALPAGEWARNING: "Zvolte prosím odkazovanú stránku a uložte pre zverejnenie tejto stránky"
@@ -219,15 +308,23 @@ sk:
     SearchResults: "Výsledky vyhľadávania"
   SideReport:
     BROKENFILES: "Stránky z poškodenými súbormi"
+    BROKENLINKS: "Stránky z poškodenými odkazmi"
     BROKENREDIRECTORPAGES: "Presmerovacie stránky ukazujú na zmazané stránky"
     BROKENVIRTUALPAGES: "Virtuálne stránky odkazujú na vymazané stránky"
     BrokenLinksGroupTitle: "Výkazy porušených odkazov"
     ContentGroupTitle: "Výkazy obsahu"
     EMPTYPAGES: "Prázdne stránky"
     LAST2WEEKS: "Stránky upravené počas posledných 2 týždňov"
-    ParameterLiveCheckbox: "Skontrolovať publikovanú stránku"
+    OtherGroupTitle: Ostatné
+    ParameterLiveCheckbox: "Skontolovať publikovanú stránku"
+    REPEMPTY: "{title} výkaz je prázdny."
   SilverStripeNavigator:
     ARCHIVED: Archivované
+  SilverStripeNavigatorLink:
+    ShareInstructions: "Na zdieľaniu tejto stránky skopírujte a vložte odkaz nižšie."
+    ShareLink: "Zdieľať odkaz"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Zavrieť
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Pridať stránku"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -248,10 +345,28 @@ sk:
     SINGULARNAME: "Presmerovacia stránka"
   SilverStripe\CMS\Model\SiteTree:
     DESCRIPTION: "Obyčajná stránka s vlastným obsahom."
+    PLURALNAME: "Štruktúry webu"
+    SINGULARNAME: "Štruktúra webu"
   SilverStripe\CMS\Model\VirtualPage:
     DESCRIPTION: "Zobrazí obsah inej stránky"
     PLURALNAME: "Virtuálne stránky"
     SINGULARNAME: "Virtuálna stránka"
+  SiteConfig:
+    DEFAULTTHEME: "(Použi predvolenú tému)"
+    EDITHEADER: "Kto môže editovať stránky na tomto webe?"
+    EDIT_PERMISSION: "Spravovať konfiguráciu webu"
+    EDIT_PERMISSION_HELP: "Možnosť meniť globálne prístupové nastavenia/právomoci pre hlavné stránky."
+    PLURALNAME: "Konfigurácie webu"
+    SINGULARNAME: "Konfigurácia webu"
+    SITENAMEDEFAULT: "Názov vášho webu"
+    SITETAGLINE: "Slogan stránky"
+    SITETITLE: "Titulok webu"
+    TABACCESS: Prístup
+    TABMAIN: Hlavné
+    TAGLINEDEFAULT: "váš citát sem"
+    THEME: Téma
+    TOPLEVELCREATE: "Kto môže vytvárať koreňové stránky webu?"
+    VIEWHEADER: "Kto môže vidieť stránky na tomto webe?"
   SiteTree:
     ACCESSANYONE: Ktokoľvek
     ACCESSHEADER: "Kto môže prezerať túto stránku?"
@@ -259,9 +374,11 @@ sk:
     ACCESSONLYTHESE: "Iba títo ľudia (vyberte zo zoznamu)"
     ADDEDTODRAFTHELP: "Stránka ešte nebola zverejnená"
     ADDEDTODRAFTSHORT: Koncept
+    ALLOWCOMMENTS: "Povoliť komentáre na tejto stránke?"
     APPEARSVIRTUALPAGES: "Tento obsah sa zobrazí aj na virtuálnych stránkach v {title} sekciách."
     ARCHIVEDPAGEHELP: "Stránka je odstránená z konceptu a z webu"
     ARCHIVEDPAGESHORT: Archivované
+    BUTTONARCHIVEDESC: "Nezverejniť a odoslať do archívu"
     BUTTONCANCELDRAFT: "Zrušiť zmeny v koncepte"
     BUTTONCANCELDRAFTDESC: "Vymazať návrh a vrátiť sa k aktuálne zverejnenej stránke"
     BUTTONDELETEDESC: "Odstrániť z konceptu/publikovania a presunúť do archívu"
@@ -278,7 +395,10 @@ sk:
     DEFAULTCONTACTTITLE: Kontakt
     DEFAULTHOMECONTENT: "<p>Vitajte v SilverStripe! Toto je základná domáca stránka. Môžte ju upraviť otvorením <a href=\"admin/\">CMS</a>.</p><p>Môžte tiež vstúpiť k <a href=\"http://docs.silverstripe.org\">dokumentácii vývojára</a>, alebo sa priučit na <a href=\"http://www.silverstripe.org/learn/lessons\">SilverStripe lekciách</a>.</p>"
     DEFAULTHOMETITLE: Domov
+    DELETEDPAGEHELP: "Stránka už nie je viacej zverejnená"
+    DELETEDPAGESHORT: Zmazané
     DEPENDENT_NOTE: "Nasledujúce stránky sú závislé na tejto stránke. To zahŕňa virtuálne stránky, presmerovacie stránky a stránky s odkazmi obsahu."
+    DESCRIPTION: "Obyčajná jednoduchá stránka s vlastným obsahom."
     DependtPageColumnLinkType: "Typ odkazu"
     DependtPageColumnURL: URL
     EDITANYONE: "Ktokoľvek kto sa môže prihlásiť do CMS"
@@ -317,20 +437,25 @@ sk:
     PARENTID: "Nadradená stránka"
     PARENTTYPE: "Pozícia stránky"
     PARENTTYPE_ROOT: "Stránka najvyššej úrovne"
-    PARENTTYPE_SUBPAGE: "Podstránka pod rodičovskou stránkou"
+    PARENTTYPE_SUBPAGE: "Podstránka pod rodičovskou stránkov"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Spravovať prístupové práva pre obsah"
     PERMISSION_GRANTACCESS_HELP: "Povoliť nastavenie obmedzenia pre stránku v sekcií \"Stránky\"."
+    PLURALNAME: Stránky
     PageTypNotAllowedOnRoot: "Stránka typu \"{type}\" nie je povolená na najvyššej úrovni"
     PageTypeNotAllowed: "Stránka typu \"{type}\" nie je povolená ako potomok nadradenej stránky"
+    REMOVEDFROMDRAFTHELP: "Stránka je zverejnená, ale bola odstránená z konceptu"
+    REMOVEDFROMDRAFTSHORT: "Odstránené z konceptu"
     REMOVE_INSTALL_WARNING: "Upozornenie: Z bezpečnostných dôvodov odstránte súbor install.php z SilverStripe inštalácie."
     REORGANISE_DESCRIPTION: "Zmeniť štruktúru webu"
     REORGANISE_HELP: "Zoradiť stránky v stromovej štruktúre pomocou tiahni a pusť."
     SHOWINMENUS: "Zobraziť v ponuke?"
     SHOWINSEARCH: "Zobraziť v hľadaní?"
+    SINGULARNAME: Stránka
     TABBEHAVIOUR: Správanie
     TABCONTENT: "Hlavný obsah"
     TABDEPENDENT: "Závislé stránky"
     TOPLEVEL: "Obsah Webu (Najvyššia úroveň)"
+    TOPLEVELCREATORGROUPS: "Tvorcovia najvyššej úrovne"
     URLSegment: "Čast URL"
     VIEWERGROUPS: "Skupiny prezeračov"
     VIEW_ALL_DESCRIPTION: "Prezerať akúkoľvek stránku"
@@ -344,6 +469,8 @@ sk:
     many_many_ImageTracking: "Záznamy o obrázkoch"
     many_many_LinkTracking: "Záznamy o odkazoch"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Zoznam zobrazuje všetky stránky, kde bol súbor pridaný pomocou WYSIWYG editora."
+    EDIT: Editovať
     TITLE_INDEX: "#"
     TITLE_TYPE: Typ
     TITLE_USED_ON: "Použité na"
@@ -359,7 +486,10 @@ sk:
     HAVEASKED: "Požiadali ste o zobrazenie obsahu webu z"
   VirtualPage:
     CHOOSE: "Odkazovaná stránka"
+    DESCRIPTION: "Zobrazí obsah inej stránky"
     EditLink: editovať
     HEADER: "Toto je virtuálna stránka"
     HEADERWITHLINK: "Toto je virtuálna stránka, kopíruje sa obsah z \"{title}\" ({link})"
+    PLURALNAME: "Virtuálne stránky"
     PageTypNotAllowedOnRoot: "Pôvodná stránka typu \"{type}\" nie je povolená na najvyššej úrovni pre túto virtuálnu stránku"
+    SINGULARNAME: "Virtuálna stránka"

--- a/lang/sl.yml
+++ b/lang/sl.yml
@@ -1,10 +1,43 @@
 sl:
   AssetAdmin:
+    ADDFILES: "Dodaj datoteke"
+    ActionAdd: "Dodaj mapo"
+    AppCategoryArchive: Arhiv
+    AppCategoryAudio: Avdio
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Slika
+    AppCategoryVideo: Video
+    BackToFolder: "Nazaj v mapo"
+    CMSMENU_OLD: "Datoteke (starejše)"
+    CREATED: Datum
+    CurrentFolderOnly: "Nastavi limit za trenutno mapo?"
+    DetailsView: Podrobno
     ErrorItemPermissionDenied: "Izgleda, da nimate ustreznih pravic, da bi dodali {ObjectTitle} v kampanjo"
     ErrorNotFound: "Tip: {Type} ne obstaja"
+    FILES: Datoteke
+    FILESYSTEMSYNC: "Sinhroniziraj datoteke"
+    FILESYSTEMSYNCTITLE: "Osveži vnose v bazo podatkov CMS ali fatoteke v datotečnem sistemu. Uporabno, kadar nalagate mimo CMS, npr. prek FTP. "
+    FROMTHEINTERNET: "S spleta"
+    FROMYOURCOMPUTER: "Z vašega računalnika"
+    Filetype: "Tip datoteke"
+    ListView: "Pogled seznama"
+    MENUTITLE: Datoteke
+    NEWFOLDER: "Nova mapa"
+    SIZE: Velikost
+    THUMBSDELETED: "{count} neuporabljenih predoglednih sličic je bilo izbrisanih"
+    Upload: Naloži
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Izbriši mape"
+  AssetAdmin_Tools:
+    FILTER: Filter
+  AssetAdmin_left_ss:
+    GO: Pojdi
   AssetTableField:
     BACKLINKCOUNT: "Uporabljeno na:"
     PAGES: Stran/Strani
+  BackLink_Button_ss:
+    Back: Nazaj
   BrokenLinksReport:
     Any: Poljuben
     BROKENLINKS: "Poročilo o nedelujočih povezavah"
@@ -32,10 +65,16 @@ sl:
   CMSBatchAction_Archive:
     TITLE: "Odstrani iz objave in arhiviraj"
   CMSBatchActions:
+    ARCHIVE: Arhiv
+    ARCHIVED_PAGES: "Arhivirane %d strani"
+    DELETE_DRAFT_PAGES: "Izbriši z osnutka spletnega mesta"
+    DELETE_PAGES: "Izbriši z objavljenega spletnega mesta"
     PUBLISHED_PAGES: "Objavljenih je bilo %d strani. (Število napak %d)"
     PUBLISH_PAGES: Objavi
     RESTORE: Obnovi
     RESTORED_PAGES: "Obnovljene %d strani"
+  CMSFileAddController:
+    MENUTITLE: Datoteke
   CMSMain:
     ACCESS: "Dostop do razdelka '{title}' "
     ACCESS_HELP: "Dovoli vpogled  sklop z drevesno strukturo in vsebino. Pravice za ogled in urejanje je možno urejati prek dropdown-seznamov za vsako posamezno stran, ali pa ločeno v sklopu Nastavitve pravic za upravljanje z vsebino (Content permissions). "
@@ -48,7 +87,11 @@ sl:
     ChoosePageParentMode: "Izberite mesto, kjer želite ustvariti novo stran"
     ChoosePageType: "Izberi tip strani"
     Create: Ustvari
+    DELETE: "Izbriši z osnutka spletnega mesta"
+    DELETEFP: "Izbriši z objavljenega spletnega mesta"
     EMAIL: E-naslov
+    EditTree: "Uredi drevesno strukturo"
+    MENUTITLE: "Uredi stran"
     NEWPAGE: "Nov {pagetype}"
     PAGENOTEXISTS: "Stran na tem naslovu ne obstaja"
     PUBALLCONFIRM: "Objavite vse strani spletnega mesta (vsebine bodo prekopirane v \"objavljeno\" različico spletnega mesta)."
@@ -58,17 +101,25 @@ sl:
     REMOVEDPAGE: "'{title}' je odstranjen z objavljenega spletnega mesta. "
     REMOVEDPAGEFROMDRAFT: "Vsebina, odstranjena iz osnutka spletnega mesta: '%s'"
     ROLLBACK: "Ponastavi na to različico"
+    SAVE: Shrani
     SAVED: "Uspešno shranjeno '{title}'."
     SAVEDRAFT: "Shrani osnutek"
     TabContent: Vsebina
     TabHistory: Zgodovina
     TabSettings: Nastavitve
     UNPUBLISH_AND_ARCHIVE: "Odstrani iz objave in arhiviraj"
+  CMSMain_left_ss:
+    RESET: Ponastavi
   CMSPageAddController:
+    MENUTITLE: "Dodaj stran"
     ParentMode_top: "Stran na prvem nivoju"
+  CMSPageEditController:
+    MENUTITLE: "Uredi stran"
   CMSPageHistoryController:
     COMPAREMODE: "Način primerjanja (izberite dve)"
     COMPAREVERSIONS: "Primerjaj različice"
+    COMPARINGVERSION: "Primerjava različic {version1} in {version2}."
+    MENUTITLE: Zgodovina
     REVERTTOTHISVERSION: "Povrni v to različico"
     SHOWUNPUBLISHED: "Pokaži neobjavljeno različico"
     SHOWVERSION: "Pokaži različico"
@@ -80,6 +131,8 @@ sl:
     PREVIEW: "Predogled spletnega mesta"
     UNKNOWN: Neznano
     WHEN: Kdaj
+  CMSPageSettingsController:
+    MENUTITLE: "Uredi stran"
   CMSPagesController:
     MENUTITLE: Strani
   CMSPagesController_Tools_ss:
@@ -88,8 +141,11 @@ sl:
     Title: "Objavljene strani"
   CMSSearch:
     FILTERDATEFROM: Od
+    FILTERDATEHEADING: Datum
     FILTERDATETO: Do
     PAGEFILTERDATEHEADING: "Nazadnje spremenjeno"
+  CMSSettingsController:
+    MENUTITLE: Nastavitve
   CMSSiteTreeFilter_Search:
     Title: "Vse strani"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -102,6 +158,7 @@ sl:
     CMS: CMS
     DRAFT: Osnutek
     DRAFTSITE: "Osnutek spletnega mesta"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Za ogled osnutka vsebine ali arhiva tega spletnega mesta, se morate prijaviti s podatki za dostop do CMS-vmesnika. <a href=\"%s\">Nazaj na objavljeno različico spletnega mesta.</a>"
     Email: E-naslov
     INSTALL_SUCCESS: "Namestitev je bila uspešna!"
     InstallFilesDeleted: "Namestitvene datoteke so bile uspešno izbrisane."
@@ -146,37 +203,71 @@ sl:
     DEFAULTERRORPAGETITLE: "Strani ni mogoče najti"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Oprostite, pri vaši zahtevi je prišlo do težave.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Napaka na strežniku"
+    DESCRIPTION: "Prilagojena vsebina za različne primere napak (npr. \"Želene strani nismo uspeli najti.\")"
+    ERRORFILEPROBLEM: "Napaka pri odpiranju datoteke \"{filename}\" za pisanje. Prosim, preverite pravice za urejanje datoteke."
+    PLURALNAME: "Strani za napake"
+    SINGULARNAME: "Stran za napako"
+  File:
+    Title: Naslov
+  Folder:
+    AddFolderButton: "Dodaj mapo"
+    DELETEUNUSEDTHUMBNAILS: "Izbriši neuporabljene ikone"
+    UNUSEDFILESTITLE: "Neuporabljene datoteke"
+    UNUSEDTHUMBNAILSTITLE: "Neuporabljene ikone (pomanjšane slike)"
+    UploadFilesButton: Naloži
+  LeftAndMain:
+    DELETED: Izbrisano
+    PreviewButton: Predogled
+    SAVEDUP: Shranjeno.
+    SearchResults: "Iskani rezultati"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Dostop do CMS-vmesnika"
   Permissions:
     CONTENT_CATEGORY: "Nastavitve dovoljenj za upravljanje z vsebino"
     PERMISSIONS_CATEGORY: "Vloge in dovoljenja za dostop"
   RedirectorPage:
+    DESCRIPTION: "Preusmeri na drugo notranjo stran"
     HASBEENSETUP: "Nastavljena preusmeritev še nima določenega cilja."
     HEADER: "Ta stran bo preusmerila uporabnike na drugo stran"
     OTHERURL: "URL druge spletne strani"
+    PLURALNAME: "Preusmeritvene strani"
     REDIRECTTO: "Preusmeri na"
     REDIRECTTOEXTERNAL: "Druga spletna stran"
     REDIRECTTOPAGE: "Stran na tvojem spletnem mestu"
+    SINGULARNAME: "Preusmeritvena stran"
     YOURPAGE: "Stran na tvojem spletnem mestu"
   RemoveOrphanedPagesTask:
     BUTTONRUN: Zaženi
     CHOOSEOPERATION: "Izberi operacijo:"
     SELECTALL: "izberi vse"
     UNSELECTALL: "odstrani vse"
+  ReportAdmin:
+    MENUTITLE: Poročila
+    ReportTitle: Naslov
+  ReportAdminForm:
+    FILTERBY: "Filtriraj po"
   SearchForm:
     GO: Pojdi
     SEARCH: Išči
     SearchResults: "Rezultati iskanja"
   SideReport:
     BROKENFILES: "Strani s poškodovanimi datotekami"
+    BROKENLINKS: "Strani z nedelujočimi povezavami"
     BROKENREDIRECTORPAGES: "Preusmerjene strani, ki kažejo izbrisane strani"
     BROKENVIRTUALPAGES: "Navidezne strani, ki kažejo izbrisane strani"
     BrokenLinksGroupTitle: "Poročila o nedelujočih povezavah"
     ContentGroupTitle: "Poročila o vsebini"
     EMPTYPAGES: "Strani brez vsebine"
     LAST2WEEKS: "Strani, spremenjene v zadnjih 2 tednih"
+    OtherGroupTitle: Drugo
     ParameterLiveCheckbox: "Preveri na objavljenem spletnem mestu"
+    REPEMPTY: "Poročilo {title} je prazno."
   SilverStripeNavigator:
     ARCHIVED: Arhivirano
+  SilverStripeNavigatorLink:
+    ShareLink: "Posreduj povezavo"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Zapri
   SilverStripe\CMS\Controllers\CMSPageAddController:
     MENUTITLE: "Dodaj stran"
   SilverStripe\CMS\Controllers\CMSPageEditController:
@@ -196,6 +287,20 @@ sl:
   SilverStripe\CMS\Model\VirtualPage:
     PLURALNAME: "Virtualne strani"
     SINGULARNAME: "Virtualna stran"
+  SiteConfig:
+    DEFAULTTHEME: "(Uporabi privzeto temo)"
+    EDITHEADER: "Kdo lahko ureja strani na tem spletnem mestu?"
+    EDIT_PERMISSION: "Upravljanje nastavitev spletnega mesta"
+    EDIT_PERMISSION_HELP: "Možnost upravljanja z dostopom na najvišji ravni"
+    SITENAMEDEFAULT: "Naziv vašega spletnega mesta"
+    SITETAGLINE: Slogan
+    SITETITLE: "Naslov spletnega mesta (title)"
+    TABACCESS: Dostop
+    TABMAIN: Domov
+    TAGLINEDEFAULT: "sem vpišite slogan"
+    THEME: Tema
+    TOPLEVELCREATE: "Kdo lahko ustvarja glavne strani (na prvem nivoju)?"
+    VIEWHEADER: "Kdo lahko vidi strani na tem spletnem mestu?"
   SiteTree:
     ACCESSANYONE: Vsakdo
     ACCESSHEADER: "Kdo lahko vidi to stran?"
@@ -203,6 +308,7 @@ sl:
     ACCESSONLYTHESE: "Samo ti uporabniki (izberite jih s seznama)"
     ADDEDTODRAFTHELP: "Stran še ni bila objavljena"
     ADDEDTODRAFTSHORT: Osnutek
+    ALLOWCOMMENTS: "DOvoli komentarje na tej strani?"
     ARCHIVEDPAGESHORT: Arhivirano
     BUTTONCANCELDRAFT: "Prekliči spremembe osnutka"
     BUTTONCANCELDRAFTDESC: "Izbriši osnutek in ponastavi na trenutno objavljeno stran"
@@ -216,7 +322,10 @@ sl:
     DEFAULTABOUTTITLE: "O nas"
     DEFAULTCONTACTTITLE: Kontakt
     DEFAULTHOMETITLE: Domov
+    DELETEDPAGEHELP: "Stran ni več objavljena"
+    DELETEDPAGESHORT: Izbrisano
     DEPENDENT_NOTE: "Naslednje strani so odvisne od vsebine tukaj (vključuje navidezne strani, preusmerjevalne strani in strani s povezavami v vsebini)"
+    DESCRIPTION: "Generična vsebina stran"
     DependtPageColumnLinkType: "Tip povezave"
     DependtPageColumnURL: URL
     EDITANYONE: "Vsakdo, ki se prijavi v CMS-vmesnik"
@@ -254,17 +363,22 @@ sl:
     PARENTTYPE_SUBPAGE: "Podstran (izberi spodaj)"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Upravljaj s pravicami za dostop do vsebine"
     PERMISSION_GRANTACCESS_HELP: "Dovoli nastavitve pravic za dostop do izbrane strani v sklopu \"Strani\"."
+    PLURALNAME: Strani
     PageTypNotAllowedOnRoot: "Tip strani \"{type}\" ne more biti del osnovne korenske ravni"
     PageTypeNotAllowed: "Tip strani \"{type}\" ne more biti podrejen tej nadrejeni strani."
+    REMOVEDFROMDRAFTHELP: "Stran je objavljena, vendar ni bila izbrisana iz osnutkov."
+    REMOVEDFROMDRAFTSHORT: "Odstranjeno iz osnutkov"
     REMOVE_INSTALL_WARNING: "Pozor: Zaradi varnosti priporočamo, da odstranite install.php it te SilverStripe namestitve."
     REORGANISE_DESCRIPTION: "Spremeni strukturo spletnega mesta"
     REORGANISE_HELP: "Razvrsti strani v drevesni strukturi s funkcijo \"povleci in izpusti\"."
     SHOWINMENUS: "Pokaži v meniju?"
     SHOWINSEARCH: "Pokaži v iskalniku?"
+    SINGULARNAME: Stran
     TABBEHAVIOUR: Vedenje
     TABCONTENT: Vsebina
     TABDEPENDENT: "Odvisne strani"
     TOPLEVEL: "Vsebina Strani (Zgornja Stopnja)"
+    TOPLEVELCREATORGROUPS: "Glavni uredniki."
     URLSegment: "URL naslov strani"
     VIEWERGROUPS: "Skupine obiskovalcev"
     VIEW_ALL_DESCRIPTION: "Prikaz vse strani"
@@ -277,6 +391,8 @@ sl:
     many_many_ImageTracking: "Spremljanje slik"
     many_many_LinkTracking: "Spremljanje povezav"
   SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Ta seznam prikazuje vse strani, kjer so bile datoteke dodane s pomočjo WYSIWYG urejevalnika."
+    EDIT: Uredi
     TITLE_INDEX: "#"
     TITLE_TYPE: Tip
     TITLE_USED_ON: "Uporabljeno na"
@@ -292,5 +408,8 @@ sl:
     HAVEASKED: "Za vpogled v vsebino našega spletnega mesta ste zaprosili"
   VirtualPage:
     CHOOSE: "Povezana stran"
+    DESCRIPTION: "Prikaži vsebino druge strani"
     EditLink: uredi
     HEADER: "To je navidezna stran"
+    PLURALNAME: "Virtualne strani"
+    SINGULARNAME: "Virtualna stran"

--- a/lang/sr.yml
+++ b/lang/sr.yml
@@ -1,7 +1,41 @@
 sr:
+  AssetAdmin:
+    ADDFILES: "Додај датотеке"
+    ActionAdd: "Додај фасциклу"
+    AppCategoryArchive: Архива
+    AppCategoryAudio: Аудио
+    AppCategoryDocument: Документ
+    AppCategoryFlash: Flash
+    AppCategoryImage: Слика
+    AppCategoryVideo: Видео
+    BackToFolder: "Повратак у фасциклу"
+    CREATED: Датум
+    CurrentFolderOnly: "Само у овој фасцикли?"
+    DetailsView: Детаљи
+    FILES: Датотеке
+    FILESYSTEMSYNC: "Синхронизуј датотеке"
+    FILESYSTEMSYNCTITLE: "Ажурирање уноса у базу података CMS-a везаних за датотеке из датотечког система. Опција је корисна када је вршено постављање датотека изван CMS-а, нпр. путем FTP-а."
+    FROMTHEINTERNET: "Са интернета"
+    FROMYOURCOMPUTER: "Са Вашег рачунара"
+    Filetype: "Тип датотеке"
+    ListView: "Приказ у виду листе"
+    MENUTITLE: Датотеке
+    NEWFOLDER: "Нова фасцикла"
+    SIZE: Величина
+    THUMBSDELETED: "{count} некоришћених сличицâ је обрисано"
+    TreeView: "Преглед у виду стабла"
+    Upload: Постави
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Обриши фасцикле"
+  AssetAdmin_Tools:
+    FILTER: Филтер
+  AssetAdmin_left_ss:
+    GO: Иди
   AssetTableField:
     BACKLINKCOUNT: "Користи се на:"
     PAGES: страници(а)
+  BackLink_Button_ss:
+    Back: Назад
   BrokenLinksReport:
     Any: "Било који"
     BROKENLINKS: "Извештај о оштећеним линковима"
@@ -27,8 +61,14 @@ sr:
   CMSAddPageController:
     Title: "Додај страницу"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "Из нацрта сајта избрисано %d страница. Није успело брисање %d страница."
+    DELETED_PAGES: "Из објављеног сајта избрисано %d страница. Није успело брисање %d страница."
+    DELETE_DRAFT_PAGES: "Избриши из нацрта сајта"
+    DELETE_PAGES: "Избриши из објављеног сајта"
     PUBLISHED_PAGES: "Објављено %d страница. Није успело објављивање %d страница."
     PUBLISH_PAGES: Објави
+  CMSFileAddController:
+    MENUTITLE: Датотеке
   CMSMain:
     ACCESS: "Приступ '{title}' секцији"
     ACCESS_HELP: "Дозвољава преглед секције која садржи стабло страница и садржај. Дозволе за преглед и уређивање могу се подесити путем специфичних падајућих листи појединачних страница, као и путем \"Дозволе за садржај\"."
@@ -38,8 +78,13 @@ sr:
     ChoosePageParentMode: "Изаберите где желите да креирате ову страницу"
     ChoosePageType: "Изабери тип странице"
     Create: Креирај
+    DELETE: "Избриши нацрт"
+    DELETEFP: Избриши
+    DESCREMOVED: "и {count} потомака"
     DUPLICATED: "'{title}' успешно дуплиран"
     DUPLICATEDWITHCHILDREN: "'{title}' и деца успешно дуплирани"
+    EditTree: "Измени стабло"
+    MENUTITLE: "Измени страницу"
     NEWPAGE: "Нова {pagetype}"
     PAGENOTEXISTS: "Ова страница не постоји"
     PAGETYPEANYOPT: "Било која"
@@ -47,22 +92,31 @@ sr:
     PUBALLFUN: "Функција „Објави све“ "
     PUBPAGES: "Урађено: Објављено {count} страница"
     PageAdded: "Успешно креирана страница"
+    REMOVED: "Са објављеног сајта обрисана је страница '{title}'{description}"
     REMOVEDPAGE: "Са објављеног сајта уклоњена је страница '{title}'"
     REMOVEDPAGEFROMDRAFT: "Страница '%s' је уклоњена из нацрта сајта"
     RESTORED: "'{title}' успешно обновљен"
     ROLLBACK: "Врати се на ову верзију"
     ROLLEDBACKPUBv2: "Враћено на објављену верзију."
     ROLLEDBACKVERSIONv2: "Враћено на верзију #%d."
+    SAVE: Сачувај
     SAVEDRAFT: "Сачувај нацрт"
     TabContent: Садржај
     TabHistory: Историја
     TabSettings: Подешавања
+  CMSMain_left_ss:
+    RESET: "Врати у пређашње стање"
   CMSPageAddController:
+    MENUTITLE: "Додај страницу"
     ParentMode_child: "Као подстраницу друге странице"
     ParentMode_top: "Вршни ниво"
+  CMSPageEditController:
+    MENUTITLE: "Измени страницу"
   CMSPageHistoryController:
     COMPAREMODE: "Режим поређења (изабери два)"
     COMPAREVERSIONS: "Упореди верзије"
+    COMPARINGVERSION: "Поређење верзија {version1} и {version2}."
+    MENUTITLE: Историја
     REVERTTOTHISVERSION: "Врати на ову верзију"
     SHOWUNPUBLISHED: "Прикажи необјављене верзије"
     SHOWVERSION: "Прикажи верзију"
@@ -75,7 +129,10 @@ sr:
     PUBLISHER: Објављивач
     UNKNOWN: Непознато
     WHEN: Датум
+  CMSPageSettingsController:
+    MENUTITLE: "Измени страницу"
   CMSPagesController:
+    GalleryView: "Приказ у виду галерије"
     ListView: "Приказ у виду листе"
     MENUTITLE: Странице
     TreeView: "Приказ у виду стабла"
@@ -83,7 +140,10 @@ sr:
     FILTER: Филтер
   CMSSearch:
     FILTERDATEFROM: Од
+    FILTERDATEHEADING: Датум
     FILTERDATETO: За
+  CMSSettingsController:
+    MENUTITLE: Подешавања
   CMSSiteTreeFilter_Search:
     Title: "Све странице"
   ContentControl:
@@ -94,6 +154,7 @@ sr:
     CMS: CMS
     DRAFT: Нацрт
     DRAFTSITE: "Нарцт сајта"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Да би сте прегледали нацрт сајта или архивирани садржај морате бити пријављени Вашом CMS лозинком. <a href=\"%s\">Кликните овде да би сте се вратили на објављени сајт.</a>"
     Email: Е-пошта
     INSTALL_SUCCESS: "Инсталација је успешно обављена!"
     InstallFilesDeleted: "Инсталационе датотеке су успешно обрисане."
@@ -139,17 +200,40 @@ sr:
     DEFAULTERRORPAGETITLE: "Страница није пронађена"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Извињавамо се, постоји проблем при обради Вашег захтева.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Грешка сервера"
+    DESCRIPTION: "Прилагођени садржај за различите случајеве грешака (нпр. \"Страница није пронађена\" )"
+    ERRORFILEPROBLEM: "Грешка при отварању датотеке \"{filename}\" за упис. Молимо Вас да проверите права приступа датотеци. "
+    SINGULARNAME: "Страница грешке"
+  Folder:
+    AddFolderButton: "Додај фасциклу"
+    DELETEUNUSEDTHUMBNAILS: "Избриши некоришћене сличице"
+    UNUSEDFILESTITLE: "Некоришћене датотеке"
+    UNUSEDTHUMBNAILSTITLE: "Некоришћени умањени прикази"
+    UploadFilesButton: Постави
+  LeftAndMain:
+    DELETED: Избрисано.
+    PreviewButton: "Претходни преглед"
+    SAVEDUP: Сачувано.
+    SearchResults: "Резултати претраживања"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Приступ CMS-у"
   Permissions:
     CONTENT_CATEGORY: "Дозволе за садржај"
     PERMISSIONS_CATEGORY: "Улоге и дозволе за приступ"
   RedirectorPage:
+    DESCRIPTION: "Преусмерава на другу интерну страницу"
     HASBEENSETUP: "Страници за преусмеравање није подешено одредиште на које преусмерава."
     HEADER: "Ова страница ће преусмерити кориснике на другу страницу"
     OTHERURL: "URL другог веб сајта"
     REDIRECTTO: "Преусмери на"
     REDIRECTTOEXTERNAL: "Други веб сајт"
     REDIRECTTOPAGE: "Страницу на Вашем веб сајту"
+    SINGULARNAME: "Страница за преусмеравање"
     YOURPAGE: "Страница на Вашем веб сајту"
+  ReportAdmin:
+    MENUTITLE: Извештаји
+    ReportTitle: Наслов
+  ReportAdminForm:
+    FILTERBY: "Филтрирај по"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Молимо вас да објавите повезану страницу, како би виртуелна страница била објављена"
     VIRTUALPAGEWARNING: "Молимо Вас да изаберете повезану страницу и сачувате измену пре него што објавите ову страницу"
@@ -160,15 +244,38 @@ sr:
     SearchResults: "Резултати претраживања"
   SideReport:
     BROKENFILES: "Странице са оштећеним датотекама"
+    BROKENLINKS: "Странице са оштећеним линковима"
     BROKENREDIRECTORPAGES: "Странице за преусмеривање које показују на избрисане странице"
     BROKENVIRTUALPAGES: "Виртуелне странице која показују на избрисане странице"
     BrokenLinksGroupTitle: "Извештај о оштећеним линковима"
     ContentGroupTitle: "Извештаји о садржају"
     EMPTYPAGES: "Празне странice"
     LAST2WEEKS: "Странице мењане у задње 2 недеље"
+    OtherGroupTitle: Остало
     ParameterLiveCheckbox: "Провери објављени сајт"
+    REPEMPTY: "Извештај {title} је празан."
   SilverStripeNavigator:
     ARCHIVED: Архивирано
+  SilverStripeNavigatorLink:
+    ShareLink: "Подели линк"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Затвори
+  SiteConfig:
+    DEFAULTTHEME: "(Користи подразумевану тему)"
+    EDITHEADER: "Ко може да мења странице на овом сајту?"
+    EDIT_PERMISSION: "Управљање конфигурацијом сајта"
+    EDIT_PERMISSION_HELP: "Могућност измене подешавања глобалног приступа/дозволâ за приступ страницама вршног нивоа"
+    PLURALNAME: "Конфигурације сајта"
+    SINGULARNAME: "Конфигурација сајта"
+    SITENAMEDEFAULT: "Назив сајта"
+    SITETAGLINE: Слоган
+    SITETITLE: "Наслов сајта"
+    TABACCESS: Приступ
+    TABMAIN: Главно
+    TAGLINEDEFAULT: "Ваш слоган"
+    THEME: Тема
+    TOPLEVELCREATE: "Ко може креирати странице вршног нивоа на сајту?"
+    VIEWHEADER: "Ко може да види странице овог сајта?"
   SiteTree:
     ACCESSANYONE: Свако
     ACCESSHEADER: "Ко може да види ову страницу?"
@@ -176,6 +283,7 @@ sr:
     ACCESSONLYTHESE: "Само ове особе (изабери са листе)"
     ADDEDTODRAFTHELP: "Страница још није објављена"
     ADDEDTODRAFTSHORT: Нацрт
+    ALLOWCOMMENTS: "Дозволити коментаре на овој страни?"
     APPEARSVIRTUALPAGES: "Овај садржај се приказује и у секцијама {title} виртуелних страницâ."
     BUTTONCANCELDRAFT: "Откажи промене нацрта"
     BUTTONCANCELDRAFTDESC: "Избришите свој нацрт и вратите се на тренутно објављену страну"
@@ -189,7 +297,10 @@ sr:
     DEFAULTABOUTTITLE: "О нама"
     DEFAULTCONTACTTITLE: "Контактирајте нас"
     DEFAULTHOMETITLE: "Почетна страница"
+    DELETEDPAGEHELP: "Страница није више објављена"
+    DELETEDPAGESHORT: Избрисано
     DEPENDENT_NOTE: "Следеће странице зависе од ове странице. Ово подразумева витруелне странице, странице за преусмеравање и странице са линковима на садржај."
+    DESCRIPTION: "Обична страница"
     DependtPageColumnLinkType: "Тип линка"
     DependtPageColumnURL: URL
     EDITANYONE: "Свако ко може да се пријави на CMS"
@@ -227,17 +338,22 @@ sr:
     PARENTTYPE_SUBPAGE: "Подстраница родитељске странице"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Управљај дозволама за садржај"
     PERMISSION_GRANTACCESS_HELP: "Омогућава подешавање ограничења приступа у секцији \"Странице\" за сваку страницу појединачно."
+    PLURALNAME: Странице
     PageTypNotAllowedOnRoot: "Тип странице \"{type}\" није дозвољен на вршном нивоу"
     PageTypeNotAllowed: "Тип странице \"{type}\" није дозвољен за децу ове родитељске странице"
+    REMOVEDFROMDRAFTHELP: "Странице је објављена, али је избрисана из нацрта"
+    REMOVEDFROMDRAFTSHORT: "Избрисано из нацрта"
     REMOVE_INSTALL_WARNING: "Упозорење: из безбедносних разлога било би пожељно да обришете датотеку  install.php ове SilverStripe инсталације"
     REORGANISE_DESCRIPTION: "Измени структуру сајта"
     REORGANISE_HELP: "Преуреди странице у стаблу сајта користећи поступак повуци и испусти."
     SHOWINMENUS: "Приказати у менијима?"
     SHOWINSEARCH: "Приказати у претраживањима?"
+    SINGULARNAME: Страница
     TABBEHAVIOUR: Понашање
     TABCONTENT: "Главни садржај"
     TABDEPENDENT: "Зависне странице"
     TOPLEVEL: "Садржај сајта (вршни ниво)"
+    TOPLEVELCREATORGROUPS: "Креатори вршног нивоа"
     URLSegment: "Сегмент URL-a"
     VIEWERGROUPS: "Групе за преглед"
     VIEW_ALL_DESCRIPTION: "Погледај било коју страницу"
@@ -262,7 +378,9 @@ sr:
     HAVEASKED: "Замољени сте да погледате садржај овог сајта"
   VirtualPage:
     CHOOSE: "Повезана страница"
+    DESCRIPTION: "Приказује садржај друге странице"
     EditLink: измени
     HEADER: "Ово је виртуелна страница"
     HEADERWITHLINK: "Ово је виртуелна страница која копира садржај из \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Оригинални тип странице \"{type}\" није дозвољен на вршном нивоу за ову виртуелну страницу"
+    SINGULARNAME: "Виртуелна страница"

--- a/lang/sr_RS@latin.yml
+++ b/lang/sr_RS@latin.yml
@@ -1,7 +1,41 @@
 sr_RS@latin:
+  AssetAdmin:
+    ADDFILES: "Dodaj datoteke"
+    ActionAdd: "Dodaj fasciklu"
+    AppCategoryArchive: Arhiva
+    AppCategoryAudio: Audio
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Slika
+    AppCategoryVideo: Video
+    BackToFolder: "Povratak u fasciklu"
+    CREATED: Datum
+    CurrentFolderOnly: "Samo u ovoj fascikli?"
+    DetailsView: Detalji
+    FILES: Datoteke
+    FILESYSTEMSYNC: "Sinhronizuj datoteke"
+    FILESYSTEMSYNCTITLE: "Ažuriranje unosa u bazu podataka CMS-a vezanih za datoteke iz datotečkog sistema. Opcija je korisna kada je vršeno postavljanje datoteka izvan CMS-a, npr. putem FTP-a."
+    FROMTHEINTERNET: "Sa interneta"
+    FROMYOURCOMPUTER: "Sa Vašeg računara"
+    Filetype: "Tip datoteke"
+    ListView: "Prikaz u vidu liste"
+    MENUTITLE: Datoteke
+    NEWFOLDER: "Nova fascikla"
+    SIZE: Veličina
+    THUMBSDELETED: "{count} nekorišćenih sličicâ je obrisano"
+    TreeView: "Pregled u vidu stabla"
+    Upload: Postavi
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Obriši fascikle"
+  AssetAdmin_Tools:
+    FILTER: Filter
+  AssetAdmin_left_ss:
+    GO: Idi
   AssetTableField:
     BACKLINKCOUNT: "Koristi se na:"
     PAGES: stranici(a)
+  BackLink_Button_ss:
+    Back: Nazad
   BrokenLinksReport:
     Any: "Bilo koji"
     BROKENLINKS: "Izveštaj o oštećenim linkovima"
@@ -27,8 +61,14 @@ sr_RS@latin:
   CMSAddPageController:
     Title: "Dodaj stranicu"
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "Iz nacrta sajta izbrisano %d stranica. Nije uspelo brisanje %d stranica."
+    DELETED_PAGES: "Iz objavljenog sajta izbrisano %d stranica. Nije uspelo brisanje %d stranica."
+    DELETE_DRAFT_PAGES: "Izbriši iz nacrta sajta"
+    DELETE_PAGES: "Izbriši iz objavljenog sajta"
     PUBLISHED_PAGES: "Objavljeno %d stranica. Nije uspelo objavljivanje %d stranica."
     PUBLISH_PAGES: Objavi
+  CMSFileAddController:
+    MENUTITLE: Datoteke
   CMSMain:
     ACCESS: "Pristup '{title}' sekciji"
     ACCESS_HELP: "Dozvoljava pregled sekcije koja sadrži stablo stranica i sadržaj. Dozvole za pregled i uređivanje mogu se podesiti putem specifičnih padajućih listi pojedinačnih stranica, kao i putem \"Dozvole za sadržaj\"."
@@ -38,8 +78,13 @@ sr_RS@latin:
     ChoosePageParentMode: "Izaberite gde želite da kreirate ovu stranicu"
     ChoosePageType: "Izaberi tip stranice"
     Create: Kreiraj
+    DELETE: "Izbriši nacrt"
+    DELETEFP: Izbriši
+    DESCREMOVED: "i {count} potomaka"
     DUPLICATED: "'{title}' uspešno dupliran"
     DUPLICATEDWITHCHILDREN: "'{title}' i deca uspešno duplirani"
+    EditTree: "Izmeni stablo"
+    MENUTITLE: "Izmeni stranicu"
     NEWPAGE: "Nova {pagetype}"
     PAGENOTEXISTS: "Ova stranica ne postoji"
     PAGETYPEANYOPT: "Bilo koja"
@@ -47,22 +92,31 @@ sr_RS@latin:
     PUBALLFUN: "Funkcija „Objavi sve“ "
     PUBPAGES: "Urađeno: Objavljeno {count} stranica"
     PageAdded: "Uspešno kreirana stranica"
+    REMOVED: "Sa objavljenog sajta obrisana je stranica '{title}'{description}"
     REMOVEDPAGE: "Sa objavljenog sajta uklonjena je stranica '{title}'"
     REMOVEDPAGEFROMDRAFT: "Stranica '%s' je uklonjena iz nacrta sajta"
     RESTORED: "'{title}' uspešno obnovljen"
     ROLLBACK: "Vrati se na ovu verziju"
     ROLLEDBACKPUBv2: "Vraćeno na objavljenu verziju."
     ROLLEDBACKVERSIONv2: "Vraćeno na verziju #%d."
+    SAVE: Sačuvaj
     SAVEDRAFT: "Sačuvaj nacrt"
     TabContent: Sadržaj
     TabHistory: Istorija
     TabSettings: Podešavanja
+  CMSMain_left_ss:
+    RESET: "Vrati u pređašnje stanje"
   CMSPageAddController:
+    MENUTITLE: "Dodaj stranicu"
     ParentMode_child: "Kao podstranicu druge stranice"
     ParentMode_top: "Vršni nivo"
+  CMSPageEditController:
+    MENUTITLE: "Izmeni stranicu"
   CMSPageHistoryController:
     COMPAREMODE: "Režim poređenja (izaberi dva)"
     COMPAREVERSIONS: "Uporedi verzije"
+    COMPARINGVERSION: "Poređenje verzija {version1} i {version2}."
+    MENUTITLE: Istorija
     REVERTTOTHISVERSION: "Vrati na ovu verziju"
     SHOWUNPUBLISHED: "Prikaži neobjavljene verzije"
     SHOWVERSION: "Prikaži verziju"
@@ -75,7 +129,10 @@ sr_RS@latin:
     PUBLISHER: Objavljivač
     UNKNOWN: Nepoznato
     WHEN: Datum
+  CMSPageSettingsController:
+    MENUTITLE: "Izmeni stranicu"
   CMSPagesController:
+    GalleryView: "Prikaz u vidu galerije"
     ListView: "Prikaz u vidu liste"
     MENUTITLE: Stranice
     TreeView: "Prikaz u vidu stabla"
@@ -83,7 +140,10 @@ sr_RS@latin:
     FILTER: Filter
   CMSSearch:
     FILTERDATEFROM: Od
+    FILTERDATEHEADING: Datum
     FILTERDATETO: Za
+  CMSSettingsController:
+    MENUTITLE: Podešavanja
   CMSSiteTreeFilter_Search:
     Title: "Sve stranice"
   ContentControl:
@@ -94,6 +154,7 @@ sr_RS@latin:
     CMS: CMS
     DRAFT: Nacrt
     DRAFTSITE: "Narct sajta"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Da bi ste pregledali nacrt sajta ili arhivirani sadržaj morate biti prijavljeni Vašom CMS lozinkom. <a href=\"%s\">Kliknite ovde da bi ste se vratili na objavljeni sajt.</a>"
     Email: E-pošta
     INSTALL_SUCCESS: "Instalacija je uspešno obavljena!"
     InstallFilesDeleted: "Instalacione datoteke su uspešno obrisane."
@@ -139,17 +200,40 @@ sr_RS@latin:
     DEFAULTERRORPAGETITLE: "Stranica nije pronađena"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Izvinjavamo se, postoji problem pri obradi Vašeg zahteva.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Greška servera"
+    DESCRIPTION: "Prilagođeni sadržaj za različite slučajeve grešaka (npr. \"Stranica nije pronađena\" )"
+    ERRORFILEPROBLEM: "Greška pri otvaranju datoteke \"{filename}\" za upis. Molimo Vas da proverite prava pristupa datoteci. "
+    SINGULARNAME: "Stranica greške"
+  Folder:
+    AddFolderButton: "Dodaj fasciklu"
+    DELETEUNUSEDTHUMBNAILS: "Izbriši nekorišćene sličice"
+    UNUSEDFILESTITLE: "Nekorišćene datoteke"
+    UNUSEDTHUMBNAILSTITLE: "Nekorišćeni umanjeni prikazi"
+    UploadFilesButton: Postavi
+  LeftAndMain:
+    DELETED: Izbrisano.
+    PreviewButton: "Prethodni pregled"
+    SAVEDUP: Sačuvano.
+    SearchResults: "Rezultati pretraživanja"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Pristup CMS-u"
   Permissions:
     CONTENT_CATEGORY: "Dozvolje za sadržaj"
     PERMISSIONS_CATEGORY: "Uloge i dozvole za pristup"
   RedirectorPage:
+    DESCRIPTION: "Preusmerava na drugu internu stranicu"
     HASBEENSETUP: "Stranici za preusmeravanje nije podešeno odredište na koje preusmerava."
     HEADER: "Ova stranica će preusmeriti korisnike na drugu stranicu"
     OTHERURL: "URL drugog veb sajta"
     REDIRECTTO: "Preusmeri na"
     REDIRECTTOEXTERNAL: "Drugi veb sajt"
     REDIRECTTOPAGE: "Stranicu na Vašem veb sajtu"
+    SINGULARNAME: "Stranica za preusmeravanje"
     YOURPAGE: "Stranica na Vašem veb sajtu"
+  ReportAdmin:
+    MENUTITLE: Izveštaji
+    ReportTitle: Naslov
+  ReportAdminForm:
+    FILTERBY: "Filtriraj po"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Molimo vas da objavite povezanu stranicu, kako bi virtuelna stranica bila objavljena"
     VIRTUALPAGEWARNING: "Molimo Vas da izaberete povezanu stranicu i sačuvate izmenu pre nego što objavite ovu stranicu"
@@ -160,15 +244,38 @@ sr_RS@latin:
     SearchResults: "Rezultati pretraživanja"
   SideReport:
     BROKENFILES: "Stranice sa oštećenim datotekama"
+    BROKENLINKS: "Stranice sa oštećenim linkovima"
     BROKENREDIRECTORPAGES: "Stranice za preusmerivanje koje pokazuju na izbrisane stranice"
     BROKENVIRTUALPAGES: "Virtuelne stranice koja pokazuju na izbrisane stranice"
     BrokenLinksGroupTitle: "Izveštaj o oštećenim linkovima"
     ContentGroupTitle: "Izveštaji o sadržaju"
     EMPTYPAGES: "Prazne stranice"
     LAST2WEEKS: "Stranice menjane u zadnje 2 nedelje"
+    OtherGroupTitle: Ostalo
     ParameterLiveCheckbox: "Proveri objavljeni sajt"
+    REPEMPTY: "Izveštaj {title} je prazan."
   SilverStripeNavigator:
     ARCHIVED: Arhivirano
+  SilverStripeNavigatorLink:
+    ShareLink: "Podeli link"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Zatvori
+  SiteConfig:
+    DEFAULTTHEME: "(Koristi podrazumevanu temu)"
+    EDITHEADER: "Ko može da menja stranice na ovom sajtu?"
+    EDIT_PERMISSION: "Upravljanje konfiguracijom sajta"
+    EDIT_PERMISSION_HELP: "Mogućnost izmene podešavanja globalnog pristupa/dozvola za pristup stranicama vršnog nivoa"
+    PLURALNAME: "Konfiguracije sajta"
+    SINGULARNAME: "Konfiguracija sajta"
+    SITENAMEDEFAULT: "Naziv sajta"
+    SITETAGLINE: Slogan
+    SITETITLE: "Naslov sajta"
+    TABACCESS: Pristup
+    TABMAIN: Glavno
+    TAGLINEDEFAULT: "Vaš slogan"
+    THEME: Tema
+    TOPLEVELCREATE: "Ko može kreirati stranice vršnog nivoa na sajtu?"
+    VIEWHEADER: "Ko može da vidi stranice ovog sajta?"
   SiteTree:
     ACCESSANYONE: Svako
     ACCESSHEADER: "Ko može da vidi ovu stranicu?"
@@ -176,6 +283,7 @@ sr_RS@latin:
     ACCESSONLYTHESE: "Samo ove osobe (izaberi sa liste)"
     ADDEDTODRAFTHELP: "Stranica još nije objavljena"
     ADDEDTODRAFTSHORT: Nacrt
+    ALLOWCOMMENTS: "Dozvoliti komentare na ovoj strani?"
     APPEARSVIRTUALPAGES: "Ovaj sadržaj se prikazuje i u sekcijama {title} virtuelnih stranicâ."
     BUTTONCANCELDRAFT: "Otkaži promene nacrta"
     BUTTONCANCELDRAFTDESC: "Izbrišite svoj nacrt i vratite se na trenutno objavljenu stranu"
@@ -189,7 +297,10 @@ sr_RS@latin:
     DEFAULTABOUTTITLE: "O nama"
     DEFAULTCONTACTTITLE: "Kontaktirajte nas"
     DEFAULTHOMETITLE: "Početna stranica"
+    DELETEDPAGEHELP: "Stranica nije više objavljena"
+    DELETEDPAGESHORT: Izbrisano
     DEPENDENT_NOTE: "Sledeće stranice zavise od ove stranice. Ovo podrazumeva vitruelne stranice, stranice za preusmeravanje i stranice sa linkovima na sadržaj."
+    DESCRIPTION: "Obična stranica"
     DependtPageColumnLinkType: "Tip linka"
     DependtPageColumnURL: URL
     EDITANYONE: "Svako ko može da se prijavi na CMS"
@@ -227,17 +338,22 @@ sr_RS@latin:
     PARENTTYPE_SUBPAGE: "Podstranica roditeljske stranice"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Upravljaj dozvolama za pristup sadržaju"
     PERMISSION_GRANTACCESS_HELP: "Omogućava podešavanje ograničenja pristupa u sekciji \"Stranice\" za svaku stranicu pojedinačno."
+    PLURALNAME: Stranice
     PageTypNotAllowedOnRoot: "Tip stranice \"{type}\" nije dozvoljen na vršnom nivou"
     PageTypeNotAllowed: "Tip stranice \"{type}\" nije dozvoljen za decu ove roditeljske stranice"
+    REMOVEDFROMDRAFTHELP: "Stranice je objavljena, ali je izbrisana iz nacrta"
+    REMOVEDFROMDRAFTSHORT: "Izbrisano iz nacrta"
     REMOVE_INSTALL_WARNING: "Upozorenje: iz bezbednosnih razloga bilo bi poželjno da obrišete datoteku  install.php ove SilverStripe instalacije"
     REORGANISE_DESCRIPTION: "Izmeni strukturu sajta"
     REORGANISE_HELP: "Preuredi stranice u stablu sajta koristeći postupak povuci i ispusti."
     SHOWINMENUS: "Prikazati u menijima?"
     SHOWINSEARCH: "Prikazati u pretraživanjima?"
+    SINGULARNAME: Stranica
     TABBEHAVIOUR: Ponašanje
     TABCONTENT: "Glavni sadržaj"
     TABDEPENDENT: "Zavisne stranice"
     TOPLEVEL: "Sadržaj sajta (vršni nivo)"
+    TOPLEVELCREATORGROUPS: "Kreatori vršnog nivoa"
     URLSegment: "Segment URL-a"
     VIEWERGROUPS: "Grupe za pregled"
     VIEW_ALL_DESCRIPTION: "Pogledaj bilo koju stranicu"
@@ -262,7 +378,9 @@ sr_RS@latin:
     HAVEASKED: "Zamoljeni ste da pogledate sadržaj ovog sajta"
   VirtualPage:
     CHOOSE: "Povezana stranica"
+    DESCRIPTION: "Prikazuje sadržaj druge stranice"
     EditLink: izmeni
     HEADER: "Ovo je virtuelna stranica"
     HEADERWITHLINK: "Ovo je virtuelna stranica koja kopira sadržaj iz \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Originalni tip stranice \"{type}\" nije dozvoljen na vršnom nivou za ovu virtuelnu stranicu"
+    SINGULARNAME: "Virtuelna stranica"

--- a/lang/sv.yml
+++ b/lang/sv.yml
@@ -1,7 +1,41 @@
 sv:
+  AssetAdmin:
+    ADDFILES: "Lägg till filer"
+    ActionAdd: "Skapa mapp"
+    AppCategoryArchive: Arkivera
+    AppCategoryAudio: Ljud
+    AppCategoryDocument: Dokument
+    AppCategoryFlash: Flash
+    AppCategoryImage: Bild
+    AppCategoryVideo: Video
+    BackToFolder: "Tillbaka till mappen"
+    CREATED: Datum
+    CurrentFolderOnly: "Begränsa till aktuell mapp?"
+    DetailsView: Detaljer
+    FILES: Filer
+    FILESYSTEMSYNC: "Synkronisera filer"
+    FILESYSTEMSYNCTITLE: "Uppdatera CMS:ets databasposter för filer i filsystemet. Användbart när nya filer har laddats upp utanför CMS:et, t.ex. via FTP."
+    FROMTHEINTERNET: "Från internet"
+    FROMYOURCOMPUTER: "Från din dator"
+    Filetype: Filtyp
+    ListView: Listvy
+    MENUTITLE: Filer
+    NEWFOLDER: "Ny mapp"
+    SIZE: Storlek
+    THUMBSDELETED: "{count} oanvända tumnaglar har raderats"
+    TreeView: Trädvy
+    Upload: "Ladda upp"
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Radera mapparna"
+  AssetAdmin_Tools:
+    FILTER: Filtrera
+  AssetAdmin_left_ss:
+    GO: Kör
   AssetTableField:
     BACKLINKCOUNT: "Använd på:"
     PAGES: sida(-or)
+  BackLink_Button_ss:
+    Back: Tillbaka
   BrokenLinksReport:
     Any: Alla
     BROKENLINKS: "Rapport för brutna länkar"
@@ -27,10 +61,18 @@ sv:
   CMSAddPageController:
     Title: "Skapa sida"
   CMSBatchActions:
+    ARCHIVE: Arkivera
+    ARCHIVED_PAGES: "Arkiverade %d sidor"
+    DELETED_DRAFT_PAGES: "Raderade %d sidor från utkastsajten, %d misslyckades"
+    DELETED_PAGES: "Raderade %d sidor från den publiserade sajten, %d misslyckades"
+    DELETE_DRAFT_PAGES: "Radera från utkast"
+    DELETE_PAGES: "Radera från publicerade sajten"
     PUBLISHED_PAGES: "Publicerade %d sidor, %d misslyckades"
     PUBLISH_PAGES: Publicera
     RESTORE: Återskapa
     RESTORED_PAGES: "Återskapade %d sidor"
+  CMSFileAddController:
+    MENUTITLE: Filer
   CMSMain:
     ACCESS: "Tillgång till sektionen '{title}'"
     ACCESS_HELP: "Tillåt visning av sektionen innehållande sidträdet och dess innehåll. Rättigheter att visa och redigera sidan kan hanteras i dess rullgardinsmenyer, liksom i \"Innehållsbehörigheter\"."
@@ -43,8 +85,13 @@ sv:
     ChoosePageParentMode: "Välj var du vill skapa denna sida"
     ChoosePageType: "Välj sidtyp"
     Create: Skapa
+    DELETE: "Radera utkast"
+    DELETEFP: Radera
+    DESCREMOVED: "och {count} ättlingar"
     DUPLICATED: "Duplicerade '{title}' utan problem"
     DUPLICATEDWITHCHILDREN: "Duplicerade '{title}' och undersidor utan problem"
+    EditTree: "Redigera trädet"
+    MENUTITLE: "Redigera sida"
     NEWPAGE: "Ny {pagetype}"
     PAGENOTEXISTS: "Den här sidan finns inte"
     PAGETYPEANYOPT: "Vilken som helst"
@@ -52,6 +99,7 @@ sv:
     PUBALLFUN: "\"Publicera alla\"-funktion"
     PUBPAGES: "Klar: Publicerade {count} sidor"
     PageAdded: "Lyckades skapa sida"
+    REMOVED: "Tog bort '{title}'{description} från den publicerade sajten"
     REMOVEDPAGE: "Tog bort '{title}' från den publicerade sajten"
     REMOVEDPAGEFROMDRAFT: "Raderade '%s' från utkast"
     RESTORED: "Återskapandet av  '{title}' lyckades"
@@ -61,16 +109,24 @@ sv:
     ROLLBACK: "Återställ den här versionen"
     ROLLEDBACKPUBv2: "Återställde till den publicerade versionen."
     ROLLEDBACKVERSIONv2: "Återställde till version #%d."
+    SAVE: Spara
     SAVEDRAFT: "Spara utkast"
     TabContent: Innehåll
     TabHistory: Historia
     TabSettings: Inställningar
+  CMSMain_left_ss:
+    RESET: Rensa
   CMSPageAddController:
+    MENUTITLE: "Skapa sida"
     ParentMode_child: "Under en annan sida"
     ParentMode_top: Toppnivå
+  CMSPageEditController:
+    MENUTITLE: "Redigera sidan"
   CMSPageHistoryController:
     COMPAREMODE: "Jämföringsläge (välj två)"
     COMPAREVERSIONS: "Jämför versioner"
+    COMPARINGVERSION: "Jämför version {version1} och {version2}."
+    MENUTITLE: Historia
     REVERTTOTHISVERSION: "Ändra till denna version"
     SHOWUNPUBLISHED: "Visa opublicerade versioner"
     SHOWVERSION: "Visa version"
@@ -83,7 +139,10 @@ sv:
     PUBLISHER: Utgivare
     UNKNOWN: Okänd
     WHEN: När
+  CMSPageSettingsController:
+    MENUTITLE: "Redigera sida"
   CMSPagesController:
+    GalleryView: Gallerivy
     ListView: Listvy
     MENUTITLE: Sidor
     TreeView: Trädvy
@@ -93,7 +152,10 @@ sv:
     Title: "Publicerade sidor"
   CMSSearch:
     FILTERDATEFROM: Från
+    FILTERDATEHEADING: Datum
     FILTERDATETO: Till
+  CMSSettingsController:
+    MENUTITLE: Inställningar
   CMSSiteTreeFilter_Search:
     Title: "Alla sidor"
   CMSSiteTreeFilter_StatusRemovedFromDraftPages:
@@ -106,6 +168,7 @@ sv:
     CMS: CMS
     DRAFT: Utkast
     DRAFTSITE: Utkast
+    DRAFT_SITE_ACCESS_RESTRICTION: "Du måste logga med ditt CMS-lösenord för att kunna se utkast och arkiverat material. <a href=\"%s\">Klicka här för att gå tillbaks till den publicerade sajten.</a>"
     Email: E-post
     INSTALL_SUCCESS: "Installation lyckades!"
     InstallFilesDeleted: "Installationsfilerna raderades utan problem."
@@ -153,17 +216,40 @@ sv:
     DEFAULTERRORPAGETITLE: "Sidan hittades inte"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Ursäkta, ett fel uppstod vid hanteringen av din förfrågan.</p>"
     DEFAULTSERVERERRORPAGETITLE: Serverfel
+    DESCRIPTION: "Anpassat innehåll för olika felärenden (t.ex. \"Sidan kan inte hittas\")"
+    ERRORFILEPROBLEM: "Kunde inte skriva filen \"{filename}\". Var vänlig kontrollera skrivrättigheterna."
+    SINGULARNAME: Felsida
+  Folder:
+    AddFolderButton: "Skapa mapp"
+    DELETEUNUSEDTHUMBNAILS: "Radera oanvända tumnaglar"
+    UNUSEDFILESTITLE: "Oanvända filer"
+    UNUSEDTHUMBNAILSTITLE: "Oanvända tumnaglar"
+    UploadFilesButton: "Ladda upp"
+  LeftAndMain:
+    DELETED: Raderad.
+    PreviewButton: Förhandsgranska
+    SAVEDUP: Sparad.
+    SearchResults: Sökresultat
+  Permission:
+    CMS_ACCESS_CATEGORY: CMS-tillgång
   Permissions:
     CONTENT_CATEGORY: Innehållsåtkomst
     PERMISSIONS_CATEGORY: "Roller och åtkomst"
   RedirectorPage:
+    DESCRIPTION: "Omdirigerar till en annan intern sida"
     HASBEENSETUP: "En omdirigeringssida har skapats utan att ha något mål."
     HEADER: "Den här sidan omdirigerar användare till en annan sida"
     OTHERURL: "Andra sidans URL"
     REDIRECTTO: "Omdirigera till"
     REDIRECTTOEXTERNAL: "En annan sajt"
     REDIRECTTOPAGE: "En sida på din sajt"
+    SINGULARNAME: Omdirigeringssida
     YOURPAGE: "Sida på din sajt"
+  ReportAdmin:
+    MENUTITLE: Rapporter
+    ReportTitle: Titel
+  ReportAdminForm:
+    FILTERBY: "Filtrera på"
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: "Publicera den länkade sidan för att kunna publicera den virtuella sidan"
     VIRTUALPAGEWARNING: "Välj en länkad sida och spara först för att kunna publicera den här sidan"
@@ -174,15 +260,38 @@ sv:
     SearchResults: Sökresultat
   SideReport:
     BROKENFILES: "Sidor med trasiga filer"
+    BROKENLINKS: "Sidor med trasiga länkar"
     BROKENREDIRECTORPAGES: "Omdirigeringssidor som pekar på raderade sidor"
     BROKENVIRTUALPAGES: "Virtuella sidor som pekar på raderade sidor"
     BrokenLinksGroupTitle: "Rapport för trasiga länkar"
     ContentGroupTitle: Innehållsrapport
     EMPTYPAGES: "Tomma sidor"
     LAST2WEEKS: "Sidor som har redigerats de senaste 2 veckorna"
+    OtherGroupTitle: Annat
     ParameterLiveCheckbox: "Kontrollera live sajt"
+    REPEMPTY: "Raporten {title} är tom."
   SilverStripeNavigator:
     ARCHIVED: Arkiverad
+  SilverStripeNavigatorLink:
+    ShareLink: "Dela länk"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Stäng
+  SiteConfig:
+    DEFAULTTHEME: "(Använd standardtema)"
+    EDITHEADER: "Vem kan redigera sidor på den här sajten?"
+    EDIT_PERMISSION: "Redigera sajtkonfiguration"
+    EDIT_PERMISSION_HELP: "Möjlighet att ändra den globala åtkomstinställningar / toppnivåbehörigheter."
+    PLURALNAME: "Sajt inställningar"
+    SINGULARNAME: "Sajt inställning"
+    SITENAMEDEFAULT: "Din Sajts Namn"
+    SITETAGLINE: "Din sajts Slogan"
+    SITETITLE: Sajttitel
+    TABACCESS: Tillgång
+    TABMAIN: Allmänt
+    TAGLINEDEFAULT: "din underrubrik här"
+    THEME: Tema
+    TOPLEVELCREATE: "Vem kan skapa sidor i sajtroten?"
+    VIEWHEADER: "Vem kan se sidor på den här sajten?"
   SiteTree:
     ACCESSANYONE: Alla
     ACCESSHEADER: "Vem kan se den här sidan?"
@@ -190,9 +299,11 @@ sv:
     ACCESSONLYTHESE: "Bara dessa (välj från listan)"
     ADDEDTODRAFTHELP: "Sidan har inte publicerats än"
     ADDEDTODRAFTSHORT: Utkast
+    ALLOWCOMMENTS: "Tillåt kommentar på den här sidan?"
     APPEARSVIRTUALPAGES: "Detta innehåll förekommer även på en virtuell sida i sektionen {title}."
     ARCHIVEDPAGEHELP: "Sidan är borttagen från utkast och från live"
     ARCHIVEDPAGESHORT: Arkiverad
+    BUTTONARCHIVEDESC: "Avpublicerad och skickat till arkiv"
     BUTTONCANCELDRAFT: "Ångra utkaständringar"
     BUTTONCANCELDRAFTDESC: "Radera utkast och återgå till den publicerade sidan"
     BUTTONPUBLISHED: Publicerad
@@ -206,7 +317,10 @@ sv:
     DEFAULTCONTACTTITLE: "Kontakta oss"
     DEFAULTHOMECONTENT: "<p>Välkommen till SilverStripe!  Detta är hemsidan din startsida. Du kan ändra denna sida genom att gå till <a href=\"admin/\">administrationsdelen</a>.</p><p> Du har tillgång till You can now access the <a href=\"http://docs.silverstripe.org\">utvecklar dokumentationen</a>, eller börja med att titta på <a href=\"http://www.silverstripe.org/learn/lessons\">SilverStripelektionerna</a>.</p>"
     DEFAULTHOMETITLE: Hem
+    DELETEDPAGEHELP: "Sidan är inte längre publicerad"
+    DELETEDPAGESHORT: Raderad
     DEPENDENT_NOTE: "Följande sidor berörs av den här sidan. Inklusive virtuella sidor, omdirigeringssidor, och sidor med innehållslänkar."
+    DESCRIPTION: "Generisk innehållssida"
     DependtPageColumnLinkType: Länktyp
     DependtPageColumnURL: URL
     EDITANYONE: "Alla som kan logga in"
@@ -244,17 +358,22 @@ sv:
     PARENTTYPE_SUBPAGE: "Undersida under en överordnad sida (välj nedan)"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Administrera åtkomsträttigheter för innehåll"
     PERMISSION_GRANTACCESS_HELP: "Tillåt inställning av sidspecifika åtkomstbegränsningar i \"Sidor\"-sektionen."
+    PLURALNAME: Sidor
     PageTypNotAllowedOnRoot: "Sidtypen \"{type}\" tillåts inte på rotnivå"
     PageTypeNotAllowed: "Sidtypen \"{type}\" tillåts inte som barn till förälderns sida"
+    REMOVEDFROMDRAFTHELP: "Sidan är publicerad men har raderats från utkastet"
+    REMOVEDFROMDRAFTSHORT: "Raderad från utkast"
     REMOVE_INSTALL_WARNING: "Varning: Du bör radera install.php från SilverStripe-installationen p.g.a säkerhetsskäl."
     REORGANISE_DESCRIPTION: "Ändra sidstrukturen"
     REORGANISE_HELP: "Flytta om sidorna i sidträdet genom att dra och släppa."
     SHOWINMENUS: "Visa i menyer?"
     SHOWINSEARCH: "Visa i sökningar?"
+    SINGULARNAME: Sida
     TABBEHAVIOUR: Beteende
     TABCONTENT: Huvudinnehåll
     TABDEPENDENT: "Beroende sidor"
     TOPLEVEL: "Sajtinnehåll (toppnivå)"
+    TOPLEVELCREATORGROUPS: "Topp-nivå skapare"
     URLSegment: URL-segment
     VIEWERGROUPS: Åtkomstgrupper
     VIEW_ALL_DESCRIPTION: "Visa alla sidor"
@@ -267,6 +386,9 @@ sv:
     many_many_BackLinkTracking: "Spåra inlänkar"
     many_many_ImageTracking: "Spåra bild"
     many_many_LinkTracking: "Spåra länk"
+  SiteTreeFileExtension:
+    BACKLINK_LIST_DESCRIPTION: "Denna lista viasar alla sidor där filen har blivit tillagd/uppladdad via WYSIWIG editorn"
+    EDIT: ändra
   SiteTreeURLSegmentField:
     EMPTY: "Ange ett URL-segment eller klicka på avbryt"
     HelpChars: "Specialtecken konverteras eller tas bort"
@@ -279,7 +401,9 @@ sv:
     HAVEASKED: "Du har efterfrågat att se innehållet på vår sajt på"
   VirtualPage:
     CHOOSE: "Länkad sida"
+    DESCRIPTION: "Visar innehåll från en annan sida"
     EditLink: redigera
     HEADER: "Det här är en virutell sida"
     HEADERWITHLINK: "Det här är en virtuell sida som kopierar innehållet från \"{title}\" ({link})"
     PageTypNotAllowedOnRoot: "Ursprungliga sidan av typ \"{type}\" tillåts inte på rotnivå för denna virtuella sida"
+    SINGULARNAME: "Virtuell sida"

--- a/lang/th.yml
+++ b/lang/th.yml
@@ -1,7 +1,41 @@
 th:
+  AssetAdmin:
+    ADDFILES: เพิ่มไฟล์
+    ActionAdd: เพิ่มโฟลเดอร์
+    AppCategoryArchive: รายการ
+    AppCategoryAudio: ไฟล์เสียง
+    AppCategoryDocument: เอกสาร
+    AppCategoryFlash: แฟลช
+    AppCategoryImage: รูปภาพ
+    AppCategoryVideo: วีดีโอ
+    BackToFolder: ย้อนกลับไปที่โฟลเดอร์
+    CREATED: วันที่
+    CurrentFolderOnly: จำกัดเฉพาะโฟลเดอร์นี้?
+    DetailsView: รายละเอียด
+    FILES: ไฟล์
+    FILESYSTEMSYNC: ผสานไฟล์
+    FILESYSTEMSYNCTITLE: "อัพเดทรายการไฟลในฐานข้อมูล CMS ในระบบไฟล์ มีประโยชน์สำหรับการอัพโหลดไฟล์ใหม่นอกระบบ CMS เช่น ผ่านทาง FTP"
+    FROMTHEINTERNET: จากอินเทอร์เน็ต
+    FROMYOURCOMPUTER: จากเครื่องคอมพิวเตอร์ของคุณ
+    Filetype: ชนิดของไฟล์
+    ListView: มุมมองแบบแสดงรายการ
+    MENUTITLE: ไฟล์
+    NEWFOLDER: สร้างโฟลเดอร์ใหม่
+    SIZE: ขนาด
+    THUMBSDELETED: "{count} รูปย่อที่ไม่ได้ถูกใช้งานได้ถูกลบทิ้งแล้ว"
+    TreeView: "มุมมองแบบ Tree"
+    Upload: อัพโหลด
+  AssetAdmin_DeleteBatchAction:
+    TITLE: ลบโฟลเดอร์
+  AssetAdmin_Tools:
+    FILTER: ตัวกรองข้อมูล
+  AssetAdmin_left_ss:
+    GO: ไป
   AssetTableField:
     BACKLINKCOUNT: "ถูกใช้งานเมื่อ:"
     PAGES: หน้า
+  BackLink_Button_ss:
+    Back: ย้อนกลับ
   BrokenLinksReport:
     Any: ใดๆก็ได้
     BROKENLINKS: รายงานลิงค์เสีย
@@ -26,8 +60,14 @@ th:
   CMSAddPageController:
     Title: เพิ่มหน้า
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "ลบ %d หน้าจากเว็บไซต์ฉบับร่างแล้ว, ล้มเหลว %d"
+    DELETED_PAGES: "ลบ %d หน้าจากเว็บไซต์ที่เผยแพร่อยู่แล้ว ล้มเหลว %d"
+    DELETE_DRAFT_PAGES: ลบออกจากเว็บไซต์ฉบับร่าง
+    DELETE_PAGES: ลบออกจากเว็บไซต์ที่เผยแพร่อยู่
     PUBLISHED_PAGES: "เผยแพร่แล้ว %d หน้า, ล้วเหลว %d"
     PUBLISH_PAGES: เผยแพร่
+  CMSFileAddController:
+    MENUTITLE: ไฟล์
   CMSMain:
     ACCESS: "เข้าถึงเซ็กชั่น '{title}'"
     ACCESS_HELP: "อนุญาตให้เปิดดูส่วนของเซ็กชั่นที่บรรจุรายการหน้าเว็บแบบทรีและเนื้อหาได้ สิทธิ์ในการเปิดดูและแก้ไขสามารถจัดการได้ผ่านทางหน้าเว็บทีระบุอยู่ในเมนูแบบดรอปดาวน์ เช่นเดียวกับ \"สิทธิ์อนุญาตของเนื้อหา\" ที่แยกออกมาต่างหากด้วยเช่นกัน"
@@ -36,6 +76,11 @@ th:
     ChoosePageParentMode: เลือกว่าต้องการสร้างหน้าเว็บนี้ไว้ที่ไหน
     ChoosePageType: เลือกประเภทของหน้าเว็บ
     Create: สร้าง
+    DELETE: ลบออกจากเว็บไซต์ฉบับร่าง
+    DELETEFP: ลบ
+    DESCREMOVED: "และ {count} รายการลูก"
+    EditTree: "แก้ไขรายการแบบ Tree"
+    MENUTITLE: แก้ไขหน้าเว็บ
     NEWPAGE: "ใหม่ {pagetype}"
     PAGENOTEXISTS: ไม่มีหน้านี้อยู่
     PAGETYPEANYOPT: ประเภทใดก็ได้
@@ -47,15 +92,23 @@ th:
     REMOVEDPAGEFROMDRAFT: "ลบ '%s' ออกจากเว็บไซต์ฉบับร่างแล้ว"
     RESTORED: "เรียกคืนค่า '{title}' เสร็จเรียบร้อยแล้ว"
     ROLLBACK: ย้อนกลับไปที่รุ่นนี้
+    SAVE: บันทึก
     TabContent: เนื้อหา
     TabHistory: ประวัติย้อนหลัง
     TabSettings: ตั้งค่า
+  CMSMain_left_ss:
+    RESET: รีเซ็ต
   CMSPageAddController:
+    MENUTITLE: เพิ่มหน้า
     ParentMode_child: อยู่ใต้หน้าอื่นๆ
     ParentMode_top: ระดับสูงสุด
+  CMSPageEditController:
+    MENUTITLE: แก้ไขหน้าเว็บ
   CMSPageHistoryController:
     COMPAREMODE: "โหมดเปรียบเทียบ (เลือกสองรายการ)"
     COMPAREVERSIONS: เปรียบเทียบรุ่น
+    COMPARINGVERSION: "กำลังเปรียบเทียบรุ่น {version1} และ {version2}."
+    MENUTITLE: ประวัติย้อนหลัง
     REVERTTOTHISVERSION: ย้อนกลับไปที่รุ่นนี้
     SHOWUNPUBLISHED: แสดงรุ่นที่ระงับการเผยแพร่ไว้
     SHOWVERSION: แสดงข้อมูลรุ่น
@@ -67,8 +120,16 @@ th:
     PUBLISHER: ผู้เผยแพร่
     UNKNOWN: ไม่ทราบ
     WHEN: เมื่อ
+  CMSPageSettingsController:
+    MENUTITLE: แก้ไขหน้าเว็บ
+  CMSPagesController:
+    GalleryView: มุมมองแบบแกลอรี่
   CMSPagesController_Tools_ss:
     FILTER: ตัวกรองข้อมูล
+  CMSSearch:
+    FILTERDATEHEADING: วันที่
+  CMSSettingsController:
+    MENUTITLE: ตั้งค่า
   CMSSiteTreeFilter_Search:
     Title: หน้าทั้งหมด
   ContentControl:
@@ -77,6 +138,7 @@ th:
     ARCHIVEDSITE: รุ่นสำหรับดูตัวอย่าง
     ARCHIVEDSITEFROM: เว็บไซต์ที่จัดเก็บไว้ถาวรจาก
     DRAFTSITE: เว็บไซต์ฉบับร่าง
+    DRAFT_SITE_ACCESS_RESTRICTION: "คุณต้องเข้าสู่ระบบด้วยรหัสผ่าน CMS ของคุณ หากต้องการเปิดดูฉบับร่าง หรือเนื้อหาย้อนหลัง.  <a href=\"%s\">คลิกที่นี่เพื่อย้อนกลับไปที่เว็บไซต์ที่เผยแพร่อยู่.</a>"
     Email: อีเมล
     INSTALL_SUCCESS: การติดตั้งเสร็จสมบูรณ์
     InstallFilesDeleted: ไฟล์ติดตั้งได้ถูกลบทิ้งเรียบร้อยแล้ว
@@ -120,28 +182,72 @@ th:
     DEFAULTERRORPAGETITLE: ไม่พบหน้าที่ต้องการ
     DEFAULTSERVERERRORPAGECONTENT: "<p>ขออภัย, เกิดข้อผิดพลาดบางประการในการจัดการตามคำร้องขอของคุณ</p>"
     DEFAULTSERVERERRORPAGETITLE: เซิร์ฟเวอร์เกิดข้อผิดพลาด
+    DESCRIPTION: "กำหนดเนื้อหาเองสำหรับข้อผิดพลาดต่างๆ (e.g. \"ไม่พบหน้าเว็บที่ต้องการ\")"
+    ERRORFILEPROBLEM: "เกิดข้อผิดพลาดในการเปิดไฟล์ \"{filename}\" เพื่อเขียนข้อมูล. กรุณาตรวจสอบสิทธิ์."
+    SINGULARNAME: หน้าเว็บแสดงข้อผิดพลาด
+  Folder:
+    AddFolderButton: เพิ่มโฟลเดอร์
+    DELETEUNUSEDTHUMBNAILS: ลบรูปย่อที่ไม่ได้ใช้งาน
+    UNUSEDFILESTITLE: ไฟล์ที่ไม่ได้ใช้งาน
+    UNUSEDTHUMBNAILSTITLE: รูปย่อที่ไม่ได้ใช้งาน
+    UploadFilesButton: อัพโหลด
+  LeftAndMain:
+    DELETED: ถูกลบแล้ว
+    SAVEDUP: บันทึกแล้ว
+  Permission:
+    CMS_ACCESS_CATEGORY: "การเข้าถึง CMS"
   Permissions:
     CONTENT_CATEGORY: สิทธิ์อนุญาตของเนื้อหา
     PERMISSIONS_CATEGORY: บทบาทและสิทธิ์อนุญาตการเข้าถึง
   RedirectorPage:
+    DESCRIPTION: เปลี่ยนเส้นทางไปยังหน้าเว็บภายในอื่นๆ
     HASBEENSETUP: หน้าเว็บที่มีการเปลี่ยนเส้นทางซึ่งได้รับการตั้งค่าโดยปราศจากตำแหน่งปลายทางที่ต้องการเปลี่ยนเส้นทางไป
     HEADER: หน้าเว็บนี้จะเปลี่ยนเส้นทางผู้ใช้งานไปยังหน้าเว็บอื่นๆ
     OTHERURL: "ที่อยู่ URL ของเว็บไซต์อื่นๆ"
     REDIRECTTO: เปลี่ยนเส้นทางไปที่
     REDIRECTTOEXTERNAL: เว็บไซต์อื่นๆ
     REDIRECTTOPAGE: หน้าเว็บในเว็บไซต์ของคุณ
+    SINGULARNAME: หน้าเว็บเปลี่ยนเส้นทาง
     YOURPAGE: หน้าเว็บที่อยู่บนเว็บไซต์ของคุณ
+  ReportAdmin:
+    MENUTITLE: รายงาน
+    ReportTitle: หัวเรื่อง
+  ReportAdminForm:
+    FILTERBY: แสดงข้อมูลตาม
   SearchForm:
     SearchResults: ผลการค้นหา
   SideReport:
     BROKENFILES: หน้าเว็บที่มีไฟล์เสีย
+    BROKENLINKS: หน้าเว็บที่มีลิงค์เสีย
     BROKENREDIRECTORPAGES: เปลี่ยนเส้นทางหน้าเว็บที่ชี้ไปที่หน้าเว็บที่ถูกลบแล้ว
     BROKENVIRTUALPAGES: หน้าเว็บจำลองชี้ไปที่หน้าเว็บที่ถูกลบทิ้งไปแล้ว
     BrokenLinksGroupTitle: รายงานลิงค์เสีย
     ContentGroupTitle: รายงานเกี่ยวกับเนื้อหา
     EMPTYPAGES: หน้าเว็บที่ยังไม่มีเนื้อหา
     LAST2WEEKS: "หน้าเว็บที่ถูกแก้ไขใน 2 สัปดาห์ล่าสุด"
+    OtherGroupTitle: อื่นๆ
     ParameterLiveCheckbox: ดูเว็บไซต์แบบสดๆ
+    REPEMPTY: "รายงาน {title} ยังว่างอยู่"
+  SilverStripeNavigatorLink:
+    ShareLink: ลิงก์ที่ต้องการแชร์
+  SilverStripeNavigatorLinkl:
+    CloseLink: ปิด
+  SiteConfig:
+    DEFAULTTHEME: (ใช้ชุดธีมเริ่มต้น)
+    EDITHEADER: ใครสามารถแก้ไขหน้าเว็บบนเว็บไซต์นี้ได้บ้าง?
+    EDIT_PERMISSION: การจัดการการกำหนดค่าของเว็บไซต์
+    EDIT_PERMISSION_HELP: สามารถแก้ไขการตั้งค่าการเข้าถึงระบบโดยรวมได้/แก้ไขสิทธิ์หน้าเว็บในระดับสูงสุดได้
+    PLURALNAME: กำหนดค่าเว็บไซต์
+    SINGULARNAME: กำหนดค่าเว็บไซต์
+    SITENAMEDEFAULT: ชื่อเว็บไซต์ของคุณ
+    SITETAGLINE: สโลแกนของเว็บไซต์
+    SITETITLE: ชื่อเว็บไซต์
+    TABACCESS: เข้าถึง
+    TABMAIN: หน้าหลัก
+    TAGLINEDEFAULT: กรอกสโลแกนของคุณลงที่นี่
+    THEME: ชุดธีม
+    TOPLEVELCREATE: "ใครบ้างที่สามารถสร้างหน้าเว็บที่ตำแหน่ง root ของเว็บไซต์ได้?"
+    VIEWHEADER: ใครบ้่างที่สามารถเปิดดูหน้าเว็บบนเว็บไซต์นี้ได้?
   SiteTree:
     ACCESSANYONE: ทุกคน
     ACCESSHEADER: ใครบ้างที่สามารถเปิดดูหน้านี้ได้?
@@ -149,6 +255,7 @@ th:
     ACCESSONLYTHESE: "เฉพาะบุคคลเหล่านี้เท่านั้น (เลือกจากรายการ)"
     ADDEDTODRAFTHELP: หน้าเว็บยังไม่ได้ถูกเผยแพร่
     ADDEDTODRAFTSHORT: ฉบับร่าง
+    ALLOWCOMMENTS: อนุญาตให้แสดงความเห็นในหน้านีหรือไม่?
     APPEARSVIRTUALPAGES: "เนื้อหานี้ปรากฏอยู่ในหน้าเว็บจำลองในส่วนของ {title} ด้วยเช่นกัน"
     BUTTONCANCELDRAFT: ยกเลิกการเปลี่ยนแปลงในฉบับร่าง
     BUTTONCANCELDRAFTDESC: ลบฉบับร่างของคุณแล้วย้อนกลับไปใช้หน้าเว็บที่เผยแพร่อยู่ในขณะนี้
@@ -159,7 +266,10 @@ th:
     DEFAULTABOUTTITLE: เกี่ยวกับเรา
     DEFAULTCONTACTTITLE: ติดต่อเรา
     DEFAULTHOMETITLE: หน้าแรก
+    DELETEDPAGEHELP: หน้าเว็บไม่ได้ถูกเผยแพร่อีกต่อไปแล้ว
+    DELETEDPAGESHORT: ถูกลบ
     DEPENDENT_NOTE: "หน้าเว็บต่อไปนี้อาศัยหน้าเว็บนี้เป็นตัวอ้างอิง ซึ่งได้แก่หน้าเว็บจำลอง, หน้าเว็บที่เปลี่ยนเส้นทาง, และหน้าเว็บที่มีลิงก์เนื้อหาอยู่ด้วย"
+    DESCRIPTION: หน้าเนื้อหาทั่วไป
     DependtPageColumnLinkType: ชนิดของลิงค์
     EDITANYONE: "ทุกคนสามารถเข้าสู่ระบบของ CMS ได้ทั้งหมด"
     EDITHEADER: ใครสามารถแก้ไขหน้านี้ได้บ้าง?
@@ -189,17 +299,22 @@ th:
     PARENTTYPE_SUBPAGE: หน้าเว็บย่อยที่อยู่ใต้หน้าเว็บแม่
     PERMISSION_GRANTACCESS_DESCRIPTION: การจัดการสิทธิ์การเข้าถึงเนื้อหา
     PERMISSION_GRANTACCESS_HELP: "อนุญาตให้มีการตั้งค่าข้อจำกัดในการเข้าถึงหน้าเว็บเฉพาะหน้าได้จากส่วนของ \"หน้าเว็บ\""
+    PLURALNAME: หน้า
     PageTypNotAllowedOnRoot: "ประเภทของหน้าเว็บ \"{type}\" ไม่ได้รับอนุญาตให้สามารถใช้งานได้ที่ตำแหน่ง root"
     PageTypeNotAllowed: "ชนิดของหน้าเว็บ \"{type}\" ไม่ได้รับอนุญาตให้ใช้เป็นหน้าเว็บลูกของหน้าเว็บแม่นี้"
+    REMOVEDFROMDRAFTHELP: "หน้าเว็บถูกเผยแพร่แล้ว แต่ถูกลบออกจากฉบับร่างด้วยเช่นกัน"
+    REMOVEDFROMDRAFTSHORT: ลบออกจากฉบับร่าง
     REMOVE_INSTALL_WARNING: "คำเตือน: คุณควรลบไฟล์ install.php ออกหลังการติดตั้ง SilverStripe เพื่อความปลอดภัย"
     REORGANISE_DESCRIPTION: เปลี่ยนโครงสร้างเว็บไซต์
     REORGANISE_HELP: จัดเรียงหน้าเว็บที่อยู่ในแผนผังเว็บไซต์แบบต้นไม้โดยการลากและวาง
     SHOWINMENUS: แสดงในเมนู?
     SHOWINSEARCH: แสดงในผลลัพธ์ของการค้นหาหรือไม่?
+    SINGULARNAME: หน้า
     TABBEHAVIOUR: พฤติกรรม
     TABCONTENT: เนื้อหา
     TABDEPENDENT: หน้าย่อย
     TOPLEVEL: "เนื้อหาเว็บไซต์ (ระดับสูงสุด)"
+    TOPLEVELCREATORGROUPS: ผู้สร้างระดับสูงสุด
     URLSegment: "ส่วนการจัดการ URL"
     VIEWERGROUPS: กลุ่มผู้ชม
     VIEW_ALL_DESCRIPTION: เปิดดูหน้าเว็บใดก็ได้
@@ -217,5 +332,7 @@ th:
     CANACCESS: "คุณสามารถเข้าถึงเว็บไซต์รุ่นย้อนหลังได้จากลิงก์นี้:"
     HAVEASKED: คุณได้ร้องขอเพื่อเปิดดูเนื้อหาในเว็บไซต์ของเราเมื่อ
   VirtualPage:
+    DESCRIPTION: แสดงเนื้อหาของหน้าเว็บอื่นๆ
     HEADER: นี่เป็นหน้าเว็บจำลอง
     PageTypNotAllowedOnRoot: "ชนิดของหน้าเว็บดั้งเดิม \"{type}\" ไม่ได้รับอนุญาตให้ใช้งานกับหน้าเว็บจำลองที่ตำแหน่ง root"
+    SINGULARNAME: หน้าจำลอง

--- a/lang/tr.yml
+++ b/lang/tr.yml
@@ -1,4 +1,19 @@
 tr:
+  AssetAdmin:
+    ADDFILES: "Dosyaları ekle"
+    ActionAdd: "Klasör ekle"
+    AppCategoryArchive: Arşiv
+    AppCategoryAudio: Ses
+    AppCategoryDocument: Belge
+    AppCategoryImage: Görüntü
+    AppCategoryVideo: Video
+    FILES: Dosyalar
+    Filetype: "Dosya türü"
+    NEWFOLDER: YeniKlasör
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Klasörleri sil"
+  AssetAdmin_left_ss:
+    GO: Git
   AssetTableField:
     PAGES: sayfa(lar)
   BrokenLinksReport:
@@ -10,39 +25,59 @@ tr:
   CMSAddPageController:
     Title: "Sayfa ekle"
   CMSBatchActions:
+    DELETE_PAGES: "Yayındaki siteden sil"
     PUBLISH_PAGES: Yayınla
+  CMSFileAddController:
+    MENUTITLE: Dosyalar
   CMSMain:
     AddNew: "Yeni sayfa ekle"
     AddNewButton: "Yeni ekle"
     ChoosePageParentMode: "Sayfanın nereye oluşturulacağını seç"
     ChoosePageType: "Sayfa tipini seç"
     Create: Oluştur
+    DELETE: "Taslak siteden kaldır"
+    DELETEFP: "Yayındaki siteden kaldır"
+    MENUTITLE: "Sayfayı düzenle"
     PAGENOTEXISTS: "Sayfa bulunamadı"
     PUBALLCONFIRM: "Lütfen taslak sitedeki tüm sayfaları yayınlanmakta olan siteye kopyalayıp yayınla."
     PUBALLFUN: "\"Hepsini Yayınla\" özelliği"
     PageAdded: "Sayfa başarıyla oluşturuldu"
     REMOVEDPAGEFROMDRAFT: "'%s' taslak siteden silindi"
     ROLLBACK: "Bu sürüme geri dön"
+    SAVE: Kaydet
     TabContent: İçerik
     TabHistory: Geçmiş
     TabSettings: Ayarlar
+  CMSMain_left_ss:
+    RESET: Sıfırla
+  CMSPageAddController:
+    MENUTITLE: "Sayfa ekle"
+  CMSPageEditController:
+    MENUTITLE: "Sayfayı Düzenle"
   CMSPageHistoryController:
     COMPAREVERSIONS: "Versiyonları karşılaştır"
+    MENUTITLE: Geçmiş
   CMSPageHistoryController_versions_ss:
     AUTHOR: Yazar
     NOTPUBLISHED: Yayınlanmamış
     PUBLISHER: Yayınlayan
     UNKNOWN: Bilinmeyen
     WHEN: "Ne zaman"
+  CMSPageSettingsController:
+    MENUTITLE: "Sayfayı düzenle"
   CMSPagesController:
+    GalleryView: "Galeri Görünümü"
     MENUTITLE: Sayfalar
   CMSPagesController_Tools_ss:
     FILTER: Filtre
+  CMSSettingsController:
+    MENUTITLE: Ayarlar
   CMSSiteTreeFilter_Search:
     Title: "Tüm sayfalar"
   ContentControl:
     NOTEWONTBESHOWN: "Not: Bu mesaj ziyaretçilerinize gösterilmeyecektir."
   ContentController:
+    DRAFT_SITE_ACCESS_RESTRICTION: "Taslak veya arşivlenmiş içeriği görebilmek için CMS şifrenizle giriş yapmış olmanız gerekmektedir. <a href=\"%s\">Yayınlanmış siteye geri dönmek için buraya tıklayın.</a>"
     Email: Eposta
     INSTALL_SUCCESS: "Kurulum Başarılı!"
     InstallFilesDeleted: "Kurulum dosyaları başarıyla silindi."
@@ -76,7 +111,17 @@ tr:
     CODE: "Hata kodu"
     DEFAULTERRORPAGECONTENT: "<p>Varolmayan bir sayfaya ulaşmaya çalışıyorsunuz.</p><p>Lütfen ulaşmak istediğiniz URL'i kontrol edip tekrar deneyiniz.</p>"
     DEFAULTERRORPAGETITLE: "Sayfa bulunamadı"
+  Folder:
+    DELETEUNUSEDTHUMBNAILS: "Kullanılmamış thumbnail leri sil"
+    UNUSEDFILESTITLE: "Kullanılmamış dosyalar"
+    UNUSEDTHUMBNAILSTITLE: "Kullanılmamış thumbnail ler"
+  LeftAndMain:
+    DELETED: Silindi.
+    SAVEDUP: Kaydedildi.
+  Permission:
+    CMS_ACCESS_CATEGORY: "CMS Erişimi"
   RedirectorPage:
+    DESCRIPTION: "Başka iç sayfaya yönlendir"
     HASBEENSETUP: "Yönlendirilecek yeri olmayan bir yönlendirme sayfası ayarlandı."
     HEADER: "Bu sayfa, kullanıcıları başka bir sayfaya yönlendirir"
     OTHERURL: "Başka bir siteye ait URL"
@@ -84,22 +129,38 @@ tr:
     REDIRECTTOEXTERNAL: "Başka bir site"
     REDIRECTTOPAGE: "Web sitenizdeki bir sayfa"
     YOURPAGE: "Web sitenizdeki bir sayfa"
+  ReportAdmin:
+    MENUTITLE: Raporlar
   SearchForm:
     GO: Git
     SEARCH: Ara
   SideReport:
     BROKENFILES: "Kırık link bulunan sayfalar"
+    BROKENLINKS: "Kırık link bulunan sayfalar"
     BrokenLinksGroupTitle: "Kırık linki rapor et"
     ContentGroupTitle: "İçerik raporları"
     EMPTYPAGES: "Boş sayfalar"
     LAST2WEEKS: "Son 2 haftada düzenlenmiş sayfalar"
+    OtherGroupTitle: Diğeri
     ParameterLiveCheckbox: "Yayındaki siteyi kontrol et"
+  SilverStripeNavigatorLink:
+    ShareLink: "Linki paylaş"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Kapat
+  SiteConfig:
+    DEFAULTTHEME: "(Varsayılan temayı kullan)"
+    SITENAMEDEFAULT: "Site Adınız"
+    SITETITLE: "Site başlığı"
+    TABACCESS: Erişim
+    TABMAIN: Ana
+    THEME: Tema
   SiteTree:
     ACCESSANYONE: Herkes
     ACCESSHEADER: "Bu sayfayı kimler görüntüleyebilir?"
     ACCESSLOGGEDIN: "Giriş yapmış kullanıcılar"
     ACCESSONLYTHESE: "Sadece bu kişiler (listeden seçiniz)"
     ADDEDTODRAFTSHORT: Taslak
+    ALLOWCOMMENTS: "Bu sayfada yorumlara izin verilsin mi?"
     BUTTONCANCELDRAFT: "Taslak değikliklerini iptal et"
     BUTTONCANCELDRAFTDESC: "Taslağı sil ve şu an yayında olan sayfaya geri döndür"
     BUTTONUNPUBLISH: "Yayından kaldır"
@@ -128,6 +189,7 @@ tr:
     PARENTTYPE: "Sayfa konumu"
     PARENTTYPE_ROOT: "Üst seviye sayfa"
     PERMISSION_GRANTACCESS_DESCRIPTION: "Grupların işlem ve düzenlemelerinin kontrolü"
+    REMOVEDFROMDRAFTHELP: "Sayfa yayınlandı ve taslaklardan silindi"
     REORGANISE_DESCRIPTION: "Site yapısını değiştir"
     REORGANISE_HELP: "Site ağacının sürükle&bırak şeklinde tekrardan düzenle"
     SHOWINMENUS: "Menülerde gösterilsin mi?"
@@ -147,3 +209,4 @@ tr:
     HAVEASKED: "Şu tarihe kadar olan site içeriğini görüntülemek istediniz:"
   VirtualPage:
     HEADER: "Bu sanal bir sayfadır"
+    SINGULARNAME: "Sanal Sayfa"

--- a/lang/uk.yml
+++ b/lang/uk.yml
@@ -1,7 +1,38 @@
 uk:
+  AssetAdmin:
+    ADDFILES: "Додати файли"
+    ActionAdd: "Додати папку"
+    AppCategoryArchive: Архівувати
+    AppCategoryAudio: Аудіо
+    AppCategoryImage: Зображення
+    AppCategoryVideo: Відео
+    BackToFolder: "Повернутися до папки"
+    CREATED: Дата
+    CurrentFolderOnly: "Обмежити до поточної папки?"
+    DetailsView: Деталі
+    FILES: Файли
+    FILESYSTEMSYNCTITLE: "Оновлення бази даних файлів у файловій системі. Корисно, коли нові файли були завантажені поза CMS, наприклад, через FTP."
+    FROMTHEINTERNET: "З інтернету"
+    FROMYOURCOMPUTER: "З мого комп'ютера"
+    Filetype: "Тип файлу"
+    ListView: "У вигляді списку"
+    MENUTITLE: Файли
+    NEWFOLDER: "Нова Тека"
+    SIZE: Розмір
+    THUMBSDELETED: "{count} невикористаних ескізів було видалено"
+    TreeView: "У вигляді дерева"
+    Upload: Завантажити
+  AssetAdmin_DeleteBatchAction:
+    TITLE: "Видалені папки"
+  AssetAdmin_Tools:
+    FILTER: Фільтр
+  AssetAdmin_left_ss:
+    GO: Уперед
   AssetTableField:
     BACKLINKCOUNT: "Використовується в:"
     PAGES: сторінка(и)
+  BackLink_Button_ss:
+    Back: Назад
   BrokenLinksReport:
     Any: Будь-який
     BROKENLINKS: "Звіт про биті посилання"
@@ -26,8 +57,12 @@ uk:
   CMSAddPageController:
     Title: "Додати сторінку"
   CMSBatchActions:
+    DELETE_DRAFT_PAGES: "Видалити з чорнового сайту"
+    DELETE_PAGES: "Видалити з опублікованого сайту"
     PUBLISHED_PAGES: "Опубліковано %d сторінок, %d навдач"
     PUBLISH_PAGES: Опублікувати
+  CMSFileAddController:
+    MENUTITLE: Файли
   CMSMain:
     ACCESS: "Доступ до секції '{title}' "
     ACCESS_HELP: "Дозволити перегляд розділу, що містить дерево сторінок і зміст. Дозволами на перегляд та редагування, а також окремими дозволами на контент, можна керувати на відповідних сторінках."
@@ -36,6 +71,10 @@ uk:
     ChoosePageParentMode: "Виберіть де створити цю сторінку"
     ChoosePageType: "Виберіть тип сторінки"
     Create: Створити
+    DELETE: "Видалити з чорнового сайту"
+    DELETEFP: Видалити
+    DESCREMOVED: "і {count} нащадків"
+    MENUTITLE: "Редагувати сторінку"
     PAGENOTEXISTS: "Ця сторінка не існує"
     PAGETYPEANYOPT: Будь-який
     PUBALLCONFIRM: "Будь ласка, опублікуйте кожну сторінку. Для цього перенесіть проміжний варіант до існуючого."
@@ -44,15 +83,23 @@ uk:
     REMOVEDPAGE: "'{title}' видалено з публічного сайту"
     REMOVEDPAGEFROMDRAFT: "Видалено '%s' з чорнового сайту"
     ROLLBACK: "Повернутися до цієї версії"
+    SAVE: Зберегти
     TabContent: Вміст
     TabHistory: Історія
     TabSettings: Налаштування
+  CMSMain_left_ss:
+    RESET: Відновити
   CMSPageAddController:
+    MENUTITLE: "Додати сторінку"
     ParentMode_child: "Під іншою сторінкою"
     ParentMode_top: "Вищий рівень"
+  CMSPageEditController:
+    MENUTITLE: "Редагувати сторінку"
   CMSPageHistoryController:
     COMPAREMODE: "Режим порівняння (виберіть два)"
     COMPAREVERSIONS: "Порівняти версії"
+    COMPARINGVERSION: "Порівняння версій {version1} та {version2}."
+    MENUTITLE: Історія
     REVERTTOTHISVERSION: "Відновити цю версію"
     SHOWUNPUBLISHED: "Показати неопубліковані версії"
     SHOWVERSION: "Показати версію"
@@ -64,10 +111,14 @@ uk:
     PUBLISHER: Видавець
     UNKNOWN: Невідомий
     WHEN: Коли
+  CMSPageSettingsController:
+    MENUTITLE: "Редагувати сторінку"
   CMSPagesController_Tools_ss:
     FILTER: Фільтр
   CMSSearch:
     FILTERDATEFROM: Від
+  CMSSettingsController:
+    MENUTITLE: Налаштування
   CMSSiteTreeFilter_Search:
     Title: "Всі сторінки"
   ContentControl:
@@ -75,6 +126,7 @@ uk:
   ContentController:
     ARCHIVEDSITEFROM: "Заархівований сайт з"
     DRAFTSITE: "Чорновий сайт"
+    DRAFT_SITE_ACCESS_RESTRICTION: "Ви повинні увійти у систему для перегляду чернетки даного матеріалу. <a href=\"%s\">Натсиніть для переходу на опублікований матеріал.</a>"
     Email: Е-пошта
     InstallFilesDeleted: "Інсталяційні файли були успішно видалені."
     LOGGEDINAS: "Залогований як "
@@ -91,10 +143,25 @@ uk:
     DEFAULTERRORPAGETITLE: "Сторінку не знайдено"
     DEFAULTSERVERERRORPAGECONTENT: "<p>Вибачте, під час опрацювання вашого запиту сталася помилка.</p>"
     DEFAULTSERVERERRORPAGETITLE: "Помилка сервера"
+    DESCRIPTION: "Власний вміст для різних випадків помилки (наприклад, \"Сторінку не знайдено\")"
+    ERRORFILEPROBLEM: "Помилка при відкритті файлу \"{filename}\" для запису. Перевірте, будь-ласка, дозволи на файл."
+  Folder:
+    AddFolderButton: "Додати папку"
+    DELETEUNUSEDTHUMBNAILS: "Видалити невикористані ескізи"
+    UNUSEDFILESTITLE: "Невикористані файли"
+    UNUSEDTHUMBNAILSTITLE: "Невикористані ескізи"
+    UploadFilesButton: Завантажити
+  LeftAndMain:
+    DELETED: Видалено
+    SAVEDUP: Збережено.
+    SearchResults: "Результати пошуку"
+  Permission:
+    CMS_ACCESS_CATEGORY: "Доступ до CMS"
   Permissions:
     CONTENT_CATEGORY: "Дозволи вмісту"
     PERMISSIONS_CATEGORY: "Ролі та дозволи доступу"
   RedirectorPage:
+    DESCRIPTION: "Перенаправлення на іншу внутрішню сторінку"
     HASBEENSETUP: "Сторінка перенаправлення була встановлена без указання цілі перенаправлення"
     HEADER: "Ця сторінка перенаправляє користувачів на іншу сторінку"
     OTHERURL: "URL іншого сайту"
@@ -102,19 +169,43 @@ uk:
     REDIRECTTOEXTERNAL: "Інший сайт"
     REDIRECTTOPAGE: "Сторінку на Вашому сайті"
     YOURPAGE: "Сторінки на Вашому сайті"
+  ReportAdmin:
+    MENUTITLE: Звіти
+  ReportAdminForm:
+    FILTERBY: "Фільтр по"
   SearchForm:
     GO: Уперед
     SEARCH: Пошук
     SearchResults: "Результати пошуку"
   SideReport:
     BROKENFILES: "Сторінки з пошкодженими файлами"
+    BROKENLINKS: "Сторінки з битими посиланнями"
     BROKENREDIRECTORPAGES: "Сторінки-перенаправлення вказують на видалені сторінки"
     BROKENVIRTUALPAGES: "Віртуальні сторінки вказують на видалені сторінки"
     BrokenLinksGroupTitle: "Звіт про биті посилання"
     ContentGroupTitle: "Звіти про вміст"
     EMPTYPAGES: "Порожні сторінки"
     LAST2WEEKS: "Сторінки, відредаговані за останні два тижні"
+    OtherGroupTitle: Інше
     ParameterLiveCheckbox: "Перевірити робочий сайт"
+  SilverStripeNavigatorLink:
+    ShareLink: "Поділитися посиланням"
+  SilverStripeNavigatorLinkl:
+    CloseLink: Закрити
+  SiteConfig:
+    DEFAULTTHEME: "(Використовувати тему за замовчуванням)"
+    EDITHEADER: "Хто може редагувати сторінки на цьому сайті?"
+    EDIT_PERMISSION: "Керувати конфігурацією сайту"
+    EDIT_PERMISSION_HELP: "Можливість редагування глобальних налаштувань доступу / дозволів сторінок верхнього рівня."
+    SITENAMEDEFAULT: "Назва Вашого Сайту"
+    SITETAGLINE: "Гасло сайту"
+    SITETITLE: "Заголовок сайту"
+    TABACCESS: Доступ
+    TABMAIN: Головна
+    TAGLINEDEFAULT: "тут ваш слоган"
+    THEME: "Тема оформлення"
+    TOPLEVELCREATE: "Хто може створювати сторінки верхнього рівня на сайті?"
+    VIEWHEADER: "Хто може переглядати сторінки на цьому сайті?"
   SiteTree:
     ACCESSANYONE: Будь-хто
     ACCESSHEADER: "Хто може переглядати цю сторінку?"
@@ -122,6 +213,7 @@ uk:
     ACCESSONLYTHESE: "Тільки ці люди (виберіть зі списку)"
     ADDEDTODRAFTHELP: "Сторінка ще не опублікована"
     ADDEDTODRAFTSHORT: Чорновий
+    ALLOWCOMMENTS: "Дозволити коментувати на цій сторінці?"
     APPEARSVIRTUALPAGES: "Цей вміст також відображається на віртуальній сторінці в розділі {title}."
     BUTTONCANCELDRAFT: "Відмінити зміни чернетки"
     BUTTONCANCELDRAFTDESC: "Видалити черентку та повернутися до теперішнього опублікованого варіанту"
@@ -132,6 +224,8 @@ uk:
     DEFAULTABOUTTITLE: "Про нас"
     DEFAULTCONTACTTITLE: Контакти
     DEFAULTHOMETITLE: Домівка
+    DELETEDPAGEHELP: "Сторінка вже не є опублікованою"
+    DELETEDPAGESHORT: Видалений
     DEPENDENT_NOTE: "Наступні сторінки залежать від цієї сторінки. Вони включають віртуальні сторінки, сторінки переадресації і сторінки з посиланням у змісті"
     DependtPageColumnLinkType: "Тип посилання"
     EDITANYONE: "Будь-хто, хто може увійти до системи"
@@ -162,6 +256,8 @@ uk:
     PERMISSION_GRANTACCESS_HELP: "Дозволити встановлювати обмеження доступу окремо для кожної сторінки в розділі \"Сторінки\""
     PageTypNotAllowedOnRoot: "Сторінки типу \"{type}\" не можуть бути кореневими"
     PageTypeNotAllowed: "Не дозоволяється створювати сторінки типу \"{type}\" як дочірні сторінки цієї сторінки"
+    REMOVEDFROMDRAFTHELP: "Сторінка опублікована, але видалена з чорнового сайту"
+    REMOVEDFROMDRAFTSHORT: "Видалено '%s' з чорнового сайту"
     REMOVE_INSTALL_WARNING: "Увага: Ви повинні видалити install.php з цієї установки SilverStripe з міркувань безпеки."
     REORGANISE_DESCRIPTION: "Змінити структуру сайту"
     REORGANISE_HELP: "Переставляти сторінки в дереві сайту за допомогою drag&drop"
@@ -171,6 +267,7 @@ uk:
     TABCONTENT: Вміст
     TABDEPENDENT: "Залежні сторінки"
     TOPLEVEL: "Вміст Сайту (Верхній Рівень)"
+    TOPLEVELCREATORGROUPS: "Автори найвищого рівня"
     URLSegment: "URL адреса"
     VIEWERGROUPS: "Групи глядачів"
     VIEW_ALL_DESCRIPTION: "Перегляд будь-якої сторінки"
@@ -188,5 +285,7 @@ uk:
     CANACCESS: "Ви можете перейти до архівного сайту за посиланням:"
     HAVEASKED: "Ви надіслали запит на перегляд вмісту нашої сторінки"
   VirtualPage:
+    DESCRIPTION: "Відображення вмісту іншої сторінки"
     HEADER: "Це віртуальна сторінка"
     PageTypNotAllowedOnRoot: "Тип сторінки \"{type}\" не допускається на кореневому рівні для цієї віртуальної сторінки"
+    SINGULARNAME: "Віртуальна сторінка"

--- a/lang/vi_VN.yml
+++ b/lang/vi_VN.yml
@@ -1,6 +1,7 @@
 vi_VN:
   CMSMain:
     PAGENOTEXISTS: "Không tìm thấy trang này."
+    SAVE: Lưu
   ErrorPage:
     CODE: "Mã lỗi"
     DEFAULTERRORPAGECONTENT: "<p>Bạn truy cập vào một trang không tồn tại</p><p>Xin vui lòng kiểm tra lại đường dẩn hoặc quay lại trang chủ</p>"
@@ -18,6 +19,7 @@ vi_VN:
     ACCESSHEADER: "Ai có thể xem trang này ?"
     ACCESSLOGGEDIN: "Người dùng đã đăng nhập"
     ACCESSONLYTHESE: "Chỉ những người sau đây (chọn từ danh sách)"
+    ALLOWCOMMENTS: "Cho phép bình luận trên trang này?"
     BUTTONCANCELDRAFT: "Hủy thay đổi nháp"
     BUTTONCANCELDRAFTDESC: "Xóa khỏi mục nháp và khôi phục lại trang gốc"
     BUTTONUNPUBLISH: Ẩn

--- a/lang/zh.yml
+++ b/lang/zh.yml
@@ -1,7 +1,41 @@
 zh:
+  AssetAdmin:
+    ADDFILES: 添加文件
+    ActionAdd: 添加文件夹
+    AppCategoryArchive: 存档
+    AppCategoryAudio: 音频
+    AppCategoryDocument: 文档
+    AppCategoryFlash: 刷新
+    AppCategoryImage: 图像
+    AppCategoryVideo: 视频
+    BackToFolder: 返回到文件夹
+    CREATED: 日期
+    CurrentFolderOnly: 限于当前文件夹？
+    DetailsView: 详情
+    FILES: 文件
+    FILESYSTEMSYNC: 同步文件
+    FILESYSTEMSYNCTITLE: "更新文件系统上的 CMS 数据库文件条目。当新的文件通过 CMS 以外的途径，例如 FTP，上传时，该功能十分有用。"
+    FROMTHEINTERNET: 来源于互联网
+    FROMYOURCOMPUTER: 从您的电脑
+    Filetype: 文件类型
+    ListView: 列表视图
+    MENUTITLE: 文件
+    NEWFOLDER: 新文件夹
+    SIZE: 大小
+    THUMBSDELETED: "{count} 个未使用的缩略图已被删除"
+    TreeView: 树状图
+    Upload: 上传
+  AssetAdmin_DeleteBatchAction:
+    TITLE: 删除文件夹
+  AssetAdmin_Tools:
+    FILTER: 过滤
+  AssetAdmin_left_ss:
+    GO: 前进
   AssetTableField:
     BACKLINKCOUNT: 应用于：
     PAGES: 单个或多个页面
+  BackLink_Button_ss:
+    Back: 返回
   BrokenLinksReport:
     Any: 任意
     BROKENLINKS: 报告无效链接
@@ -27,8 +61,14 @@ zh:
   CMSAddPageController:
     Title: 添加页面
   CMSBatchActions:
+    DELETED_DRAFT_PAGES: "从网站雏形中删除 %d 个页面，%d 个失败"
+    DELETED_PAGES: "从已发布网站中删除 %d 个页面，%d 个失败"
+    DELETE_DRAFT_PAGES: 从网站雏形中删除
+    DELETE_PAGES: 从已发布网站中删除
     PUBLISHED_PAGES: "发布 %d 个页面， %d 个失败"
     PUBLISH_PAGES: 发布
+  CMSFileAddController:
+    MENUTITLE: 文件
   CMSMain:
     ACCESS: "访问 '{title}' 部分"
     ACCESS_HELP: "允许查看包含页面树及内容 部分。查看和编辑权限可以通过页面特定的下拉菜单进行控制，与使用单独的”内容权限“处理一样。"
@@ -38,8 +78,13 @@ zh:
     ChoosePageParentMode: 选择在哪创建此页面
     ChoosePageType: 选择页面类型
     Create: 创建
+    DELETE: 删除草稿
+    DELETEFP: 删除
+    DESCREMOVED: "和{count}子页"
     DUPLICATED: "成功复制‘{title}’"
     DUPLICATEDWITHCHILDREN: "成功复制‘{title}’及其子页面"
+    EditTree: 编辑树
+    MENUTITLE: 编辑页面
     NEWPAGE: "新建{pagetype}"
     PAGENOTEXISTS: 该页面不存在
     PAGETYPEANYOPT: 任何
@@ -47,22 +92,31 @@ zh:
     PUBALLFUN: “全部发布”功能
     PUBPAGES: "完成：已发布{count}个页面"
     PageAdded: 成功创建页面
+    REMOVED: "从线上站点删除‘{title}'{description}"
     REMOVEDPAGE: "从已发布站点删除’{title}'"
     REMOVEDPAGEFROMDRAFT: 从草稿站点删除‘s%’
     RESTORED: "成功恢复’{title}‘"
     ROLLBACK: 回滚到该版本
     ROLLEDBACKPUBv2: 回滚到已发布版本。
     ROLLEDBACKVERSIONv2: "回滚到版本#%d。"
+    SAVE: 保存
     SAVEDRAFT: 保存草稿
     TabContent: 内容
     TabHistory: 历史记录
     TabSettings: 设置
+  CMSMain_left_ss:
+    RESET: 重置
   CMSPageAddController:
+    MENUTITLE: 添加页面
     ParentMode_child: 根据另一个页面
     ParentMode_top: 顶层
+  CMSPageEditController:
+    MENUTITLE: 编辑页面
   CMSPageHistoryController:
     COMPAREMODE: 比较模式（选择两个）
     COMPAREVERSIONS: 版本比较
+    COMPARINGVERSION: "正在对比版本{version1}和{version2}。"
+    MENUTITLE: 历史记录
     REVERTTOTHISVERSION: 恢复到这个版本
     SHOWUNPUBLISHED: 显示未发布的版本
     SHOWVERSION: 显示版本
@@ -75,7 +129,10 @@ zh:
     PUBLISHER: 发布者
     UNKNOWN: 未知的
     WHEN: 何时
+  CMSPageSettingsController:
+    MENUTITLE: 编辑页面
   CMSPagesController:
+    GalleryView: 图库视图
     ListView: 列表视图
     MENUTITLE: 页面
     TreeView: 树视图
@@ -83,7 +140,10 @@ zh:
     FILTER: 过滤器
   CMSSearch:
     FILTERDATEFROM: 从
+    FILTERDATEHEADING: 日期
     FILTERDATETO: 到
+  CMSSettingsController:
+    MENUTITLE: 设置
   CMSSiteTreeFilter_Search:
     Title: 所有页面
   ContentControl:
@@ -94,6 +154,7 @@ zh:
     CMS: 内容管理系统
     DRAFT: 草稿
     DRAFTSITE: 草稿站点
+    DRAFT_SITE_ACCESS_RESTRICTION: "您必须使用您的内容管理系统密码登录，才可以查看草稿或存档内容。<a href=\"%s\">点击这里返回到已发布的站点。</a>"
     Email: 电子邮件
     INSTALL_SUCCESS: 安装成功
     InstallFilesDeleted: 安装文件已经成功删除。
@@ -139,17 +200,40 @@ zh:
     DEFAULTERRORPAGETITLE: 未发现页面
     DEFAULTSERVERERRORPAGECONTENT: <p>对不起，处理您的请求时发生错误。</p>
     DEFAULTSERVERERRORPAGETITLE: 服务器错误
+    DESCRIPTION: 给不同的错误自定义内容（例如”未发现页面“）
+    ERRORFILEPROBLEM: "打开文件”{filename}“尝试写入. 请检查文件许可"
+    SINGULARNAME: 错误页面
+  Folder:
+    AddFolderButton: 增加文件夹
+    DELETEUNUSEDTHUMBNAILS: 删除未使用的缩略图
+    UNUSEDFILESTITLE: 未使用的文件
+    UNUSEDTHUMBNAILSTITLE: 未使用的缩略图
+    UploadFilesButton: 上传
+  LeftAndMain:
+    DELETED: 已删除。
+    PreviewButton: 预览
+    SAVEDUP: 已保存。
+    SearchResults: 搜索结果
+  Permission:
+    CMS_ACCESS_CATEGORY: 访问内容管理系统
   Permissions:
     CONTENT_CATEGORY: 内容权限
     PERMISSIONS_CATEGORY: 角色及访问权限
   RedirectorPage:
+    DESCRIPTION: 重定向到一个不同的内部页面
     HASBEENSETUP: 建立了一个没有任何跳转目标的重定向页。
     HEADER: 该页面将会使用户转向另外一个页面
     OTHERURL: 其他网站URL
     REDIRECTTO: 重定向到
     REDIRECTTOEXTERNAL: 另一个网站
     REDIRECTTOPAGE: 您网站上的一个页面
+    SINGULARNAME: 重定向页
     YOURPAGE: 您网站的页面
+  ReportAdmin:
+    MENUTITLE: 报告
+    ReportTitle: 标题
+  ReportAdminForm:
+    FILTERBY: 过滤
   SITETREE:
     VIRTUALPAGEDRAFTWARNING: 请发布链接的页面，以发布虚拟页面
     VIRTUALPAGEWARNING: 请先选择一个链接的页面并保存，以发布该页面
@@ -160,15 +244,38 @@ zh:
     SearchResults: 搜索结果
   SideReport:
     BROKENFILES: 页面含有无效文件的
+    BROKENLINKS: 还有坏链接的页面
     BROKENREDIRECTORPAGES: 重定向页面指向了已删除页面
     BROKENVIRTUALPAGES: 虚拟页面指向了已删除页面
     BrokenLinksGroupTitle: 无效链接报告
     ContentGroupTitle: 内容报告
     EMPTYPAGES: 无内容页面
     LAST2WEEKS: 过去2周内编辑过的页面
+    OtherGroupTitle: 其他
     ParameterLiveCheckbox: 检查线上站点
+    REPEMPTY: "报告{title}是空的。"
   SilverStripeNavigator:
     ARCHIVED: 已存档
+  SilverStripeNavigatorLink:
+    ShareLink: 分享链接
+  SilverStripeNavigatorLinkl:
+    CloseLink: 关闭
+  SiteConfig:
+    DEFAULTTHEME: （使用默认主题）
+    EDITHEADER: 谁可以修改该站点的页面？
+    EDIT_PERMISSION: 管理站点配置
+    EDIT_PERMISSION_HELP: 能够编辑全局访问设置/顶层页面权限。
+    PLURALNAME: 站点设置
+    SINGULARNAME: 站点设置
+    SITENAMEDEFAULT: 您的站点名称
+    SITETAGLINE: 站点标语/口号
+    SITETITLE: 站点标题
+    TABACCESS: 读取
+    TABMAIN: 主要
+    TAGLINEDEFAULT: 这里是您的标语
+    THEME: 主题
+    TOPLEVELCREATE: 谁可以在站点的根路径创建页面？
+    VIEWHEADER: 谁可以查看该站点的页面？
   SiteTree:
     ACCESSANYONE: 任何人
     ACCESSHEADER: 谁可以查看该页面？
@@ -176,6 +283,7 @@ zh:
     ACCESSONLYTHESE: 仅这些人（从列表中选择）
     ADDEDTODRAFTHELP: 页面尚未发布
     ADDEDTODRAFTSHORT: 草稿
+    ALLOWCOMMENTS: 允许在该页面进行评论？
     APPEARSVIRTUALPAGES: "该内容也出现在{title}部分的虚拟页面中。"
     BUTTONCANCELDRAFT: 取消草稿改动
     BUTTONCANCELDRAFTDESC: 删除您的草稿并回复至当前已发布的页面
@@ -189,7 +297,10 @@ zh:
     DEFAULTABOUTTITLE: 关于我们
     DEFAULTCONTACTTITLE: 联络我们
     DEFAULTHOMETITLE: 首页
+    DELETEDPAGEHELP: 页面已停止发布
+    DELETEDPAGESHORT: 已删除
     DEPENDENT_NOTE: 以下页面依赖该页。包括虚拟页面，重定向页，以及有内容链接的页面。
+    DESCRIPTION: 通用内容页
     DependtPageColumnLinkType: 链接类型
     DependtPageColumnURL: URL
     EDITANYONE: 任何人都可以登录到内容管理系统
@@ -227,17 +338,22 @@ zh:
     PARENTTYPE_SUBPAGE: 父页面之下的子页面
     PERMISSION_GRANTACCESS_DESCRIPTION: 管理访问内容的权限
     PERMISSION_GRANTACCESS_HELP: 允许在“页面”部分设置针对页面的访问限制。
+    PLURALNAME: 页面
     PageTypNotAllowedOnRoot: "页面类型“{type}”不允许做为根级页"
     PageTypeNotAllowed: "页面类型“{type}”不允许作为该父页面的子页面"
+    REMOVEDFROMDRAFTHELP: 页面已发布，但是已从草稿中删除
+    REMOVEDFROMDRAFTSHORT: 从草稿中删除
     REMOVE_INSTALL_WARNING: 警告：出于安全原因考虑，您应该从该SilverStripe安装副本中删除install.php。
     REORGANISE_DESCRIPTION: 改变站点结构
     REORGANISE_HELP: 在站点树上通过拖放重新安排页面
     SHOWINMENUS: 在菜单中显示？
     SHOWINSEARCH: 在搜索结果中显示？
+    SINGULARNAME: 页面
     TABBEHAVIOUR: 行为
     TABCONTENT: 主要内容
     TABDEPENDENT: 依赖页面
     TOPLEVEL: 站点内容（顶层）
+    TOPLEVELCREATORGROUPS: 顶层创建者
     URLSegment: URL分类
     VIEWERGROUPS: 浏览者分组
     VIEW_ALL_DESCRIPTION: 查看任何页面
@@ -262,7 +378,9 @@ zh:
     HAVEASKED: 请您查看我们网站的内容在
   VirtualPage:
     CHOOSE: 链接的页面
+    DESCRIPTION: 显示另一个页面的内容
     EditLink: 编辑
     HEADER: 这是一个虚拟页面
     HEADERWITHLINK: "这是一个从“{标题}”复制内容的虚拟页面（{链接}）"
     PageTypNotAllowedOnRoot: "此虚拟页面的根级不允许使用原页面类型 \"{type}\""
+    SINGULARNAME: 虚拟页面

--- a/lang/zh_CN.yml
+++ b/lang/zh_CN.yml
@@ -1,13 +1,26 @@
 zh_CN:
+  AssetAdmin:
+    NEWFOLDER: 新建文件夹
+  AssetAdmin_left_ss:
+    GO: 执行
   CMSMain:
+    DELETE: 从测试网站中删除
     PAGENOTEXISTS: 该网页不存在
     PUBALLCONFIRM: 请发布该站的每一网页，这样，预备发布站上的内容就会复制到正式发布站上
     PUBALLFUN: “全部发布“功能
     REMOVEDPAGEFROMDRAFT: "已从测试站点删除 '%s'"
     ROLLBACK: 恢复到这一版本
+    SAVE: 保存
   ErrorPage:
     CODE: 错误代码
+  Folder:
+    AddFolderButton: 添加文件夹
+    DELETEUNUSEDTHUMBNAILS: 删除未使用缩略图
+    UNUSEDFILESTITLE: 未使用文件
+    UNUSEDTHUMBNAILSTITLE: 未使用缩略图
+    UploadFilesButton: 上传
   RedirectorPage:
+    DESCRIPTION: 跳转至其他的内部页面
     HASBEENSETUP: 重导网页被生成，却没有什么地方由它来重导。
     HEADER: 该页会将用户重新导向另一网页
     OTHERURL: 另一网站的URL
@@ -18,11 +31,16 @@ zh_CN:
   SideReport:
     EMPTYPAGES: 空白页
     LAST2WEEKS: 在过去2周内编辑过的网页
+  SilverStripeNavigatorLink:
+    ShareLink: 分享链接
+  SilverStripeNavigatorLinkl:
+    CloseLink: 关闭
   SiteTree:
     ACCESSANYONE: 任何人
     ACCESSHEADER: 在我的网站上，谁可以浏览此页？
     ACCESSLOGGEDIN: 已登录的用户
     ACCESSONLYTHESE: 只有这些人（请从下列清单中选择）
+    ALLOWCOMMENTS: 是否允许对次页进行评论？
     BUTTONCANCELDRAFT: 取消草稿的改动
     BUTTONCANCELDRAFTDESC: 将您的草稿恢复到目前正式发布的版本
     BUTTONUNPUBLISH: 撤消发布
@@ -48,4 +66,5 @@ zh_CN:
     CANACCESS: 您可通过这个链接进入已归挡的网页：
     HAVEASKED: "在%s,您要求浏览我们网站"
   VirtualPage:
+    DESCRIPTION: 显示其他页的内容
     HEADER: 这是一个虚拟页

--- a/lang/zh_TW.yml
+++ b/lang/zh_TW.yml
@@ -1,5 +1,13 @@
 zh_TW:
+  AssetAdmin:
+    NEWFOLDER: 新資料夾
+  AssetAdmin_left_ss:
+    GO: 執行
+  BackLink_Button_ss:
+    Back: 返回
   CMSBatchActions:
+    DELETE_DRAFT_PAGES: 從草稿網站刪除
+    DELETE_PAGES: 從已出版網站刪除
     PUBLISHED_PAGES: "已出版 %d 網頁, %d 失敗"
     PUBLISH_PAGES: 出版
   CMSMain:
@@ -7,9 +15,11 @@ zh_TW:
     PUBALLCONFIRM: 請發布所有網頁
     PUBALLFUN: "\"全部發布\" 功能"
     ROLLBACK: 回複到這個的版本
+    SAVE: 儲存
   CMSPageHistoryController:
     COMPAREMODE: 比較模式(選擇兩個)
     COMPAREVERSIONS: 比較版本
+    MENUTITLE: 歷史
     REVERTTOTHISVERSION: 回復到此版本
     SHOWUNPUBLISHED: 顯示未出版的版本
     SHOWVERSION: 顯示版本
@@ -20,10 +30,15 @@ zh_TW:
     PUBLISHER: 發行者
     UNKNOWN: 未知的
     WHEN: 何時
+  CMSPageSettingsController:
+    MENUTITLE: 編輯網頁
   CMSPagesController:
+    GalleryView: 圖庫瀏覽
     ListView: 清單瀏覽
     MENUTITLE: 網頁
     TreeView: 樹狀瀏覽
+  CMSSettingsController:
+    MENUTITLE: 設定值
   CMSSiteTreeFilter_Search:
     Title: 所有網頁
   ContentControl:
@@ -34,7 +49,14 @@ zh_TW:
     DEFAULTERRORPAGETITLE: 未發現網頁
     DEFAULTSERVERERRORPAGECONTENT: "<p>抱歉, 處裡您的要求發生一個問題</p>"
     DEFAULTSERVERERRORPAGETITLE: 伺服器錯誤
+  Folder:
+    AddFolderButton: 新增資料夾
+    DELETEUNUSEDTHUMBNAILS: 刪除未使用的縮圖
+    UNUSEDFILESTITLE: 未使用的檔案
+    UNUSEDTHUMBNAILSTITLE: 未使用的縮圖
+    UploadFilesButton: 上傳
   RedirectorPage:
+    DESCRIPTION: 重新導向到一個內部不同的網頁
     HASBEENSETUP: 沒有任何地方被重新導向的一個重新導向網頁已被設定.
     HEADER: 本網頁將重新導向用戶至別的網頁
     OTHERURL: 其他網站網址
@@ -45,11 +67,16 @@ zh_TW:
   SideReport:
     EMPTYPAGES: 空頁
     LAST2WEEKS: 網頁在過去兩個禮拜有被更改過
+  SilverStripeNavigatorLink:
+    ShareLink: 分享鏈結
+  SilverStripeNavigatorLinkl:
+    CloseLink: 關閉
   SiteTree:
     ACCESSANYONE: 所有人
     ACCESSHEADER: 誰可以瀏覽這頁？
     ACCESSLOGGEDIN: 已登入的使用者
     ACCESSONLYTHESE: 只有這些人(從清單選擇)
+    ALLOWCOMMENTS: 允許留言嗎？
     BUTTONCANCELDRAFT: 取消草稿更變
     BUTTONCANCELDRAFTDESC: 刪除草稿並回複到正式發布的版本
     BUTTONUNPUBLISH: 取消發布
@@ -59,6 +86,7 @@ zh_TW:
     DEFAULTABOUTTITLE: 關於我們
     DEFAULTCONTACTTITLE: 連絡我們
     DEFAULTHOMETITLE: 首頁
+    DELETEDPAGESHORT: 已刪除
     DEPENDENT_NOTE: "以下的網頁是依附在本網頁的. 這包含了虛擬網頁, 重新導向網頁, 以及有內容鏈結的網頁."
     DependtPageColumnLinkType: 鏈結類型
     DependtPageColumnURL: 網址
@@ -87,6 +115,7 @@ zh_TW:
     PARENTTYPE_SUBPAGE: 在母頁下面的次頁
     PERMISSION_GRANTACCESS_DESCRIPTION: 管理內容的存取權限
     PERMISSION_GRANTACCESS_HELP: 允許設定在"網頁"部分的網頁-特定存取限制.
+    REMOVEDFROMDRAFTSHORT: 從草稿移除
     REMOVE_INSTALL_WARNING: "警告: 為了安全理由你應該從SilverStripe的安裝中移除install.php."
     REORGANISE_DESCRIPTION: 改變網站結構
     REORGANISE_HELP: "經由 拉&放 於網站樹狀架構內重新安排網頁."
@@ -96,6 +125,7 @@ zh_TW:
     TABCONTENT: 內容
     TABDEPENDENT: 依賴網頁
     TOPLEVEL: "網站內容 (高層)"
+    TOPLEVELCREATORGROUPS: 頂級創作者
     URLSegment: 網址分類
     VIEWERGROUPS: 瀏覽者群組
     VIEW_ALL_DESCRIPTION: 瀏覽任何網頁
@@ -111,4 +141,6 @@ zh_TW:
     CANACCESS: 您可以利用哲格連結到已歸檔站：
     HAVEASKED: 您要瀏覽這一天的網站內容：
   VirtualPage:
+    DESCRIPTION: 顯示其他網頁的內容
     HEADER: 這是一個虛擬網頁
+    SINGULARNAME: 虛擬網頁


### PR DESCRIPTION
This reverts commit 475b73357950827cb1de8a0e7b305bd6d445bba0.

It pulled updates from transifex *after* we switched translations
to 4.x only mode - which resulted in a lot of translation keys being
moved around. For example, asset-related translations went from
framework to the asset-admin module. The removal of these translations
in 3.x caused translations to go partially missing, since these new
modules are 4.x only.

See https://github.com/silverstripe/silverstripe-framework/issues/7002