### PR TITLE
Fix: TreeDropdownField showing broken page icons (fixes silverstripe/framework#7420)

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2830,7 +2830,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		}
 		$flags = $this->getStatusFlags();
 		$treeTitle = sprintf(
-			"<span class=\"jstree-pageicon page-icon class-%s\"></span><span class=\"item\" data-allowedchildren=\"%s\">%s</span>",
+			"<span class=\"jstree-pageicon class-%s\"></span><span class=\"item\" data-allowedchildren=\"%s\">%s</span>",
 			Convert::raw2htmlid($this->class),
 			Convert::raw2att(Convert::raw2json($children)),
 			Convert::raw2xml(str_replace(array("\n","\r"),"",$this->MenuTitle))


### PR DESCRIPTION
Removing this class hides the page type icons in the “unexpanded” TreeDropdownField (they still show up when you expand it), restoring the old behaviour.

Looks like a regression from https://github.com/silverstripe/silverstripe-cms/pull/1936