### PR TITLE
FIX Ensure tab states are reflected when switching on page edit screen

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -350,6 +350,21 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         }
     }
 
+    /**
+     * Decide which is the active primary tab in a CMS edit screen
+     *
+     * @return string
+     */
+    public function getActiveTab()
+    {
+        if ($this instanceof CMSPageSettingsController) {
+            return 'settings';
+        } elseif ($this instanceof CMSPageHistoryController) {
+            return 'history';
+        }
+        return 'edit';
+    }
+
     public function LinkWithSearch($link)
     {
         // Whitelist to avoid side effects

--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_Content.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_Content.ss
@@ -10,17 +10,17 @@
 
 					<div class="cms-content-header-tabs cms-tabset">
 						<ul class="cms-tabset-nav-primary nav nav-tabs">
-							<li class="nav-item content-treeview<% if $class == 'SilverStripe\\CMS\\Controllers\\CMSPageEditController' %> ui-tabs-active<% end_if %>">
+							<li class="nav-item content-treeview<% if $ActiveTab == 'edit' %> ui-tabs-active<% end_if %>">
 								<a href="$LinkPageEdit" class="nav-link cms-panel-link" title="Form_EditForm" data-href="$LinkPageEdit">
 				  <% _t('SilverStripe\CMS\Controllers\CMSMain.TabContent', 'Content') %>
 								</a>
 							</li>
-							<li class="nav-item content-listview<% if $class == 'SilverStripe\\CMS\\Controllers\\CMSPageSettingsController' %> ui-tabs-active<% end_if %>">
+							<li class="nav-item content-listview<% if $ActiveTab == 'settings' %> ui-tabs-active<% end_if %>">
 								<a href="$LinkPageSettings" class="nav-link cms-panel-link" title="Form_EditForm" data-href="$LinkPageSettings">
 				  <% _t('SilverStripe\CMS\Controllers\CMSMain.TabSettings', 'Settings') %>
 								</a>
 							</li>
-							<li class="nav-item content-listview<% if $class == 'SilverStripe\\CMS\\Controllers\\CMSPageHistoryController' %> ui-tabs-active<% end_if %>">
+							<li class="nav-item content-listview<% if $ActiveTab == 'history' %> ui-tabs-active<% end_if %>">
 								<a href="$LinkPageHistory" class="nav-link cms-panel-link" title="Form_EditForm" data-href="$LinkPageHistory">
 				  <% _t('SilverStripe\CMS\Controllers\CMSMain.TabHistory', 'History') %>
 								</a>

--- a/tests/behat/features/edit-a-page.feature
+++ b/tests/behat/features/edit-a-page.feature
@@ -27,3 +27,14 @@ Feature: Edit a page
     When I click on "About Us" in the tree
     Then the "Title" field should contain "About Us!"
     And the "Content" HTML field should contain "my new content"
+
+  @javascript
+  Scenario: I can toggle between the main tabs on a page
+    When I click on "About Us" in the tree
+    Then I should see an edit page form
+    And I should see a "Settings" tab in the CMS content header tabs
+    And the "Content" header tab should be active
+
+    When I click on "Settings" in the header tabs
+    Then the "Settings" header tab should be active
+    And the "Content" header tab should not be active


### PR DESCRIPTION
Resolves #1883 and resolves #1887