### PR TITLE
FIX: Use Hierarchy::prepopulate_numchildren_cache in tree-generation

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -54,6 +54,7 @@ use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\ORM\HiddenClass;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
 use SilverStripe\ORM\Hierarchy\MarkedSet;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\ORM\ValidationResult;
@@ -493,6 +494,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         // Pre-cache sitetree version numbers for querying efficiency
         Versioned::prepopulate_versionnumber_cache(SiteTree::class, Versioned::DRAFT);
         Versioned::prepopulate_versionnumber_cache(SiteTree::class, Versioned::LIVE);
+
+        if (method_exists(Hierarchy::class, 'prepopulate_numchildren_cache')) {
+            Hierarchy::prepopulate_numchildren_cache(SiteTree::class, Versioned::DRAFT);
+        }
+
         $html = $this->getSiteTreeFor($this->config()->get('tree_class'));
 
         $this->extend('updateSiteTreeAsUL', $html);

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -491,13 +491,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
      */
     public function SiteTreeAsUL()
     {
-        // Pre-cache sitetree version numbers for querying efficiency
-        Versioned::prepopulate_versionnumber_cache(SiteTree::class, Versioned::DRAFT);
-        Versioned::prepopulate_versionnumber_cache(SiteTree::class, Versioned::LIVE);
-
-        if (method_exists(Hierarchy::class, 'prepopulate_numchildren_cache')) {
-            Hierarchy::prepopulate_numchildren_cache(SiteTree::class, Versioned::DRAFT);
-        }
+        $filter = $this->getSearchFilter();
+        SiteTree::singleton()->prepopulateTreeDataCache(null, [
+            'childrenMethod' => $filter ? $filter->getChildrenMethod() : 'AllChildrenIncludingDeleted',
+            'numChildrenMethod' => $filter ? $filter->getNumChildrenMethod() : 'numChildren',
+        ]);
 
         $html = $this->getSiteTreeFor($this->config()->get('tree_class'));
 

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -491,13 +491,15 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
      */
     public function SiteTreeAsUL()
     {
+        $treeClass = $this->config()->get('tree_class');
         $filter = $this->getSearchFilter();
-        SiteTree::singleton()->prepopulateTreeDataCache(null, [
+
+        DataObject::singleton($treeClass)->prepopulateTreeDataCache(null, [
             'childrenMethod' => $filter ? $filter->getChildrenMethod() : 'AllChildrenIncludingDeleted',
             'numChildrenMethod' => $filter ? $filter->getNumChildrenMethod() : 'numChildren',
         ]);
 
-        $html = $this->getSiteTreeFor($this->config()->get('tree_class'));
+        $html = $this->getSiteTreeFor($treeClass);
 
         $this->extend('updateSiteTreeAsUL', $html);
 


### PR DESCRIPTION
Only relevant if https://github.com/silverstripe/silverstripe-framework/pull/8380 is avialable,
however coded defensively so it can be merged before that PR if needs 
be.

See https://github.com/silverstripe/silverstripe-framework/issues/8379

# Parent issue
* silverstripe/silverstripe-cms#2250