### PR TITLE
add controller_name config var to SiteTree for easier override

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -185,6 +185,15 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     private static $hide_ancestor = null;
 
+    /**
+     * You can define the class of the controller that maps to your SiteTree object here if
+     * you don't want to rely on the magic of appending Controller to the Classname
+     *
+     * @config
+     * @var string
+     */
+    private static $controller_name = null;
+
     private static $db = array(
         "URLSegment" => "Varchar(255)",
         "Title" => "Varchar(255)",
@@ -2763,11 +2772,16 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
     /**
      * Find the controller name by our convention of {$ModelClass}Controller
+     * Can be overriden by config variable
      *
      * @return string
      */
     public function getControllerName()
     {
+        if ($controller = Config::inst()->get(static::class, 'controller_name')) {
+            return $controller;
+        }
+
         //default controller for SiteTree objects
         $controller = ContentController::class;
 

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -1505,6 +1505,16 @@ class SiteTreeTest extends SapphireTest
     }
 
     /**
+     * Test that the controller name for a SiteTree instance can be gathered when set directly via config var
+     */
+    public function testGetControllerNameFromConfig()
+    {
+        Config::inst()->update(Page::class, 'controller_name', 'This\\Is\\A\\New\\Controller');
+        $class = new Page;
+        $this->assertSame('This\\Is\\A\\New\\Controller', $class->getControllerName());
+    }
+
+    /**
      * Test that underscored class names (legacy) are still supported (deprecation notice is issued though).
      */
     public function testGetControllerNameWithUnderscoresIsSupported()


### PR DESCRIPTION
Currently you can do this by overriding the `getControllerName()` method but this feels more idiomatic. Means that you can more easily do things like put your controllers in a `MySite\Control` namespace and have your pages in `Mysite\Model`. Additionally saves having to do the while loop if you don't have to - could be an aim to have this as required by 5.0 to reduce unnecessary cycles (and ✨ magic ✨ ).