### PR TITLE
MINOR Update CMS test to explicitetly register the CMSPageHistoryController

### DIFF
--- a/tests/php/Controllers/CMSPageHistoryControllerTest.php
+++ b/tests/php/Controllers/CMSPageHistoryControllerTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\CMS\Tests\Controllers;
 use Page;
 use SilverStripe\CMS\Controllers\CMSPageHistoryController;
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
@@ -25,6 +26,11 @@ class CMSPageHistoryControllerTest extends FunctionalTest
     public function setUp()
     {
         parent::setUp();
+
+        Injector::inst()->registerService(
+            new CMSPageHistoryController(),
+            CMSPageHistoryController::class
+        );
 
         $this->loginWithPermission('ADMIN');
 


### PR DESCRIPTION
Parent issues silverstripe/silverstripe-versioned-admin#67 and silverstripe/silverstripe-cms#2277

Once https://github.com/silverstripe/silverstripe-versioned-admin/pull/71 got merged in, the CMSPageHistoryController started failing because the new CMSPageHistoryViewerController was getting injected.