### PR TITLE
WIP: NEW Add Title, Last Edited and Last Editor as default columns in all CMS reports

### DIFF
--- a/code/Reports/AbstractCMSReport.php
+++ b/code/Reports/AbstractCMSReport.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SilverStripe\CMS\Reports;
+
+use SilverStripe\CMS\Controllers\CMSPageEditController;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Control\Controller;
+use SilverStripe\Reports\Report;
+use SilverStripe\Security\Member;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Provides some common functionality for all CMS module reports
+ */
+abstract class AbstractCMSReport extends Report
+{
+    /**
+     * By default we provide the page title with a clickable link, the last edited date and the member's name
+     * who last edited the page.
+     *
+     * @return array[]
+     */
+    public function columns()
+    {
+        // @todo remove coupling to global state
+        $isDraft = isset($_REQUEST['filters']['CheckSite']) && $_REQUEST['filters']['CheckSite'] === 'Draft';
+        if ($isDraft) {
+            $dateTitle = _t(__CLASS__ . '.ColumnDateLastModified', 'Date last modified');
+        } else {
+            $dateTitle = _t(__CLASS__ . '.ColumnDateLastPublished', 'Date last published');
+        }
+        $linkBase = CMSPageEditController::singleton()->Link('show');
+
+        return [
+            'Title' => [
+                'title' => _t(__CLASS__ . '.PageName', 'Page name'),
+                'formatting' => function ($value, $item) use ($linkBase) {
+                    return sprintf(
+                        '<a href="%s" title="%s">%s</a>',
+                        Controller::join_links($linkBase, $item->ID),
+                        _t(__CLASS__ . '.HoverTitleEditPage', 'Edit page'),
+                        $value
+                    );
+                },
+            ],
+            'LastEdited' => [
+                'title' => $dateTitle,
+                'casting' => 'DBDatetime->Full',
+            ],
+            'AuthorID' => [
+                'title' =>  _t(__CLASS__ . '.LastEditor', 'Last Editor'),
+                'formatting' => function ($value, SiteTree $item) {
+                    $latestVersion = Versioned::get_latest_version(SiteTree::class, $item->ID);
+                    if (!$latestVersion) {
+                        return '';
+                    }
+
+                    /** @var Member $member */
+                    $member = Member::get()->byID($latestVersion->AuthorID);
+                    if ($member) {
+                        return sprintf('%s %s', $member->FirstName, $member->Surname);
+                    }
+                    return '';
+                },
+            ],
+        ];
+    }
+}

--- a/code/Reports/BrokenFilesReport.php
+++ b/code/Reports/BrokenFilesReport.php
@@ -8,13 +8,11 @@ use SilverStripe\CMS\Model\VirtualPage;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Reports\Report;
 use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 
