### PR TITLE
MINOR: Add CMS specific hierarchy config

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -13,3 +13,9 @@ Name: cmsmodals
 SilverStripe\Admin\ModalController:
   extensions:
     - SilverStripe\CMS\Forms\InternalLinkModalExtension
+---
+Name: cmshierarchy
+---
+SilverStripe\ORM\Hierarchy\Hierarchy:
+  node_threshold_total: 50
+  node_threshold_leaf: 250


### PR DESCRIPTION
Copied directly from the class definition, but just to improve visibility of these settings which are highly impactful to CMS performance.