### PR TITLE
[Fix] CMSMain::save - class change & publish perms

### DIFF
--- a/code/controllers/CMSMain.php
+++ b/code/controllers/CMSMain.php
@@ -963,7 +963,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 			if(!singleton($this->stat('tree_class'))->canCreate()) return Security::permissionFailure($this);
 			$record = $this->getNewItem($id, false);
 		}
-
+		
 		// TODO Coupling to SiteTree
 		$record->HasBrokenLink = 0;
 		$record->HasBrokenFile = 0;
@@ -972,12 +972,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
 		// Update the class instance if necessary
 		if(isset($data['ClassName']) && $data['ClassName'] != $record->ClassName) {
-			$newClassName = $record->ClassName;
-			// The records originally saved attribute was overwritten by $form->saveInto($record) before.
-			// This is necessary for newClassInstance() to work as expected, and trigger change detection
-			// on the ClassName attribute
-			$record->setClassName($data['ClassName']);
-			// Replace $record with a new instance
+			// Replace $record with a new instance of the new class
+			$newClassName = $data['ClassName'];
 			$record = $record->newClassInstance($newClassName);
 		}
 


### PR DESCRIPTION
See issue:
https://github.com/silverstripe/silverstripe-cms/issues/2194

- Added missing check for publishing rights.
- Fixed class change as it was treating ClassName attrs in reverse order (going new->to->old, rather than old->to->new).