### PR TITLE
BUGFIX reverting to publish still shows draft changes

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -2081,6 +2081,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
             );
         } else {
             $record->doRevertToLive();
+            $record->publishRecursive();
             $message = _t(
                 __CLASS__ . '.ROLLEDBACKPUBv2',
                 "Rolled back to published version."


### PR DESCRIPTION
Fixed #2305 

The current version creates a new version of what is currently published. However, the version of the new draft doesn't match the version of what is published so the CMS things its unpublished.

This change publishes the new draft to ensure that the published/draft version is consistent throughout all systems (ie. CMS, changesets, campaigns etc.).