### PR TITLE
fixed deprecated create_function() in PHP 7.2

### DIFF
--- a/code/model/SiteTree.php
+++ b/code/model/SiteTree.php
@@ -2113,7 +2113,7 @@ class SiteTree extends DataObject implements PermissionProvider,i18nEntityProvid
 
 		// This filter ensures that the ParentID dropdown selection does not show this node,
 		// or its descendents, as this causes vanishing bugs
-		$parentIDField->setFilterFunction(create_function('$node', "return \$node->ID != {$this->ID};"));
+		$parentIDField->setFilterFunction(function($node) { return $node->ID != $this->ID; });
 		$parentTypeSelector->addExtraClass('parentTypeSelector');
 
 		$tabBehaviour->setTitle(_t('SiteTree.TABBEHAVIOUR', "Behavior"));


### PR DESCRIPTION
fixed for "PHP Deprecated:  Function create_function() is deprecated in \cms\code\model\SiteTree.php on line 2116" while using PHP 7.2