### PR TITLE
BUG Fix CMS components failing to register on other CMS sections

### DIFF
--- a/_config/scripts.yml
+++ b/_config/scripts.yml
@@ -1,0 +1,9 @@
+---
+Name: cmsscripts
+---
+SilverStripe\Admin\LeftAndMain:
+  extra_requirements_javascript:
+    - 'silverstripe/cms: client/dist/js/bundle.js'
+    - 'silverstripe/cms: client/dist/js/SilverStripeNavigator.js'
+  extra_requirements_css:
+    - 'silverstripe/cms: client/dist/styles/bundle.css'


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-framework/issues/7996

Alternative solution to moving CMS components to admin module (https://github.com/silverstripe/silverstripe-cms/pull/2176)