### PR TITLE
FIX Allow CMS to be used without Report

### DIFF
--- a/code/Reports/BrokenFilesReport.php
+++ b/code/Reports/BrokenFilesReport.php
@@ -12,6 +12,10 @@ use SilverStripe\Reports\Report;
 use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 
+if (!class_exists(Report::class)) {
+    return;
+}
+
 class BrokenFilesReport extends Report
 {
 

--- a/code/Reports/BrokenFilesReport.php
+++ b/code/Reports/BrokenFilesReport.php
@@ -12,9 +12,11 @@ use SilverStripe\Reports\Report;
 use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 
+// phpcs:disable PSR1.Files.SideEffects
 if (!class_exists(Report::class)) {
     return;
 }
+// phpcs:enable
 
 class BrokenFilesReport extends Report
 {

--- a/code/Reports/BrokenLinksReport.php
+++ b/code/Reports/BrokenLinksReport.php
@@ -15,6 +15,10 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\Reports\Report;
 
+if (!class_exists(Report::class)) {
+    return;
+}
+
 /**
  * Content side-report listing pages with broken links
  */

--- a/code/Reports/BrokenLinksReport.php
+++ b/code/Reports/BrokenLinksReport.php
@@ -15,9 +15,11 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\Reports\Report;
 
+// phpcs:disable PSR1.Files.SideEffects
 if (!class_exists(Report::class)) {
     return;
 }
+// phpcs:enable
 
 /**
  * Content side-report listing pages with broken links

--- a/code/Reports/BrokenRedirectorPagesReport.php
+++ b/code/Reports/BrokenRedirectorPagesReport.php
@@ -11,9 +11,11 @@ use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Reports\Report;
 
+// phpcs:disable PSR1.Files.SideEffects
 if (!class_exists(Report::class)) {
     return;
 }
+// phpcs:enable
 
 class BrokenRedirectorPagesReport extends Report
 {

--- a/code/Reports/BrokenRedirectorPagesReport.php
+++ b/code/Reports/BrokenRedirectorPagesReport.php
@@ -11,6 +11,10 @@ use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Reports\Report;
 
+if (!class_exists(Report::class)) {
+    return;
+}
+
 class BrokenRedirectorPagesReport extends Report
 {
 

--- a/code/Reports/BrokenVirtualPagesReport.php
+++ b/code/Reports/BrokenVirtualPagesReport.php
@@ -11,6 +11,10 @@ use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Reports\Report;
 
+if (!class_exists(Report::class)) {
+    return;
+}
+
 class BrokenVirtualPagesReport extends Report
 {
 

--- a/code/Reports/BrokenVirtualPagesReport.php
+++ b/code/Reports/BrokenVirtualPagesReport.php
@@ -11,9 +11,11 @@ use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\Reports\Report;
 
+// phpcs:disable PSR1.Files.SideEffects
 if (!class_exists(Report::class)) {
     return;
 }
+// phpcs:enable
 
 class BrokenVirtualPagesReport extends Report
 {

--- a/code/Reports/EmptyPagesReport.php
+++ b/code/Reports/EmptyPagesReport.php
@@ -7,9 +7,11 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\ORM\DataList;
 use SilverStripe\Reports\Report;
 
+// phpcs:disable PSR1.Files.SideEffects
 if (!class_exists(Report::class)) {
     return;
 }
+// phpcs:enable
 
 class EmptyPagesReport extends Report
 {

--- a/code/Reports/EmptyPagesReport.php
+++ b/code/Reports/EmptyPagesReport.php
@@ -7,6 +7,10 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\ORM\DataList;
 use SilverStripe\Reports\Report;
 
+if (!class_exists(Report::class)) {
+    return;
+}
+
 class EmptyPagesReport extends Report
 {
 

--- a/code/Reports/RecentlyEditedReport.php
+++ b/code/Reports/RecentlyEditedReport.php
@@ -7,9 +7,11 @@ use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Reports\Report;
 
+// phpcs:disable PSR1.Files.SideEffects
 if (!class_exists(Report::class)) {
     return;
 }
+// phpcs:enable
 
 class RecentlyEditedReport extends Report
 {

--- a/code/Reports/RecentlyEditedReport.php
+++ b/code/Reports/RecentlyEditedReport.php
@@ -7,6 +7,10 @@ use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Reports\Report;
 
+if (!class_exists(Report::class)) {
+    return;
+}
+
 class RecentlyEditedReport extends Report
 {
 

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         "silverstripe/admin": "^1.1@dev",
         "silverstripe/campaign-admin": "^1.1@dev",
         "silverstripe/framework": "^4.1@dev",
-        "silverstripe/reports": "^4.1@dev",
         "silverstripe/siteconfig": "^4.1@dev",
         "silverstripe/versioned": "^1.1@dev",
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "silverstripe/reports": "^4.1@dev"
     },
     "extra": {
         "branch-alias": {
@@ -51,5 +51,8 @@
         }
     },
     "prefer-stable": true,
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "suggest": {
+        "silverstripe/reports": "Display CMS specific reports."
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
-        "silverstripe/reports": "^4.1@dev"
+        "phpunit/phpunit": "^5.7"
     },
     "extra": {
         "branch-alias": {

--- a/tests/php/Reports/CmsReportsTest.php
+++ b/tests/php/Reports/CmsReportsTest.php
@@ -17,9 +17,11 @@ use SilverStripe\Assets\File;
 use SilverStripe\Dev\SapphireTest;
 use Page;
 
+// phpcs:disable PSR1.Files.SideEffects
 if (!class_exists(Report::class)) {
     return;
 }
+// phpcs:enable
 
 class CmsReportsTest extends SapphireTest
 {

--- a/tests/php/Reports/CmsReportsTest.php
+++ b/tests/php/Reports/CmsReportsTest.php
@@ -17,6 +17,10 @@ use SilverStripe\Assets\File;
 use SilverStripe\Dev\SapphireTest;
 use Page;
 
+if (!class_exists(Report::class)) {
+    return;
+}
+
 class CmsReportsTest extends SapphireTest
 {
 


### PR DESCRIPTION
Fixing https://github.com/silverstripe/silverstripe-cms/issues/2241

I've remove reports from the main composer dependencies and made it a dev dependency instead. I've also added it to the "suggests". Do let me know if this is not the recommended way of doing this.
