### PR TITLE
ENHANCEMENT: Cache canCreate in CMSMain

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -8,3 +8,8 @@ SilverStripe\Core\Injector\Injector:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:
       namespace: "CMSMain_SiteTreeHints"
+  Psr\SimpleCache\CacheInterface.SiteTree_CreatableChildren:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "SiteTree_CreatableChildren"
+

--- a/_config/permissions.yml
+++ b/_config/permissions.yml
@@ -6,7 +6,6 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\Security\InheritedPermissions
     constructor:
       BaseClass: SilverStripe\CMS\Model\SiteTree
-      CacheService: '%$Psr\SimpleCache\CacheInterface.InheritedPermissions'
     properties:
       DefaultPermissions: '%$SilverStripe\SiteConfig\SiteConfigPagePermissions'
       GlobalEditPermissions:

--- a/_config/permissions.yml
+++ b/_config/permissions.yml
@@ -6,6 +6,7 @@ SilverStripe\Core\Injector\Injector:
     class: SilverStripe\Security\InheritedPermissions
     constructor:
       BaseClass: SilverStripe\CMS\Model\SiteTree
+      CacheService: '%$Psr\SimpleCache\CacheInterface.InheritedPermissions'
     properties:
       DefaultPermissions: '%$SilverStripe\SiteConfig\SiteConfigPagePermissions'
       GlobalEditPermissions:
@@ -15,3 +16,5 @@ SilverStripe\Core\Injector\Injector:
     properties:
       Services:
         - '%$SilverStripe\Security\PermissionChecker.sitetree'
+        - '%$SilverStripe\CMS\Controllers\CMSMain'
+        - '%$SilverStripe\CMS\Model\SiteTree'

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1017,7 +1017,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $cacheKey = $this->generateHintsCacheKey($memberID);
         $json = $cache->get($cacheKey);
 
