### PR TITLE
Remove sprintf translations in CMSMain in favour of named parameters

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1742,7 +1742,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         $this->getResponse()->addHeader(
             'X-Status',
-            rawurlencode(sprintf(_t(__CLASS__ . '.REMOVEDPAGEFROMDRAFT', "Removed '{title}' from the draft site"), $record->Title))
+            rawurlencode(_t(
+                __CLASS__ . '.REMOVEDPAGEFROMDRAFT',
+                "Removed '{title}' from the draft site",
+                ['title' => $record->Title]
+            ))
         );
 
         // Even if the record has been deleted from stage and live, it can be viewed in "archive mode"
@@ -1774,7 +1778,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         $this->getResponse()->addHeader(
             'X-Status',
-            rawurlencode(sprintf(_t(__CLASS__ . '.ARCHIVEDPAGE', "Archived page '{title}'"), $record->Title))
+            rawurlencode(_t(
+                __CLASS__ . '.ARCHIVEDPAGE',
+                "Archived page '{title}'",
+                ['title' => $record->Title]
+            ))
         );
 
         // Even if the record has been deleted from stage and live, it can be viewed in "archive mode"


### PR DESCRIPTION
Follow up fix from #1826