### PR TITLE
NEW Add extension point to SiteTree::Link

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -517,7 +517,9 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     public function Link($action = null)
     {
-        return Controller::join_links(Director::baseURL(), $this->RelativeLink($action));
+        $link = Controller::join_links(Director::baseURL(), $this->RelativeLink($action));
+        $this->extend('updateLink', $link, $action);
+        return $link;
     }
 
     /**


### PR DESCRIPTION
To allow user code to update the result of `::Link` outside of `::RelativeLink`