### PR TITLE
FIX Update field names in Behat tests for new search form namespacing

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -903,13 +903,20 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $params = $this->getRequest()->requestVar('q') ?: [];
         $context->setSearchParams($params);
 
-        $placeholder = _t('SilverStripe\\CMS\\Search\\SearchForm.FILTERLABELTEXT', 'Search') . ' "' . SiteTree::singleton()->i18n_plural_name() . '"';
+        $placeholder = _t('SilverStripe\\CMS\\Search\\SearchForm.FILTERLABELTEXT', 'Search') . ' "' .
+            SiteTree::singleton()->i18n_plural_name() . '"';
+
+        $searchParams = $context->getSearchParams();
+
+        $searchParams = array_combine(array_map(function($key) {
+            return 'Search__' . $key;
+        }, array_keys($searchParams)), $searchParams);
 
         $schema = [
             'formSchemaUrl' => $schemaUrl,
             'name' => 'Term',
             'placeholder' => $placeholder,
-            'filters' => $context->getSearchParams() ?: new \stdClass // stdClass maps to empty json object '{}'
+            'filters' => $searchParams ?: new \stdClass // stdClass maps to empty json object '{}'
         ];
 
         return Convert::raw2json($schema);
@@ -926,24 +933,24 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
     {
         // Create the fields
         $dateFrom = DateField::create(
-            'LastEditedFrom',
+            'Search__LastEditedFrom',
             _t('SilverStripe\\CMS\\Search\\SearchForm.FILTERDATEFROM', 'From')
         )->setLocale(Security::getCurrentUser()->Locale);
         $dateTo = DateField::create(
-            'LastEditedTo',
+            'Search__LastEditedTo',
             _t('SilverStripe\\CMS\\Search\\SearchForm.FILTERDATETO', 'To')
         )->setLocale(Security::getCurrentUser()->Locale);
         $filters = CMSSiteTreeFilter::get_all_filters();
         // Remove 'All pages' as we set that to empty/default value
         unset($filters[CMSSiteTreeFilter_Search::class]);
         $pageFilter = DropdownField::create(
-            'FilterClass',
+            'Search__FilterClass',
             _t('SilverStripe\\CMS\\Controllers\\CMSMain.PAGES', 'Page status'),
             $filters
         );
         $pageFilter->setEmptyString(_t('SilverStripe\\CMS\\Controllers\\CMSMain.PAGESALLOPT', 'All pages'));
         $pageClasses = DropdownField::create(
-            'ClassName',
+            'Search__ClassName',
             _t('SilverStripe\\CMS\\Controllers\\CMSMain.PAGETYPEOPT', 'Page type', 'Dropdown for limiting search to a page type'),
             $this->getPageTypes()
         );
@@ -953,7 +960,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $dateGroup = FieldGroup::create(
             _t('SilverStripe\\CMS\\Search\\SearchForm.PAGEFILTERDATEHEADING', 'Last edited'),
             [$dateFrom, $dateTo]
-        )->setName('LastEdited')
+        )->setName('Search__LastEdited')
         ->addExtraClass('fieldgroup--fill-width');
 
         // Create the Field list

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -908,7 +908,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         $searchParams = $context->getSearchParams();
 
-        $searchParams = array_combine(array_map(function($key) {
+        $searchParams = array_combine(array_map(function ($key) {
             return 'Search__' . $key;
         }, array_keys($searchParams)), $searchParams);
 

--- a/tests/behat/features/search-for-a-page.feature
+++ b/tests/behat/features/search-for-a-page.feature
@@ -14,7 +14,7 @@ Feature: Search for a page
 
   Scenario: I can search for a page by its title
     Given I fill in "Search" with "About Us"
-      And I press the "Enter" key in the "Term" field
+      And I press the "Enter" key in the "SearchBox__Term" field
     Then I should see "About Us" in the cms list
       But I should not see "Contact Us" in the cms list
 
@@ -22,7 +22,7 @@ Feature: Search for a page
     Given a "Virtual Page" "My Virtual Page"
     When I press the "Advanced" button
       And I select "Virtual Page" from "Page type"
-      And I press the "Enter" key in the "Term" field
+      And I press the "Enter" key in the "SearchBox__Term" field
     Then I should see "My Virtual Page" in the cms list
       But I should not see "Contact Us" in the cms list
 
@@ -50,7 +50,7 @@ Feature: Search for a page
     Given a "page" "Deleted Page"
       And the "page" "Deleted Page" is unpublished
       And the "page" "Deleted Page" is deleted
-    When I press the "Enter" key in the "Term" field
+    When I press the "Enter" key in the "SearchBox__Term" field
     Then I should not see "Deleted Page" in the cms list
     When I press the "Advanced" button
       And I select "All pages, including archived" from "Page status"
@@ -61,7 +61,7 @@ Feature: Search for a page
     Given a "page" "Deleted Page"
       And the "page" "Deleted Page" is unpublished
       And the "page" "Deleted Page" is deleted
-    When I press the "Enter" key in the "Term" field
+    When I press the "Enter" key in the "SearchBox__Term" field
     Then I should not see "Deleted Page" in the cms list
     When I press the "Advanced" button
       And I select "Archived pages" from "Page status"
@@ -72,7 +72,7 @@ Feature: Search for a page
   Scenario: I can include draft pages in my search
     Given a "page" "Draft Page"
       And the "page" "Draft Page" is not published
-    When I press the "Enter" key in the "Term" field
+    When I press the "Enter" key in the "SearchBox__Term" field
     Then I should see "Draft Page" in the cms list
     When I press the "Advanced" button
       And I select "Draft pages" from "Page status"
@@ -100,7 +100,7 @@ Feature: Search for a page
     Given a "page" "Live Page"
       And the "page" "Live Page" is published
       And the "page" "Live Page" is deleted
-    When I press the "Enter" key in the "Term" field
+    When I press the "Enter" key in the "SearchBox__Term" field
     Then I should not see "Live Page" in the cms list
     When I press the "Advanced" button
       And I select "Live but removed from draft" from "Page status"

--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -653,8 +653,8 @@ class CMSMainTest extends FunctionalTest
                 'name' => 'Term',
                 'placeholder' => 'Search "Pages"',
                 'filters' => [
-                    'Term' => 'test',
-                    'FilterClass' => 'SilverStripe\CMS\Controllers\CMSSiteTreeFilter_Search'
+                    'Search__Term' => 'test',
+                    'Search__FilterClass' => 'SilverStripe\CMS\Controllers\CMSSiteTreeFilter_Search'
                 ]
             ]),
             $searchSchema


### PR DESCRIPTION
Fixes the failing Behat tests in admin for when https://github.com/silverstripe/silverstripe-framework/pull/8414 and https://github.com/silverstripe/silverstripe-admin/pull/664 are merged.

The tests here won't pass until framework at least is merged

Issue: https://github.com/silverstripe/silverstripe-cms/issues/2251