### PR TITLE
Issue-2034: Fix for Page icons using data urls

### DIFF
--- a/code/Controllers/LeftAndMainPageIconsExtension.php
+++ b/code/Controllers/LeftAndMainPageIconsExtension.php
@@ -29,22 +29,15 @@ class LeftAndMainPageIconsExtension extends Extension
     public function generatePageIconsCss()
     {
         $css = '';
-
         $classes = ClassInfo::subclassesFor(SiteTree::class);
         foreach ($classes as $class) {
-            $icon = Config::inst()->get($class, 'icon');
-            if (!$icon) {
-                continue;
-            }
-
-            $cssClass = Convert::raw2htmlid($class);
-            $selector = ".page-icon.class-$cssClass, li.class-$cssClass > a .jstree-pageicon";
             $iconURL = SiteTree::singleton($class)->getPageIconURL();
             if ($iconURL) {
-                $css .= "$selector { background: transparent url('$iconURL') 0 0 no-repeat; }\n";
+                $cssClass = Convert::raw2htmlid($class);
+                $selector = sprintf('.page-icon.class-%1$s, li.class-%1$s > a .jstree-pageicon', $cssClass);
+                $css .= sprintf('%s { background: transparent url(\'%s\') 0 0 no-repeat; }', $selector, $iconURL);
             }
         }
-
         return $css;
     }
 }

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2854,6 +2854,9 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         if (!$icon) {
             return null;
         }
+        if (strpos($icon, 'data:image/') !== false) {
+            return $icon;
+        }
 
         // Icon is relative resource
         $iconResource = ModuleResourceLoader::singleton()->resolveResource($icon);


### PR DESCRIPTION
Fixes #2034

Code was getting the icon twice, both in SiteTree & LeftAndMainPageIconsExtenstion.
Now just uses `SiteTree::getPageIconURL()`
Tweaked to use `sprintf` instead of double quotes