### PR TITLE
Make `CMSMain::getSiteTreeFor()` default to `null` nodeCount

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -53,6 +53,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\HiddenClass;
+use SilverStripe\ORM\Hierarchy;
 use SilverStripe\ORM\Hierarchy\MarkedSet;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\ValidationResult;
@@ -108,8 +109,6 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
     private static $session_namespace = self::class;
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
-
-    private static $default_node_count_threshold = 30;
 
     /**
      * Amount of results showing on a single page.
@@ -467,7 +466,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $filterFunction = null,
         $nodeCountThreshold = null
     ) {
-        $nodeCountThreshold = is_null($nodeCountThreshold) ? Config::inst()->get(get_class(), 'default_node_count_threshold') : $nodeCountThreshold;
+        $nodeCountThreshold = is_null($nodeCountThreshold) ? Config::inst()->get(Hierarchy::class, 'node_threshold_total') : $nodeCountThreshold;
         // Provide better defaults from filter
         $filter = $this->getSearchFilter();
         if ($filter) {

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -21,6 +21,7 @@ use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
@@ -107,6 +108,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
     private static $session_namespace = self::class;
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
+
+    private static $default_node_count_threshold = 30;
 
     /**
      * Amount of results showing on a single page.
@@ -464,6 +467,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $filterFunction = null,
         $nodeCountThreshold = null
     ) {
+        $nodeCountThreshold = is_null($nodeCountThreshold) ? Config::inst()->get(get_class(), 'default_node_count_threshold') : $nodeCountThreshold;
         // Provide better defaults from filter
         $filter = $this->getSearchFilter();
         if ($filter) {

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -462,7 +462,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $childrenMethod = null,
         $numChildrenMethod = null,
         $filterFunction = null,
-        $nodeCountThreshold = 30
+        $nodeCountThreshold = null
     ) {
         // Provide better defaults from filter
         $filter = $this->getSearchFilter();

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -466,7 +466,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $filterFunction = null,
         $nodeCountThreshold = null
     ) {
-        $nodeCountThreshold = is_null($nodeCountThreshold) ? Config::inst()->get(Hierarchy::class, 'node_threshold_total') : $nodeCountThreshold;
+        $nodeCountThreshold = is_null($nodeCountThreshold) ? Config::inst()->get($className, 'node_threshold_total') : $nodeCountThreshold;
         // Provide better defaults from filter
         $filter = $this->getSearchFilter();
         if ($filter) {


### PR DESCRIPTION
This speeds the AJAX request from 3.81s to 1.7s

Also should only return the top level pages otherwise its just assuming and thus wasting resources

This also allows it to be fully controlled via config whereas for the `/admin/pages/treeview` AJAX call it was defaulting to 30 as no parameter was passed