### PR TITLE
NEW add SiteTree::updateAnchorsOnPage() for defining content anchors

### DIFF
--- a/code/Forms/AnchorSelectorField.php
+++ b/code/Forms/AnchorSelectorField.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\CMS\Forms;
 
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Forms\TextField;
 
@@ -38,34 +38,24 @@ class AnchorSelectorField extends TextField
     {
         $id = (int)$this->getRequest()->param('PageID');
         $anchors = $this->getAnchorsInPage($id);
+
         return json_encode($anchors);
     }
 
     /**
-     * Get anchors in the given page ID
+     * Get anchors in the given page ID.
      *
      * @param int $id
      * @return array
      */
     protected function getAnchorsInPage($id)
     {
-        // Check page is accessible
-        $page = Page::get()->byID($id);
+        $page = SiteTree::get()->byID($id);
+
         if (!$page || !$page->canView()) {
             return [];
         }
 
-        // Similar to the regex found in HtmlEditorField.js / getAnchors method.
-        $parseSuccess = preg_match_all(
-            "/\\s+(name|id)\\s*=\\s*([\"'])([^\\2\\s>]*?)\\2|\\s+(name|id)\\s*=\\s*([^\"']+)[\\s +>]/im",
-            $page->Content,
-            $matches
-        );
-        if (!$parseSuccess) {
-            return [];
-        }
-
-        // Cleanup results
-        return array_values(array_unique(array_filter(array_merge($matches[3], $matches[5]))));
+        return $page->getAnchorsOnPage();
     }
 }

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -3070,4 +3070,28 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         $this->extend('updateExcludedURLSegments', $excludes);
         return $excludes;
     }
+
+    /**
+     * @return array
+     */
+    public function getAnchorsOnPage()
+    {
+        $parseSuccess = preg_match_all(
+            "/\\s+(name|id)\\s*=\\s*([\"'])([^\\2\\s>]*?)\\2|\\s+(name|id)\\s*=\\s*([^\"']+)[\\s +>]/im",
+            $this->Content,
+            $matches
+        );
+
+        if (!$parseSuccess) {
+            return [];
+        }
+
+        $anchors = array_values(array_unique(array_filter(
+            array_merge($matches[3], $matches[5])
+        )));
+
+        $this->extend('updateAnchorsOnPage', $anchors);
+
+        return $anchors;
+    }
 }


### PR DESCRIPTION
The current AnchorSelectorField only takes into account a pages `Content` field. This causes issues with modules such as Elemental which don't use `$Content`.

Moves the anchor extraction functionality to `SiteTree::getAnchorsOnPage` function which then defines an extension hook to modify. 