### PR TITLE
API Update usage of Versioned::allVersions()

### DIFF
--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSPageHistoryController_versions.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSPageHistoryController_versions.ss
@@ -9,15 +9,15 @@
 	</thead>
 
 	<tbody>
-		<% loop $Versions %>
-		<tr id="page-$RecordID-version-$Version" class="$EvenOdd $PublishedClass<% if not $Published %><% if not $Active %> ui-helper-hidden<% end_if %><% end_if %><% if $Active %> active<% end_if %>" data-published="<% if $Published %>true<% else %>false<% end_if %>">
-			<td class="ui-helper-hidden"><input type="checkbox" name="Versions[]" id="cms-version-{$Version}" value="$Version"<% if $Active %> checked="checked"<% end_if %> /></td>
-			<% with $LastEdited %>
-				<td class="last-edited first-column" title="$Ago - $Nice">$Nice</td>
-			<% end_with %>
-			<td><% if $Author %>$Author.FirstName $Author.Surname.Initial<% else %><%t SilverStripe\\CMS\\Controllers\\CMSPageHistoryController.UNKNOWN 'Unknown' %><% end_if %></td>
-			<td class="last-column"><% if $Published %><% if $Publisher %>$Publisher.FirstName $Publisher.Surname.Initial<% else %><%t SilverStripe\\CMS\\Controllers\\CMSPageHistoryController.UNKNOWN 'Unknown' %><% end_if %><% else %><%t SilverStripe\\CMS\\Controllers\\CMSPageHistoryController.NOTPUBLISHED 'Not published' %><% end_if %></td>
-		</tr>
+		<% loop $VersionItems %>
+            <tr id="page-$RecordID-version-$Version" class="$EvenOdd <% if $WasPublished %>published<% else %>internal<% if not $Active %> ui-helper-hidden<% end_if %><% end_if %><% if $Active %> active<% end_if %>" data-published="<% if $WasPublished %>true<% else %>false<% end_if %>">
+                <td class="ui-helper-hidden"><input type="checkbox" name="Versions[]" id="cms-version-{$Version}" value="$Version"<% if $Active %> checked="checked"<% end_if %> /></td>
+                <% with $LastEdited %>
+                    <td class="last-edited first-column" title="$Ago - $Nice">$Nice</td>
+                <% end_with %>
+                <td><% if $Author %>$Author.FirstName $Author.Surname.Initial<% else %><%t SilverStripe\\CMS\\Controllers\\CMSPageHistoryController.UNKNOWN 'Unknown' %><% end_if %></td>
+                <td class="last-column"><% if $WasPublished %><% if $Publisher %>$Publisher.FirstName $Publisher.Surname.Initial<% else %><%t SilverStripe\\CMS\\Controllers\\CMSPageHistoryController.UNKNOWN 'Unknown' %><% end_if %><% else %><%t SilverStripe\\CMS\\Controllers\\CMSPageHistoryController.NOTPUBLISHED 'Not published' %><% end_if %></td>
+            </tr>
 		<% end_loop %>
 	</tbody>
 </table>


### PR DESCRIPTION
Related: https://github.com/silverstripe/silverstripe-framework/issues/7663 (implements 5.0 changes only)

Ensures CMS page history section works after https://github.com/silverstripe/silverstripe-versioned/pull/81 is merged.