### PR TITLE
NEW Use Bootstrap alerts instead of legacy message classes for install.php warning

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1968,14 +1968,14 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         }
 
         if (file_exists(BASE_PATH . '/install.php')) {
-            $fields->addFieldToTab("Root.Main", new LiteralField(
-                "InstallWarningHeader",
-                "<p class=\"message warning\">" . _t(
-                    "SilverStripe\\CMS\\Model\\SiteTree.REMOVE_INSTALL_WARNING",
+            $fields->addFieldToTab('Root.Main', LiteralField::create(
+                'InstallWarningHeader',
+                '<div class="alert alert-warning">' . _t(
+                    __CLASS__ . '.REMOVE_INSTALL_WARNING',
                     "Warning: You should remove install.php from this SilverStripe install for security reasons."
                 )
-                . "</p>"
-            ), "Title");
+                . '</div>'
+            ), 'Title');
         }
 
         if (self::$runCMSFieldsExtensions) {


### PR DESCRIPTION
Related issue: https://github.com/silverstripe/silverstripe-admin/issues/201

cc @sachajudd

Before:

![image](https://user-images.githubusercontent.com/5170590/35709894-93ccde2e-0819-11e8-9f70-2c28c921f8f2.png)

After:

![image](https://user-images.githubusercontent.com/5170590/35709899-9c22a89c-0819-11e8-8a12-da594ebc46fb.png)