-        if ($json) return $json;
+        if ($json) {
+            return $json;
+        }
 
         $canCreate = [];
         foreach ($classes as $class) {
@@ -1510,7 +1512,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $gridField = new GridField('Page', 'Pages', $list, $gridFieldConfig);
         $gridField->setAttribute('cms-loading-ignore-url-params', true);
         /** @var GridFieldDataColumns $columns */
-        $columns = $gridField->getConfig()->getComponentByType('SilverStripe\\Forms\\GridField\\GridFieldDataColumns');
+        $columns = $gridField->getConfig()->getComponentByType(GridFieldDataColumns::class);
 
         // Don't allow navigating into children nodes on filtered lists
         $fields = array(
@@ -1519,7 +1521,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
             'LastEdited' => _t('SilverStripe\\CMS\\Model\\SiteTree.LASTUPDATED', 'Last Updated'),
         );
         /** @var GridFieldSortableHeader $sortableHeader */
-        $sortableHeader = $gridField->getConfig()->getComponentByType('SilverStripe\\Forms\\GridField\\GridFieldSortableHeader');
+        $sortableHeader = $gridField->getConfig()->getComponentByType(GridFieldSortableHeader::class);
         $sortableHeader->setFieldSorting(array('getTreeTitle' => 'Title'));
         $gridField->getState()->ParentID = $parentID;
 
@@ -1663,13 +1665,13 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         if ($doPublish) {
             $record->publishRecursive();
             $message = _t(
-                'SilverStripe\\CMS\\Controllers\\CMSMain.PUBLISHED',
+                __CLASS__ . '.PUBLISHED',
                 "Published '{title}' successfully.",
                 ['title' => $record->Title]
             );
         } else {
             $message = _t(
-                'SilverStripe\\CMS\\Controllers\\CMSMain.SAVED',
+                __CLASS__ . '.SAVED',
                 "Saved '{title}' successfully.",
                 ['title' => $record->Title]
             );
@@ -1703,7 +1705,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         /** @var SiteTree $newItem */
         $newItem = Injector::inst()->create($className);
         $newItem->Title = _t(
-            'SilverStripe\\CMS\\Controllers\\CMSMain.NEWPAGE',
+            __CLASS__ . '.NEWPAGE',
             "New {pagetype}",
             'followed by a page type title',
             array('pagetype' => singleton($className)->i18n_singular_name())
@@ -1789,7 +1791,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $this->getResponse()->addHeader(
             'X-Status',
             rawurlencode(_t(
-                'SilverStripe\\CMS\\Controllers\\CMSMain.RESTORED',
+                __CLASS__ . '.RESTORED',
                 "Restored '{title}' successfully",
                 'Param {title} is a title',
                 array('title' => $record->Title)
@@ -1896,7 +1898,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         $this->getResponse()->addHeader(
             'X-Status',
-            rawurlencode(_t('SilverStripe\\CMS\\Controllers\\CMSMain.REMOVEDPAGE', "Removed '{title}' from the published site", array('title' => $record->Title)))
+            rawurlencode(_t(
+                __CLASS__ . '.REMOVEDPAGE',
+                "Removed '{title}' from the published site",
+                ['title' => $record->Title]
+            ))
         );
 
         return $this->getResponseNegotiator()->respond($this->getRequest());
@@ -2039,7 +2045,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
                     break;
                 }
             }
-            $response .= _t('SilverStripe\\CMS\\Controllers\\CMSMain.PUBPAGES', "Done: Published {count} pages", array('count' => $count));
+            $response .= _t(__CLASS__ . '.PUBPAGES', "Done: Published {count} pages", array('count' => $count));
         } else {
             $token = SecurityToken::inst();
             $fields = new FieldList();
@@ -2047,16 +2053,16 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
             $tokenField = $fields->first();
             $tokenHtml = ($tokenField) ? $tokenField->FieldHolder() : '';
             $publishAllDescription = _t(
-                'SilverStripe\\CMS\\Controllers\\CMSMain.PUBALLFUN2',
+                __CLASS__ . '.PUBALLFUN2',
                 'Pressing this button will do the equivalent of going to every page and pressing "publish".  '
                 . 'It\'s intended to be used after there have been massive edits of the content, such as when '
                 . 'the site was first built.'
             );
-            $response .= '<h1>' . _t('SilverStripe\\CMS\\Controllers\\CMSMain.PUBALLFUN', '"Publish All" functionality') . '</h1>
+            $response .= '<h1>' . _t(__CLASS__ . '.PUBALLFUN', '"Publish All" functionality') . '</h1>
 				<p>' . $publishAllDescription . '</p>
 				<form method="post" action="publishall">
 					<input type="submit" name="confirm" value="'
-                    . _t('SilverStripe\\CMS\\Controllers\\CMSMain.PUBALLCONFIRM', "Please publish every page in the site, copying content stage to live", 'Confirmation button') .'" />'
+                    . _t(__CLASS__ . '.PUBALLCONFIRM', "Please publish every page in the site, copying content stage to live", 'Confirmation button') .'" />'
                     . $tokenHtml .
                 '</form>';
         }
@@ -2089,7 +2095,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $this->getResponse()->addHeader(
             'X-Status',
             rawurlencode(_t(
-                'SilverStripe\\CMS\\Controllers\\CMSMain.RESTORED',
+                __CLASS__ . '.RESTORED',
                 "Restored '{title}' successfully",
                 array('title' => $restoredPage->Title)
             ))
@@ -2126,7 +2132,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
             $this->getResponse()->addHeader(
                 'X-Status',
                 rawurlencode(_t(
-                    'SilverStripe\\CMS\\Controllers\\CMSMain.DUPLICATED',
+                    __CLASS__ . '.DUPLICATED',
                     "Duplicated '{title}' successfully",
                     array('title' => $newPage->Title)
                 ))
@@ -2164,7 +2170,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
             $this->getResponse()->addHeader(
                 'X-Status',
                 rawurlencode(_t(
-                    'SilverStripe\\CMS\\Controllers\\CMSMain.DUPLICATEDWITHCHILDREN',
+                    __CLASS__ . '.DUPLICATEDWITHCHILDREN',
                     "Duplicated '{title}' and children successfully",
                     array('title' => $newPage->Title)
                 ))
@@ -2185,10 +2191,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $title = CMSPagesController::menu_title();
         return array(
             "CMS_ACCESS_CMSMain" => array(
-                'name' => _t('SilverStripe\\CMS\\Controllers\\CMSMain.ACCESS', "Access to '{title}' section", array('title' => $title)),
+                'name' => _t(__CLASS__ . '.ACCESS', "Access to '{title}' section", array('title' => $title)),
                 'category' => _t('SilverStripe\\Security\\Permission.CMS_ACCESS_CATEGORY', 'CMS Access'),
                 'help' => _t(
-                    'SilverStripe\\CMS\\Controllers\\CMSMain.ACCESS_HELP',
+                    __CLASS__ . '.ACCESS_HELP',
                     'Allow viewing of the section containing page tree and content. View and edit permissions can be handled through page specific dropdowns, as well as the separate "Content permissions".'
                 ),
                 'sort' => -99 // below "CMS_ACCESS_LeftAndMain", but above everything else
@@ -2208,9 +2214,15 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         return $rootTitle;
     }
 
+    /**
+     * Cache key for SiteTreeHints() method
+     *
+     * @param $memberID
+     * @return string
+     */
     protected function generateHintsCacheKey($memberID)
     {
-        return md5($memberID);
+        return md5($memberID . '_' . __CLASS__);
     }
 
     /**
@@ -2218,13 +2230,13 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
      */
     public static function flush()
     {
-        static::singleton()->clearCache();
+        CMSMain::singleton()->clearCache();
     }
 
     /**
      * Flush the hints cache for a specific member
      *
-     * @param null $memberIDs
+     * @param array $memberIDs
      */
     public function flushMemberCache($memberIDs = null)
     {
@@ -2232,12 +2244,12 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         if (!$memberIDs) {
             $cache->clear();
-        } else if (is_array($memberIDs)) {
-            foreach($memberIDs as $memberID) {
-                $key = $this->generateHintsCacheKey($memberID);
-                $cache->delete($key);
-            }
+            return;
         }
 
+        foreach ($memberIDs as $memberID) {
+            $key = $this->generateHintsCacheKey($memberID);
+            $cache->delete($key);
+        }
     }
 }

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CMS\Model;
 
 use Page;
+use Psr\SimpleCache\CacheInterface;
 use SilverStripe\CampaignAdmin\AddToCampaignHandler_FormAction;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
 use SilverStripe\CMS\Controllers\ContentController;
@@ -16,6 +17,7 @@ use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
+use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ModuleResource;
 use SilverStripe\Core\Manifest\ModuleResourceLoader;
@@ -30,7 +32,6 @@ use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
-use SilverStripe\Forms\ListboxField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\OptionsetField;
 use SilverStripe\Forms\Tab;
@@ -66,6 +67,7 @@ use SilverStripe\View\HTML;
 use SilverStripe\View\Parsers\ShortcodeParser;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\SSViewer;
+use SilverStripe\Core\Cache\MemberCacheFlusher;
 use Subsite;
 
 /**
@@ -100,7 +102,7 @@ use Subsite;
  * @mixin SiteTreeLinkTracking
  * @mixin InheritedPermissionsExtension
  */
-class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvider, CMSPreviewable, Resettable
+class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvider, CMSPreviewable, Resettable, Flushable, MemberCacheFlusher
 {
 
     /**
@@ -342,6 +344,18 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      * @var string
      */
     private static $base_description = 'Generic content page';
+
+    /**
+     * @var array
+     */
+    private static $dependencies = [
+        'creatableChildrenCache' => '%$' . CacheInterface::class . '.SiteTree_CreatableChildren'
+    ];
+
+    /**
+     * @var CacheInterface
+     */
+    protected $creatableChildrenCache;
 
     /**
      * Fetches the {@link SiteTree} object that maps to a link.
@@ -902,6 +916,25 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             return DataObject::get_by_id(self::class, $parentID);
         }
         return null;
+    }
+
+    /**
+     * @param CacheInterface $cache
+     * @return $this
+     */
+    public function setCreatableChildrenCache(CacheInterface $cache)
+    {
+        $this->creatableChildrenCache = $cache;
+
+        return $this;
+    }
+
+    /**
+     * @return CacheInterface $cache
+     */
+    public function getCreatableChildrenCache()
+    {
+        return $this->creatableChildrenCache;
     }
 
     /**
@@ -1506,6 +1539,24 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     {
         parent::flushCache($persistent);
         $this->_cache_statusFlags = null;
+    }
+
+    /**
+     * Flushes the member specific cache for creatable children
+     * @param null $memberIDs
+     */
+    public function flushMemberCache($memberIDs = null)
+    {
+        $cache = static::singleton()->getCreatableChildrenCache();
+
+        if ($memberIDs) {
+            $cache->clear();
+        } else if (is_array($memberIDs)) {
+            foreach ($memberIDs as $memberID) {
+                $key = $this->generateChildrenCacheKey($memberID);
+                $cache->delete($key);
+            }
+        }
     }
 
     public function validate()
@@ -2529,6 +2580,32 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     }
 
     /**
+     * Gets a list of the page types that can be created under this specific page
+     *
+     * @return array
+     */
+    public function creatableChildren()
+    {
+        // Build the list of candidate children
+        $cache = static::singleton()->getCreatableChildrenCache();
+        $cacheKey = $this->generateChildrenCacheKey(Security::getCurrentUser() ? Security::getCurrentUser()->ID : 0);
+        $children = $cache->get($cacheKey, []);
+        if (!$children || !isset($children[$this->ID])) {
+            $children[$this->ID] = [];
+            $candidates = static::page_type_classes();
+            foreach ($candidates as $childClass) {
+                $child = singleton($childClass);
+                if ($child->canCreate(null, ['Parent' => $this])) {
+                    $children[$this->ID][$childClass] = $child->i18n_singular_name();
+                }
+            }
+            $cache->set($cacheKey, $children);
+        }
+
+        return $children[$this->ID];
+    }
+
+    /**
      * Returns the class name of the default class for children of this page.
      *
      * @return string
@@ -2644,18 +2721,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     public function getTreeTitle()
     {
-        // Build the list of candidate children
-        $children = array();
-        $candidates = static::page_type_classes();
-        foreach ($this->allowedChildren() as $childClass) {
-            if (!in_array($childClass, $candidates)) {
-                continue;
-            }
-            $child = singleton($childClass);
-            if ($child->canCreate(null, array('Parent' => $this))) {
-                $children[$childClass] = $child->i18n_singular_name();
-            }
-        }
+        $children = $this->creatableChildren();
         $flags = $this->getStatusFlags();
         $treeTitle = sprintf(
             "<span class=\"jstree-pageicon page-icon class-%s\"></span><span class=\"item\" data-allowedchildren=\"%s\">%s</span>",
@@ -2957,6 +3023,15 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     }
 
     /**
+     * Clear the creatableChildren cache on flush
+     */
+    public static function flush()
+    {
+        Injector::inst()->get(CacheInterface::class . '.SiteTree_CreatableChildren')
+            ->clear();
+    }
+
+    /**
      * Update dependant pages
      */
     protected function updateDependentPages()
@@ -2972,5 +3047,10 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                 $page->write();
             }
         }
+    }
+
+    protected function generateChildrenCacheKey($memberID)
+    {
+        return md5($memberID . '_' . __CLASS__);
     }
 }

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1543,19 +1543,21 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
     /**
      * Flushes the member specific cache for creatable children
-     * @param null $memberIDs
+     *
+     * @param array $memberIDs
      */
     public function flushMemberCache($memberIDs = null)
     {
-        $cache = static::singleton()->getCreatableChildrenCache();
+        $cache = SiteTree::singleton()->getCreatableChildrenCache();
 
-        if ($memberIDs) {
+        if (!$memberIDs) {
             $cache->clear();
-        } else if (is_array($memberIDs)) {
-            foreach ($memberIDs as $memberID) {
-                $key = $this->generateChildrenCacheKey($memberID);
-                $cache->delete($key);
-            }
+            return;
+        }
+
+        foreach ($memberIDs as $memberID) {
+            $key = $this->generateChildrenCacheKey($memberID);
+            $cache->delete($key);
         }
     }
 
@@ -2587,7 +2589,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     public function creatableChildren()
     {
         // Build the list of candidate children
-        $cache = static::singleton()->getCreatableChildrenCache();
+        $cache = SiteTree::singleton()->getCreatableChildrenCache();
         $cacheKey = $this->generateChildrenCacheKey(Security::getCurrentUser() ? Security::getCurrentUser()->ID : 0);
         $children = $cache->get($cacheKey, []);
         if (!$children || !isset($children[$this->ID])) {
@@ -3049,6 +3051,12 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         }
     }
 
+    /**
+     * Cache key for creatableChildren() method
+     *
+     * @param int $memberID
+     * @return string
+     */
     protected function generateChildrenCacheKey($memberID)
     {
         return md5($memberID . '_' . __CLASS__);

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -315,10 +315,10 @@ class VirtualPage extends Page
                 new LiteralField(
                     'VirtualPageWarning',
                     '<div class="message notice">'
-                     . _t(
-                         'SilverStripe\\CMS\\Model\\SiteTree.VIRTUALPAGEWARNINGSETTINGS',
-                         'Please choose a linked page in the main content fields in order to publish'
-                     )
+                    . _t(
+                        'SilverStripe\\CMS\\Model\\SiteTree.VIRTUALPAGEWARNINGSETTINGS',
+                        'Please choose a linked page in the main content fields in order to publish'
+                    )
                     . '</div>'
                 ),
                 'ClassName'

--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -147,17 +147,6 @@ class CMSMainTest extends FunctionalTest
         $this->assertEquals(1, $dsCount, "Published page has no duplicate version records: it has " . $dsCount . " for version " . $latestID);
 
         $this->session()->clear('loggedInAs');
-
-        //$this->assertRegexp('/Done: Published 4 pages/', $response->getBody())
-
-        /*
-		$response = Director::test("admin/pages/publishitems", array(
-			'ID' => ''
-			'Title' => ''
-			'action_publish' => 'Save and publish',
-		), $session);
-		$this->assertRegexp('/Done: Published 4 pages/', $response->getBody())
-		*/
     }
 
     /**
@@ -581,6 +570,7 @@ class CMSMainTest extends FunctionalTest
     public function testSiteTreeHintsCache()
     {
         $cms = CMSMain::create();
+        /** @var Member $user */
         $user = $this->objFromFixture(Member::class, 'rootedituser');
         Security::setCurrentUser($user);
         $pageClass = array_values(SiteTree::page_type_classes())[0];
@@ -609,7 +599,6 @@ class CMSMainTest extends FunctionalTest
         $hints = $cms->SiteTreeHints();
         $this->assertNotNull($hints);
 
-
         // Mutating member record invalidates cache. Misses (2)
         $user->FirstName = 'changed';
         $user->write();
@@ -628,6 +617,5 @@ class CMSMainTest extends FunctionalTest
         Injector::inst()->registerService($mockPageMissesCache, $pageClass);
         $hints = $cms->SiteTreeHints();
         $this->assertNotNull($hints);
-
     }
 }

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -26,6 +26,7 @@ use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Parsers\Diff;
 use SilverStripe\View\Parsers\ShortcodeParser;
 use SilverStripe\View\Parsers\URLSegmentFilter;
+use SilverStripe\Core\Injector\Injector;
 use LogicException;
 
 class SiteTreeTest extends SapphireTest
@@ -1505,5 +1506,58 @@ class SiteTreeTest extends SapphireTest
     {
         $class = new SiteTreeTest_LegacyControllerName;
         $this->assertEquals(SiteTreeTest_LegacyControllerName_Controller::class, $class->getControllerName());
+    }
+
+    public function testTreeTitleCache()
+    {
+        $siteTree = SiteTree::create();
+        $user = $this->objFromFixture(Member::class, 'allsections');
+        Security::setCurrentUser($user);
+        $pageClass = array_values(SiteTree::page_type_classes())[0];
+
+        $mockPageMissesCache = $this->getMockBuilder($pageClass)
+            ->setMethods(['canCreate'])
+            ->getMock();
+        $mockPageMissesCache
+            ->expects($this->exactly(3))
+            ->method('canCreate');
+
+        $mockPageHitsCache = $this->getMockBuilder($pageClass)
+            ->setMethods(['canCreate'])
+            ->getMock();
+        $mockPageHitsCache
+            ->expects($this->never())
+            ->method('canCreate');
+
+        // Initially, cache misses (1)
+        Injector::inst()->registerService($mockPageMissesCache, $pageClass);
+        $title = $siteTree->getTreeTitle();
+        $this->assertNotNull($title);
+
+        // Now it hits
+        Injector::inst()->registerService($mockPageHitsCache, $pageClass);
+        $title = $siteTree->getTreeTitle();
+        $this->assertNotNull($title);
+
+
+        // Mutating member record invalidates cache. Misses (2)
+        $user->FirstName = 'changed';
+        $user->write();
+        Injector::inst()->registerService($mockPageMissesCache, $pageClass);
+        $title = $siteTree->getTreeTitle();
+        $this->assertNotNull($title);
+
+        // Now it hits again
+        Injector::inst()->registerService($mockPageHitsCache, $pageClass);
+        $title = $siteTree->getTreeTitle();
+        $this->assertNotNull($title);
+
+        // Different user. Misses. (3)
+        $user = $this->objFromFixture(Member::class, 'editor');
+        Security::setCurrentUser($user);
+        Injector::inst()->registerService($mockPageMissesCache, $pageClass);
+        $title = $siteTree->getTreeTitle();
+        $this->assertNotNull($title);
+
     }
 }

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -1558,6 +1558,5 @@ class SiteTreeTest extends SapphireTest
         Injector::inst()->registerService($mockPageMissesCache, $pageClass);
         $title = $siteTree->getTreeTitle();
         $this->assertNotNull($title);
-
     }
 }


### PR DESCRIPTION
Resolves https://github.com/silverstripe/silverstripe-cms/issues/1977

## Benchmarks

(-) CMSMain cache
(-) SiteTree cache
* 15.5s wall time
* 32.1MB memory
* 1.45s response time

(+) CMSMain cache
(-) SiteTree cache
* 15.3s wal
* 30.6MB
* 1.2s

(+) CMSMain cache
(+) SiteTree cache
* 7.5s
* 0.9s
* 31MB