-class BrokenFilesReport extends Report
+class BrokenFilesReport extends AbstractCMSReport
 {
-
     public function title()
     {
         return _t(__CLASS__.'.BROKENFILES', "Pages with broken files");
@@ -40,16 +38,6 @@ class BrokenFilesReport extends Report
 
         $stage = isset($params['OnLive']) ? Versioned::LIVE : Versioned::DRAFT;
         return Versioned::get_by_stage(SiteTree::class, $stage, $classFilter);
-    }
-
-    public function columns()
-    {
-        return array(
-            "Title" => array(
-                "title" => "Title", // todo: use NestedTitle(2)
-                "link" => true,
-            ),
-        );
     }
 
     public function getParameterFields()

--- a/code/Reports/BrokenRedirectorPagesReport.php
+++ b/code/Reports/BrokenRedirectorPagesReport.php
@@ -9,11 +9,9 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
-use SilverStripe\Reports\Report;
 
-class BrokenRedirectorPagesReport extends Report
+class BrokenRedirectorPagesReport extends AbstractCMSReport
 {
-
     public function title()
     {
         return _t(__CLASS__.'.BROKENREDIRECTORPAGES', 'RedirectorPages pointing to deleted pages');
@@ -31,18 +29,8 @@ class BrokenRedirectorPagesReport extends Report
         $classFilter = array(
             "\"ClassName\" IN ($classParams) AND \"HasBrokenLink\" = 1" => $classes
         );
-        $stage = isset($params['OnLive']) ? 'Live' : 'Stage';
+        $stage = isset($params['OnLive']) ? Versioned::LIVE : Versioned::DRAFT;
         return Versioned::get_by_stage(SiteTree::class, $stage, $classFilter);
-    }
-
-    public function columns()
-    {
-        return array(
-            "Title" => array(
-                "title" => "Title", // todo: use NestedTitle(2)
-                "link" => true,
-            ),
-        );
     }
 
     public function getParameterFields()

--- a/code/Reports/BrokenVirtualPagesReport.php
+++ b/code/Reports/BrokenVirtualPagesReport.php
@@ -9,11 +9,9 @@ use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
-use SilverStripe\Reports\Report;
 
-class BrokenVirtualPagesReport extends Report
+class BrokenVirtualPagesReport extends AbstractCMSReport
 {
-
     public function title()
     {
         return _t(__CLASS__.'.BROKENVIRTUALPAGES', 'VirtualPages pointing to deleted pages');
@@ -33,16 +31,6 @@ class BrokenVirtualPagesReport extends Report
         );
         $stage = isset($params['OnLive']) ? 'Live' : 'Stage';
         return Versioned::get_by_stage(SiteTree::class, $stage, $classFilter);
-    }
-
-    public function columns()
-    {
-        return array(
-            "Title" => array(
-                "title" => "Title", // todo: use NestedTitle(2)
-                "link" => true,
-            ),
-        );
     }
 
     public function getParameterFields()

--- a/code/Reports/EmptyPagesReport.php
+++ b/code/Reports/EmptyPagesReport.php
@@ -5,11 +5,9 @@ namespace SilverStripe\CMS\Reports;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\ORM\DataList;
-use SilverStripe\Reports\Report;
 
-class EmptyPagesReport extends Report
+class EmptyPagesReport extends AbstractCMSReport
 {
-
     public function title()
     {
         return _t(__CLASS__.'.EMPTYPAGES', "Pages with no content");
@@ -37,15 +35,5 @@ class EmptyPagesReport extends Report
             ->exclude('ClassName', RedirectorPage::class)
             ->filter('Content', [null, '', '<p></p>', '<p>&nbsp;</p>'])
             ->sort('Title');
-    }
-
-    public function columns()
-    {
-        return array(
-            "Title" => array(
-                "title" => "Title", // todo: use NestedTitle(2)
-                "link" => true,
-            ),
-        );
     }
 }

--- a/code/Reports/RecentlyEditedReport.php
+++ b/code/Reports/RecentlyEditedReport.php
@@ -4,12 +4,9 @@ namespace SilverStripe\CMS\Reports;
 
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\ORM\FieldType\DBDatetime;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\Reports\Report;
 
-class RecentlyEditedReport extends Report
+class RecentlyEditedReport extends AbstractCMSReport
 {
-
     public function title()
     {
         return _t(__CLASS__.'.LAST2WEEKS', "Pages edited in the last 2 weeks");
@@ -31,15 +28,5 @@ class RecentlyEditedReport extends Report
         return SiteTree::get()
             ->filter('LastEdited:GreaterThan', date("Y-m-d H:i:s", $threshold))
             ->sort("\"SiteTree\".\"LastEdited\" DESC");
-    }
-
-    public function columns()
-    {
-        return array(
-            "Title" => array(
-                "title" => "Title", // todo: use NestedTitle(2)
-                "link" => true,
-            ),
-        );
     }
 }


### PR DESCRIPTION
Adds more default columns to all CMS reports.

![image](https://user-images.githubusercontent.com/5170590/44124249-58e6da62-a080-11e8-83fd-42f102b8d756.png)

![image](https://user-images.githubusercontent.com/5170590/44124257-626ec914-a080-11e8-9456-f9fcc2782fac.png)


The "Last Editor" column isn't able to be exported to CSV though, which should probably block this being merged. This is because there's no dot notation link available to get from the page to the Member who saved the latest version of it.

Resolves https://github.com/silverstripe/silverstripe-reports/issues/108