### PR TITLE
Limits added to collateDescendants

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1256,6 +1256,12 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     public function collateDescendants($condition, &$collator)
     {
+        // apply reasonable hierarchy limits
+        $threshold = Config::inst()->get(Hierarchy::class, 'node_threshold_leaf');
+        if ($this->numChildren() > $threshold) {
+            return false;
+        }
+
         $children = $this->Children();
         if ($children) {
             foreach ($children as $item) {


### PR DESCRIPTION
Limits added to collateDescendants() to ensure reasonable performance with thousands of pages.

This change set fixes a performance issue with the CMS. I tested this on a site with ~4000 pages. Current version of the code iterates of all pages which is unusable for such site.

This change set is related to wider performance boost on SilverStripe 4. Please see following PRs:

https://github.com/silverstripe/silverstripe-framework/pull/7129
https://github.com/silverstripe/silverstripe-lumberjack/pull/57