### PR TITLE
FIX CMSPageHistoryControllerTest now uses a stub controller to avoid URL conflicts with versioned-admin

### DIFF
--- a/tests/php/Controllers/CMSPageHistoryControllerTest.php
+++ b/tests/php/Controllers/CMSPageHistoryControllerTest.php
@@ -4,8 +4,8 @@ namespace SilverStripe\CMS\Tests\Controllers;
 
 use Page;
 use SilverStripe\CMS\Controllers\CMSPageHistoryController;
+use SilverStripe\CMS\Tests\Controllers\CMSPageHistoryControllerTest\HistoryController;
 use SilverStripe\Control\Controller;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Forms\FieldGroup;
@@ -24,7 +24,11 @@ class CMSPageHistoryControllerTest extends FunctionalTest
     protected $versionPublishCheck2;
     protected $page;
 
-    public function setUp()
+    protected static $extra_controllers = [
+        CMSPageHistoryControllerTest\HistoryController::class,
+    ];
+
+    protected function setUp()
     {
         parent::setUp();
 
@@ -32,9 +36,6 @@ class CMSPageHistoryControllerTest extends FunctionalTest
             new CMSPageHistoryController(),
             CMSPageHistoryController::class
         );
-
-        // Bump to avoid loading any customised controllers
-        Config::modify()->set(CMSPageHistoryController::class, 'url_priority', 50);
 
         $this->loginWithPermission('ADMIN');
 
@@ -107,7 +108,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
      */
     public function testVersionsForm()
     {
-        $this->get('admin/pages/history/show/'. $this->page->ID);
+        $this->get('admin/pages/legacyhistory/show/'. $this->page->ID . '?flush');
         $form = $this->cssParser()->getBySelector('#Form_VersionsForm');
 
         $this->assertEquals(1, count($form));
@@ -125,7 +126,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
 
     public function testVersionsFormTableContainsInformation()
     {
-        $this->get('admin/pages/history/show/'. $this->page->ID);
+        $this->get('admin/pages/legacyhistory/show/'. $this->page->ID);
         $form = $this->cssParser()->getBySelector('#Form_VersionsForm');
         $rows = $form[0]->xpath("fieldset/table/tbody/tr");
 
@@ -151,7 +152,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
 
     public function testVersionsFormSelectsUnpublishedCheckbox()
     {
-        $this->get('admin/pages/history/show/'. $this->page->ID);
+        $this->get('admin/pages/legacyhistory/show/'. $this->page->ID);
         $checkbox = $this->cssParser()->getBySelector('#Form_VersionsForm_ShowUnpublished');
 
         $this->assertThat($checkbox[0], $this->logicalNot($this->isNull()));
@@ -160,7 +161,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
         $this->assertThat($checked, $this->logicalNot($this->stringContains('checked')));
 
         // viewing an unpublished
-        $this->get('admin/pages/history/show/'.$this->page->ID .'/'.$this->versionUnpublishedCheck);
+        $this->get('admin/pages/legacyhistory/show/'.$this->page->ID .'/'.$this->versionUnpublishedCheck);
         $checkbox = $this->cssParser()->getBySelector('#Form_VersionsForm_ShowUnpublished');
 
         $this->assertThat($checkbox[0], $this->logicalNot($this->isNull()));

--- a/tests/php/Controllers/CMSPageHistoryControllerTest/HistoryController.php
+++ b/tests/php/Controllers/CMSPageHistoryControllerTest/HistoryController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Controllers\CMSPageHistoryControllerTest;
+
+use SilverStripe\CMS\Controllers\CMSPageHistoryController;
+use SilverStripe\Dev\TestOnly;
+
+/**
+ * Used to circumvent potential URL conflicts with the silverstripe/versioned-admin history viewer controller
+ * when running unit tests on the legacy CMSPageHistoryController.
+ */
+class HistoryController extends CMSPageHistoryController implements TestOnly
+{
+    private static $url_segment = 'pages/legacyhistory';
+}


### PR DESCRIPTION
Fixes the tests in the 4.3 branch. Ideally we could modify the injector config OR the url_priority config so that the CMS module's history controller would be loaded first, but this doesn't seem to work in functional tests. I've added a new stub controller with a different route to ensure it can be tested in isolation.