### PR TITLE
Switch to trusty dist on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
-dist: precise
-
-sudo: false
+dist: trusty
 
 addons:
   apt:


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/pull/7092 for context. Trying out how this will go down on Behat tests in 3.x without further changes.