### PR TITLE
Update .travis.yml in line with framework .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: php
 
 dist: trusty
 
-sudo: false
+cache:
+  directories:
+    - $HOME/.composer/cache/files
 
 addons:
   apt:
     packages:
       - tidy
-
-addons:
   firefox: "31.0"
 
 env:
@@ -22,6 +22,7 @@ env:
     - SS_ENVIRONMENT_TYPE="dev"
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.6
       env: DB=MYSQL PHPUNIT_TEST=1 PHPCS_TEST=1


### PR DESCRIPTION
Might fix https://github.com/silverstripe/silverstripe-cms/issues/2036 by minimising differences between broken CMS build and working framework build.