### PR TITLE
BUG UploadField overwriteWarning isn't working in AssetAdmin

### DIFF
--- a/code/controllers/CMSFileAddController.php
+++ b/code/controllers/CMSFileAddController.php
@@ -102,6 +102,11 @@ class CMSFileAddController extends LeftAndMain {
 			)
 		);
 		$form->loadDataFrom($folder);
+		
+		if($this->currentPageID()){
+		    // Make sure this controller know current folder when AJAX 'fileexists' is fired.
+		    $uploadField->setConfig('urlFileExists', Controller::join_links($uploadField->link('fileexists'), '?ID=' . $this->currentPageID()));
+		}
 
 		$this->extend('updateEditForm', $form);
 


### PR DESCRIPTION
Enable UploadField overwriteWarning

```yaml
Upload:
  replaceFile: true
UploadField:
  defaultConfig:
    overwriteWarning: true
```

In assets admin, when you upload files with same name in non-root folder, it just replaces the file and there is no overwrite warning message.

This fix will let CMSFileAddController know the current folder when 'fileexists' AJAX request is called.