### PR TITLE
FIX Remove blind reliance on current versioning stage being valid

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2247,9 +2247,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 		);
 
 		// "readonly"/viewing version that isn't the current version of the record
-		$stageOrLiveRecord = Versioned::get_one_by_stage($this->class, Versioned::current_stage(), array(
-			'"SiteTree"."ID"' => $this->ID
-		));
+        $stageOrLiveRecord = SiteTree::get()->byID($this->ID);
 		if($stageOrLiveRecord && $stageOrLiveRecord->Version != $this->Version) {
 			$moreOptions->push(FormAction::create('email', _t('CMSMain.EMAIL', 'Email')));
 			$moreOptions->push(FormAction::create('rollback', _t('CMSMain.ROLLBACK', 'Roll back to this version')));


### PR DESCRIPTION
Related to silverstripe/silverstripe-framework#8160 .

The PR corrects SiteTree where it attempts to fetch the site tree record from the current stage using `get_one_by_stage`. In the case of tests the current stage is often null and `get_one_by_stage` expects a valid stage. Getting the site tree record directly will fetch for the appropriate stage.