### PR TITLE
MINOR: concept for a "add CMS Fields" shorthand

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2051,7 +2051,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                 $tabName = _t(
                     __CLASS__ . '.EXRA_FIELDS',
                     "ExtraFields"
-                )
+                );
             }
             $fields->addFieldsToTab(
                 'Root.'.$tabName,

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2025,6 +2025,41 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         return $fields;
     }
 
+    /**
+     * Quick way to add some fields to the CMSFields
+     *
+     * @param array $fieldsAsArray - list of fields to include, may include has_one, has_many, etc... e.g. `BackgroundImage`
+     * @param string $tabName - name of the tab to which they are to be adde, e.g. `MoreFields`
+     * @param null|FieldList - the existing CMSFields (or other FieldList) - OPTIONAL 
+     *
+     * @return FieldList
+     */
+    public function addFieldsToTab(array $fieldsAsArray, $tabName = '', $fieldList = null)
+    {
+            $fieldsToAdd = $this->scaffoldFormFields(
+                [
+                    'tabbed' => false,
+                    'includeRelations' => true,
+                    'restrictFields' => $fieldsAsArray,
+                    'ajaxSafe' => true
+                ]
+            );
+            if($fieldList === null) {
+                $fieldList = $this->getCMSFields();   
+            }
+            if($tabName === '') {
+                $tabName = _t(
+                    __CLASS__ . '.EXRA_FIELDS',
+                    "ExtraFields"
+                )
+            }
+            $fields->addFieldsToTab(
+                'Root.'.$tabName,
+                $fieldsToAdd
+            );
+            
+            return $fieldList;
+    }
 
     /**
      * Returns fields related to configuration aspects on this record, e.g. access control. See {@link getCMSFields()}


### PR DESCRIPTION
It usually takes a fair amount of time to add fields to the CMS for a page as they are not scaffolded. Doing so via shorthand method as suggested will speed this up a fair bit.  What is more, by using the scaffolding, you are less likely to make mistakes, etc...