### PR TITLE
Bugfix: SS4 Right click, add page fails

### DIFF
--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -149,7 +149,7 @@ class CMSPageAddController extends CMSPageEditController
             "AddForm",
             $fields,
             $actions
-        )->setHTMLID('Form_AddForm');
+        )->setHTMLID('Form_AddForm')->setStrictFormMethodCheck(false);
         $form->setAttribute('data-hints', $this->SiteTreeHints());
         $form->setAttribute('data-childfilter', $this->Link('childfilter'));
         $form->setValidationResponseCallback(function (ValidationResult $errors) use ($negotiator, $form) {


### PR DESCRIPTION
`addForm` function receives both POSTs and GETs.  Set the form's `strictFormMethodCheck` to false to avoid `405 Method Not Allowed` error responses.  Issue #1846.