### PR TITLE
API Virtual pages now respect cascade_deletes on source page

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -193,12 +193,16 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     );
 
     private static $has_many = array(
-        "VirtualPages" => "SilverStripe\\CMS\\Model\\VirtualPage.CopyContentFrom"
+        "VirtualPages" => VirtualPage::class . '.CopyContentFrom'
     );
 
     private static $owned_by = array(
         "VirtualPages"
     );
+
+    private static $cascade_deletes = [
+        'VirtualPages',
+    ];
 
     private static $casting = array(
         "Breadcrumbs" => "HTMLFragment",

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -66,7 +66,7 @@ class VirtualPage extends Page
     );
 
     private static $has_one = array(
-        "CopyContentFrom" => "SilverStripe\\CMS\\Model\\SiteTree",
+        "CopyContentFrom" => SiteTree::class,
     );
 
     private static $owns = array(


### PR DESCRIPTION
Fixes broken CMS tests on https://github.com/silverstripe/silverstripe-framework/pull/7257, but neither will pass in isolation.

Parent story: https://github.com/silverstripe/silverstripe-versioned/issues/23