### PR TITLE
simplify code using !empty

### DIFF
--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -435,8 +435,8 @@ HTML;
     public function getViewer($action)
     {
         // Manually set templates should be dealt with by Controller::getViewer()
-        if (isset($this->templates[$action]) && $this->templates[$action]
-            || (isset($this->templates['index']) && $this->templates['index'])
+        if (!empty($this->templates[$action])
+            || !empty($this->templates['index'])
             || $this->template
         ) {
             return parent::getViewer($action);


### PR DESCRIPTION
Hello @robbieaverill, please check my assumption first...it's been a long time since I have last used SS (v3.2 was my last, if i remember correctly)
in the following lines 438:
```php
        if (isset($this->templates[$action]) && $this->templates[$action]
            || (isset($this->templates['index']) && $this->templates['index'])
            || $this->template
        ) {
            return parent::getViewer($action);
        }
```
It looks (I really mean it, "looks", i haven't checked the parent code) like the 1st two (same-line) conditions should be wrapped inside `()` while checking for a non-index action template like it's done in the following combined condition for the 'index' action .... if NOT just kill this PR at once. :-)

If the answer is YES then we could just use on function calls `!empty(...)` which has the same effect as 'isset(...) + truthy check' and basically the same exec time

kind regards, 
maks