### PR TITLE
MINOR Speed up DependentPages by shifting existence check to table join

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1744,7 +1744,6 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             $joinClause = sprintf(
                 "\"%s\".\"ParentID\"=\"%s\".\"ID\"",
                 $siteTreelinkTable,
-                $linkTable,
                 DataObject::singleton($parentClass)->baseTable()
             );
 


### PR DESCRIPTION
This PR updates `SiteTree::BackLinkTracking` to use some convoluted inner joins to avoid having to do individual query on each result to check for its existence.

It also alter queries to add the `DependentLinkType` alias field in the select statement which seems to give us a slight performance improvement over looping over all the results and adding it manually.

# Parent issue
* https://github.com/silverstripe/silverstripe-versioned/issues/189