### PR TITLE
API Allow SiteTree::Link to be extended

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -517,7 +517,10 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     public function Link($action = null)
     {
-        return Controller::join_links(Director::baseURL(), $this->RelativeLink($action));
+        $relativeLink = $this->RelativeLink($action);
+        $link =  Controller::join_links(Director::baseURL(), $relativeLink);
+        $this->extend('updateLink', $link, $action, $relativeLink);
+        return $link;
     }
 
     /**

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -890,7 +890,7 @@ class SiteTreeTest extends SapphireTest
     }
 
     /**
-     * @covers SilverStripe\CMS\Model\SiteTree::validURLSegment
+     * @covers \SilverStripe\CMS\Model\SiteTree::validURLSegment
      */
     public function testValidURLSegmentURLSegmentConflicts()
     {
@@ -922,7 +922,7 @@ class SiteTreeTest extends SapphireTest
     }
 
     /**
-     * @covers SilverStripe\CMS\Model\SiteTree::validURLSegment
+     * @covers \SilverStripe\CMS\Model\SiteTree::validURLSegment
      */
     public function testValidURLSegmentClassNameConflicts()
     {
@@ -933,7 +933,7 @@ class SiteTreeTest extends SapphireTest
     }
 
     /**
-     * @covers SilverStripe\CMS\Model\SiteTree::validURLSegment
+     * @covers \SilverStripe\CMS\Model\SiteTree::validURLSegment
      */
     public function testValidURLSegmentControllerConflicts()
     {
@@ -1399,6 +1399,29 @@ class SiteTreeTest extends SapphireTest
         $this->assertTrue($page->canPublish());
         $page->canEditValue = false;
         $this->assertFalse($page->canPublish());
+    }
+
+    /**
+     * Test url rewriting extensions
+     */
+    public function testLinkExtension()
+    {
+        Director::config()->set('alternate_base_url', 'http://www.baseurl.com');
+        $page = new SiteTreeTest_ClassD();
+        $page->URLSegment = 'classd';
+        $page->write();
+        $this->assertEquals(
+            'http://www.updatedhost.com/classd/myaction?extra=1',
+            $page->Link('myaction')
+        );
+        $this->assertEquals(
+            'http://www.updatedhost.com/classd/myaction?extra=1',
+            $page->AbsoluteLink('myaction')
+        );
+        $this->assertEquals(
+            'classd/myaction',
+            $page->RelativeLink('myaction')
+        );
     }
 
     /**

--- a/tests/php/Model/SiteTreeTest_ExtensionA.php
+++ b/tests/php/Model/SiteTreeTest_ExtensionA.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\CMS\Model\SiteTreeExtension;
+use SilverStripe\Control\Controller;
 use SilverStripe\Dev\TestOnly;
 
 class SiteTreeTest_ExtensionA extends SiteTreeExtension implements TestOnly
@@ -12,5 +13,10 @@ class SiteTreeTest_ExtensionA extends SiteTreeExtension implements TestOnly
     public function canPublish($member)
     {
         return static::$can_publish;
+    }
+
+    public function updateLink(&$link, $action = null)
+    {
+        $link = Controller::join_links($link, '?extra=1');
     }
 }

--- a/tests/php/Model/SiteTreeTest_ExtensionB.php
+++ b/tests/php/Model/SiteTreeTest_ExtensionB.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\CMS\Model\SiteTreeExtension;
+use SilverStripe\Control\Controller;
 use SilverStripe\Dev\TestOnly;
 
 class SiteTreeTest_ExtensionB extends SiteTreeExtension implements TestOnly
@@ -12,5 +13,10 @@ class SiteTreeTest_ExtensionB extends SiteTreeExtension implements TestOnly
     public function canPublish($member)
     {
         return static::$can_publish;
+    }
+
+    public function updateLink(&$link, $action = null)
+    {
+        $link = Controller::join_links('http://www.updatedhost.com', $link);
     }
 }


### PR DESCRIPTION
This is necessary to allow post-baseurl applied links to be modified.

Useful for modules such as subsites / fluent which may need to prepend domain names.