### PR TITLE
Update illegal extensions

### DIFF
--- a/tests/php/Search/SearchFormTest.php
+++ b/tests/php/Search/SearchFormTest.php
@@ -17,7 +17,9 @@ use SilverStripe\ORM\Search\FulltextSearchable;
 use SilverStripe\PostgreSQL\PostgreSQLDatabase;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
+use SilverStripe\Subsites\Extensions\SiteTreeSubsites;
 use SilverStripe\Versioned\Versioned;
+use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
 
 /**
  * @todo Fix unpublished pages check in testPublishedPagesMatchedByTitle()
@@ -30,9 +32,12 @@ class ZZZSearchFormTest extends FunctionalTest
 
     protected static $fixture_file = 'SearchFormTest.yml';
 
-    protected static $illegal_extensions = array(
-        SiteTree::class => array('SiteTreeSubsites', 'Translatable')
-    );
+    protected static $illegal_extensions = [
+        SiteTree::class => [
+            SiteTreeSubsites::class,
+            FluentSiteTreeExtension::class,
+        ],
+    ];
 
     /**
      * @var ContentController


### PR DESCRIPTION
Updates the class references in the illegal extensions section. Replaces Translatable with Fluent. Also updates the array syntax