### PR TITLE
FIX: Remove SearchForm results() function from allowed_actions

### DIFF
--- a/code/search/ContentControllerSearchExtension.php
+++ b/code/search/ContentControllerSearchExtension.php
@@ -8,7 +8,6 @@
 class ContentControllerSearchExtension extends Extension {
 	private static $allowed_actions = array(
 		'SearchForm',
-		'results',
 	);
 
 	/**


### PR DESCRIPTION
Relates to https://github.com/silverstripe/silverstripe-cms/issues/2125