### PR TITLE
FIX Correct SilverStripeNavigator correctly in templates

### DIFF
--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -351,7 +351,7 @@ class ContentController extends Controller
             }
             $viewPageIn = _t('SilverStripe\\CMS\\Controllers\\ContentController.VIEWPAGEIN', 'View Page in:');
 
-            return <<<HTML
+            $navigator = <<<HTML
 				<div id="SilverStripeNavigator">
 					<div class="holder">
 					<div id="logInStatus">
@@ -366,6 +366,7 @@ class ContentController extends Controller
 				</div>
 					$message
 HTML;
+            return DBField::create_field('HTMLFragment', $navigator);
 
         // On live sites we should still see the archived message
         } else {
@@ -374,9 +375,9 @@ HTML;
                 /** @var DBDatetime $dateObj */
                 $dateObj = DBField::create_field('Datetime', $date);
                 // $dateObj->setVal($date);
-                return "<div id=\"SilverStripeNavigatorMessage\">" .
+                return DBField::create_field('HTMLFragment', "<div id=\"SilverStripeNavigatorMessage\">" .
                     _t('SilverStripe\\CMS\\Controllers\\ContentController.ARCHIVEDSITEFROM', 'Archived site from') .
-                    "<br>" . $dateObj->Nice() . "</div>";
+                    "<br>" . $dateObj->Nice() . "</div>");
             }
         }
         return null;


### PR DESCRIPTION
Fix #2130

`SilverStripeNavigator` needs to be cast as html otherwise it renders as escaped html