### PR TITLE
Reports: VirtualPages pointing to deleted pages report is incorrect

### DIFF
--- a/code/Reports/BrokenVirtualPagesReport.php
+++ b/code/Reports/BrokenVirtualPagesReport.php
@@ -2,42 +2,45 @@
 
 namespace SilverStripe\CMS\Reports;
 
+use SilverStripe\CMS\Model\VirtualPage;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DB;
-use SilverStripe\Versioned\Versioned;
 use SilverStripe\Reports\Report;
+use SilverStripe\Versioned\Versioned;
 
 class BrokenVirtualPagesReport extends Report
 {
 
     public function title()
     {
-        return _t(__CLASS__.'.BROKENVIRTUALPAGES', 'VirtualPages pointing to deleted pages');
+        return _t(__CLASS__ . '.BROKENVIRTUALPAGES', 'VirtualPages pointing to deleted pages');
     }
 
     public function group()
     {
-        return _t(__CLASS__.'.BrokenLinksGroupTitle', "Broken links reports");
+        return _t(__CLASS__ . '.BrokenLinksGroupTitle', "Broken links reports");
     }
 
     public function sourceRecords($params = null)
     {
-        $classes = ClassInfo::subclassesFor('SilverStripe\\CMS\\Model\\VirtualPage');
+        $classes = ClassInfo::subclassesFor(VirtualPage::class);
         $classParams = DB::placeholders($classes);
-        $classFilter = array(
-            "\"ClassName\" IN ($classParams) AND \"HasBrokenLink\" = 1" => $classes
-        );
+        $classFilter = [
+            "\"ClassName\" IN ($classParams)" => $classes,
+            "\"VirtualPage\".\"CopyContentFromID\" NOT IN (SELECT \"ID\" FROM SiteTree)",
+        ];
+
         $stage = isset($params['OnLive']) ? 'Live' : 'Stage';
-        return Versioned::get_by_stage('SilverStripe\\CMS\\Model\\SiteTree', $stage, $classFilter);
+        return Versioned::get_by_stage(VirtualPage::class, $stage, $classFilter);
     }
 
     public function columns()
     {
         return array(
             "Title" => array(
-                "title" => "Title", // todo: use NestedTitle(2)
+                "title" => "Title",
                 "link" => true,
             ),
         );
@@ -46,7 +49,7 @@ class BrokenVirtualPagesReport extends Report
     public function getParameterFields()
     {
         return new FieldList(
-            new CheckboxField('OnLive', _t(__CLASS__.'.ParameterLiveCheckbox', 'Check live site'))
+            new CheckboxField('OnLive', _t(__CLASS__ . '.ParameterLiveCheckbox', 'Check live site'))
         );
     }
 }


### PR DESCRIPTION
A virtual pointing to a deleted page is not the only way HasBrokenLink could be 1. An page extending VirtualPage could have a HTML field with a broken link in it but still point to a valid source page - this shouldn't be returned in the report.