### PR TITLE
BUG Safely check for is_site_url before parsing a shortcode

### DIFF
--- a/code/Model/SiteTreeLinkTracking_Parser.php
+++ b/code/Model/SiteTreeLinkTracking_Parser.php
@@ -1,6 +1,7 @@
 <?php
 namespace SilverStripe\CMS\Model;
 
+use DOMElement;
 use SilverStripe\Control\Director;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\View\Parsers\HTMLValue;
@@ -33,12 +34,16 @@ class SiteTreeLinkTracking_Parser
             return $results;
         }
 
+        /** @var DOMElement $link */
         foreach ($links as $link) {
             if (!$link->hasAttribute('href')) {
                 continue;
             }
 
-            $href = Director::makeRelative($link->getAttribute('href'));
+            $href = $link->getAttribute('href');
+            if (Director::is_site_url($href)) {
+                $href = Director::makeRelative($href);
+            }
 
             // Definitely broken links.
             if ($href == '' || $href[0] == '/') {

--- a/tests/php/Model/SiteTreeLinkTrackingTest.php
+++ b/tests/php/Model/SiteTreeLinkTrackingTest.php
@@ -4,12 +4,18 @@ namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\CMS\Model\SiteTreeLinkTracking_Parser;
 use SilverStripe\Assets\File;
+use SilverStripe\Control\Director;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\View\Parsers\HTMLValue;
 use Page;
 
 class SiteTreeLinkTrackingTest extends SapphireTest
 {
+    protected function setUp()
+    {
+        parent::setUp();
+        Director::config()->set('alternate_base_url', 'http://www.mysite.com/');
+    }
 
     protected function isBroken($content)
     {
@@ -25,12 +31,24 @@ class SiteTreeLinkTrackingTest extends SapphireTest
 
     public function testParser()
     {
+        // Shortcodes
         $this->assertTrue($this->isBroken('<a href="[sitetree_link,id=123]">link</a>'));
         $this->assertTrue($this->isBroken('<a href="[sitetree_link,id=123]#no-such-anchor">link</a>'));
         $this->assertTrue($this->isBroken('<a href="[file_link,id=123]">link</a>'));
+
+        // Relative urls
         $this->assertTrue($this->isBroken('<a href="">link</a>'));
         $this->assertTrue($this->isBroken('<a href="/">link</a>'));
 
+        // Non-shortcodes, assume non-broken without due reason
+        $this->assertFalse($this->isBroken('<a href="/some-page">link</a>'));
+        $this->assertFalse($this->isBroken('<a href="some-page">link</a>'));
+
+        // Absolute urls
+        $this->assertFalse($this->isBroken('<a href="http://www.mysite.com/some-page">link</a>'));
+        $this->assertFalse($this->isBroken('<a href="http://www.google.com/some-page">link</a>'));
+
+        // Anchors
         $this->assertFalse($this->isBroken('<a name="anchor">anchor</a>'));
         $this->assertFalse($this->isBroken('<a id="anchor">anchor</a>'));
         $this->assertTrue($this->isBroken('<a href="##anchor">anchor</a>'));


### PR DESCRIPTION
Prevents calling Director::makeRelative() on links that don't belong to this site.

Required for https://github.com/silverstripe/silverstripe-framework/pull/7520

Parent issue https://github.com/silverstripe/silverstripe-framework/issues/7492