### PR TITLE
FIX Ensure client config merging includes existing parent "form" attributes

### DIFF
--- a/code/Controllers/CMSPageEditController.php
+++ b/code/Controllers/CMSPageEditController.php
@@ -10,6 +10,7 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Forms\Form;
+use SilverStripe\ORM\ArrayLib;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\ValidationResult;
 
@@ -33,7 +34,7 @@ class CMSPageEditController extends CMSMain
 
     public function getClientConfig()
     {
-        return array_merge(parent::getClientConfig(), [
+        return ArrayLib::array_merge_recursive(parent::getClientConfig(), [
             'form' => [
                 'AddToCampaignForm' => [
                     'schemaUrl' => $this->Link('schema/AddToCampaignForm')


### PR DESCRIPTION
The existing code will overwrite any `$config['form']` values with its own. This change merges them instead.

Note - current state returns AddToCampaignForm and editorInternalLink. With this change it also returns EditorEmailLink and EditorExternalLink