### PR TITLE
Update page history javascript to fix big performance issue

### DIFF
--- a/javascript/CMSPageHistoryController.js
+++ b/javascript/CMSPageHistoryController.js
@@ -156,10 +156,16 @@
 			 * Function: _unselect()
 			 *
 			 * Unselects the row from the form selection.
+			 *
+			 * Using regular js to update the class rather than this.removeClass('active')
+			 * because the latter causes the browser to continuously call
+			 * element.compareDocumentPosition, causing the browser to hang for long
+			 * periods of time, especially on pages with lots of versions (e.g. 100+)
 			 */
 			_unselect: function() {
-				this.removeClass('active');
-				this.find(":input[type=checkbox]").attr("checked", false);
+				var tr = this.get(0);
+				tr.className = $.trim(tr.className.replace('active', ''));
+				this.find(":input[type=checkbox][checked]").attr("checked", false);
 			},
 			
 			/**

--- a/javascript/CMSPageHistoryController.js
+++ b/javascript/CMSPageHistoryController.js
@@ -164,7 +164,7 @@
 			 */
 			_unselect: function() {
 				var tr = this.get(0);
-				tr.className = $.trim(tr.className.replace('active', ''));
+				tr.className = $.trim(tr.className.replace(/\bactive\b/, ''));
 				this.find(":input[type=checkbox][checked]").attr("checked", false);
 			},
 			


### PR DESCRIPTION
On pages with a large amount of versions was getting extremely bad performance when clicking on the page history tab.  After the page loaded, javascript was causing the page to be unresponsive for a very long time, up to 120 seconds in chrome.

The issue boiled down to element.compareDocumentPosition being erroneously called a huge number of times by jQuery, like it was getting totally confused by itself

Have updated to use regular JS instead of jQuery for a .removeClass call, and make another jQuery selector more explicit