### PR TITLE
FIX Separating ModelAsController catch-all route

### DIFF
--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -7,10 +7,16 @@ SilverStripe\Control\Director:
     '': 'SilverStripe\CMS\Controllers\RootURLController'
     'RemoveOrphanedPagesTask//$Action/$ID/$OtherID': 'SilverStripe\CMS\Tasks\RemoveOrphanedPagesTask'
     'SiteTreeMaintenanceTask//$Action/$ID/$OtherID': 'SilverStripe\CMS\Tasks\SiteTreeMaintenanceTask'
-    '$URLSegment//$Action/$ID/$OtherID': 'SilverStripe\CMS\Controllers\ModelAsController'
 ---
 Name: legacycmsroutes
 ---
 SilverStripe\Control\Director:
   rules:
     'admin/cms': '->admin/pages'
+---
+Name: modelascontrollercatchallroute
+After: '*'
+---
+SilverStripe\Control\Director:
+  rules:
+    '$URLSegment//$Action/$ID/$OtherID': 'SilverStripe\CMS\Controllers\ModelAsController'


### PR DESCRIPTION
Fixes #2225 

By separating the catch all route off on its own and ensuring it applies after everything, we restore the original functionality while still resolving the issue the original change was trying to achieve.