### PR TITLE
Adjust `ContentController::deleteinstallfiles()` to use PUBLIC_PATH.

### DIFF
--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -512,24 +512,22 @@ HTML;
         $title = new DBVarchar("Title");
         $content = new DBHTMLText('Content');
 
-        // We can't delete index.php as it might be necessary for URL routing without mod_rewrite.
-        // There's no safe way to detect usage of mod_rewrite across webservers,
-        // so we have to assume the file is required.
-        $installfiles = [
+        // As of SS4, index.php is required and should never be deleted.
+        $installfiles = array(
             'install.php',
-            'config-form.css',
-            'config-form.html',
-            'index.html',
-        ];
+            'install-frameworkmissing.html',
+            'index.html'
+        );
 
         $unsuccessful = new ArrayList();
         foreach ($installfiles as $installfile) {
-            if (file_exists(BASE_PATH . '/' . $installfile)) {
-                @unlink(BASE_PATH . '/' . $installfile);
+            $installfilepath = PUBLIC_PATH . '/' . $installfile;
+            if (file_exists($installfilepath)) {
+                @unlink($installfilepath);
             }
 
-            if (file_exists(BASE_PATH . '/' . $installfile)) {
-                $unsuccessful->push(new ArrayData(['File' => $installfile]));
+            if (file_exists($installfilepath)) {
+                $unsuccessful->push(new ArrayData(array('File' => $installfile)));
             }
         }
 


### PR DESCRIPTION
`deleteinstallfiles` doesn't currently work because it expect the install files to be in the root.

I've also removes some old SS2.4 install legacy files from the list of files to check and added `install-frameworkmissing.html`

# Parent issue
* #2166 