### PR TITLE
NEW Add extension point to CMSMain::Breadcrumbs

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -992,6 +992,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
                 'Title' => CMSPagesController::menu_title(),
                 'Link' => ($unlinked) ? false : $this->LinkPages()
             )));
+
+            $this->extend('updateBreadcrumbs', $items);
+
             return $items;
         }
 
@@ -1008,6 +1011,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
                     : $ancestor->CMSEditLink()
             )));
         }
+
+        $this->extend('updateBreadcrumbs', $items);
 
         return $items;
     }

--- a/code/Controllers/CMSPagesController.php
+++ b/code/Controllers/CMSPagesController.php
@@ -4,6 +4,7 @@ namespace SilverStripe\CMS\Controllers;
 
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ArrayData;
 use stdClass;
@@ -33,33 +34,32 @@ class CMSPagesController extends CMSMain
 
     public function Breadcrumbs($unlinked = false)
     {
-        $items = parent::Breadcrumbs($unlinked);
+        $this->beforeExtending('updateBreadcrumbs', function (ArrayList $items) {
+            //special case for building the breadcrumbs when calling the listchildren Pages ListView action
+            if ($parentID = $this->getRequest()->getVar('ParentID')) {
+                $page = SiteTree::get()->byID($parentID);
 
-        //special case for building the breadcrumbs when calling the listchildren Pages ListView action
-        if ($parentID = $this->getRequest()->getVar('ParentID')) {
-            $page = SiteTree::get()->byID($parentID);
+                //build a reversed list of the parent tree
+                $pages = array();
+                while ($page) {
+                    array_unshift($pages, $page); //add to start of array so that array is in reverse order
+                    $page = $page->Parent;
+                }
 
-            //build a reversed list of the parent tree
-            $pages = array();
-            while ($page) {
-                array_unshift($pages, $page); //add to start of array so that array is in reverse order
-                $page = $page->Parent;
+                //turns the title and link of the breadcrumbs into template-friendly variables
+                $params = array_filter(array(
+                    'view' => $this->getRequest()->getVar('view'),
+                    'q' => $this->getRequest()->getVar('q')
+                ));
+                foreach ($pages as $page) {
+                    $params['ParentID'] = $page->ID;
+                    $item = new stdClass();
+                    $item->Title = $page->Title;
+                    $item->Link = Controller::join_links($this->Link(), '?' . http_build_query($params));
+                    $items->push(new ArrayData($item));
+                }
             }
-
-            //turns the title and link of the breadcrumbs into template-friendly variables
-            $params = array_filter(array(
-                'view' => $this->getRequest()->getVar('view'),
-                'q' => $this->getRequest()->getVar('q')
-            ));
-            foreach ($pages as $page) {
-                $params['ParentID'] = $page->ID;
-                $item = new stdClass();
-                $item->Title = $page->Title;
-                $item->Link = Controller::join_links($this->Link(), '?' . http_build_query($params));
-                $items->push(new ArrayData($item));
-            }
-        }
-
-        return $items;
+        });
+        return parent::Breadcrumbs($unlinked);
     }
 }


### PR DESCRIPTION
Part of silverstripe/silverstripe-admin#439

Allows, for example, user code to push a badge in the "Extra" attribute for the last breadcrumbs link.