### PR TITLE
MINOR Do not assume SiteTree's table will always be call SiteTree.

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1854,8 +1854,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         // DataObject::fieldExists only checks the current class, not the hierarchy
         // This allows the CMS to set the correct sort value
         if ($newItem->castingHelper('Sort')) {
+            $table = DataObject::singleton(SiteTree::class)->baseTable();
             $maxSort = DB::prepared_query(
-                'SELECT MAX("Sort") FROM "SiteTree" WHERE "ParentID" = ?',
+                "SELECT MAX(\"Sort\") FROM \"$table\" WHERE \"ParentID\" = ?",
                 array($parentID)
             )->value();
             $newItem->Sort = (int)$maxSort + 1;
@@ -1911,8 +1912,10 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         }
 
         /** @var SiteTree $record */
+        $table = DataObject::singleton(SiteTree::class)->baseTable();
+        $liveTable = DataObject::singleton(SiteTree::class)->stageTable($table, Versioned::LIVE);
         $record = Versioned::get_one_by_stage(SiteTree::class, Versioned::LIVE, array(
-            '"SiteTree_Live"."ID"' => $id
+            "\"$liveTable\".\"ID\"" => $id
         ));
 
         // a user can restore a page without publication rights, as it just adds a new draft state

--- a/code/Controllers/CMSSiteTreeFilter_ChangedPages.php
+++ b/code/Controllers/CMSSiteTreeFilter_ChangedPages.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CMS\Controllers;
 
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -18,10 +19,12 @@ class CMSSiteTreeFilter_ChangedPages extends CMSSiteTreeFilter
 
     public function getFilteredPages()
     {
+        $table = DataObject::singleton(SiteTree::class)->baseTable();
+        $liveTable = DataObject::singleton(SiteTree::class)->stageTable($table, Versioned::LIVE);
         $pages = Versioned::get_by_stage(SiteTree::class, Versioned::DRAFT);
         $pages = $this->applyDefaultFilters($pages)
-            ->leftJoin('SiteTree_Live', '"SiteTree_Live"."ID" = "SiteTree"."ID"')
-            ->where('"SiteTree"."Version" <> "SiteTree_Live"."Version"');
+            ->leftJoin($liveTable, "\"$liveTable\".\"ID\" = \"$table\".\"ID\"")
+            ->where("\"$table\".\"Version\" <> \"$liveTable\".\"Version\"");
         return $pages;
     }
 }

--- a/code/Controllers/ModelAsController.php
+++ b/code/Controllers/ModelAsController.php
@@ -135,9 +135,10 @@ class ModelAsController extends Controller implements NestedController
         }
 
         // Select child page
-        $conditions = array('"SiteTree"."URLSegment"' => $URLSegment);
+        $tableName = DataObject::singleton(SiteTree::class)->baseTable();
+        $conditions = [sprintf('"%s"."URLSegment"', $tableName) => $URLSegment];
         if (SiteTree::config()->get('nested_urls')) {
-            $conditions[] = array('"SiteTree"."ParentID"' => 0);
+            $conditions[] = [sprintf('"%s"."ParentID"', $tableName) => 0];
         }
         /** @var SiteTree $sitetree */
         $sitetree = DataObject::get_one(SiteTree::class, $conditions);

--- a/code/Reports/RecentlyEditedReport.php
+++ b/code/Reports/RecentlyEditedReport.php
@@ -27,10 +27,11 @@ class RecentlyEditedReport extends Report
 
     public function sourceRecords($params = null)
     {
+        $tableName = DataObject::singleton(SiteTree::class)->baseTable();
         $threshold = strtotime('-14 days', DBDatetime::now()->getTimestamp());
         return SiteTree::get()
             ->filter('LastEdited:GreaterThan', date("Y-m-d H:i:s", $threshold))
-            ->sort("\"SiteTree\".\"LastEdited\" DESC");
+            ->sort("\"$tableName\".\"LastEdited\" DESC");
     }
 
     public function columns()

--- a/code/Tasks/MigrateSiteTreeLinkingTask.php
+++ b/code/Tasks/MigrateSiteTreeLinkingTask.php
@@ -5,6 +5,7 @@ namespace SilverStripe\CMS\Tasks;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\Dev\Debug;
+use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\Versioned\Versioned;
 
@@ -35,11 +36,13 @@ class MigrateSiteTreeLinkingTask extends BuildTask
         Versioned::withVersionedMode(function () use (&$pages) {
             Versioned::set_stage(Versioned::DRAFT);
 
+            $sitetreeTbl = DataObject::singleton(SiteTree::class)->baseTable();
+
             /** @var SiteTree[] $linkedPages */
             $linkedPages = SiteTree::get()
                 ->innerJoin(
                     'SiteTree_LinkTracking',
-                    '"SiteTree_LinkTracking"."SiteTreeID" = "SiteTree"."ID"'
+                    "\"SiteTree_LinkTracking\".\"SiteTreeID\" = \"$sitetreeTbl\".\"ID\""
                 );
             foreach ($linkedPages as $page) {
                 // Command page to update symlink tracking

--- a/code/Tasks/SiteTreeMaintenanceTask.php
+++ b/code/Tasks/SiteTreeMaintenanceTask.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\CMS\Tasks;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\DataObject;
@@ -14,8 +15,9 @@ class SiteTreeMaintenanceTask extends Controller
 
     public function makelinksunique()
     {
-        $badURLs = "'" . implode("', '", DB::query("SELECT URLSegment, count(*) FROM SiteTree GROUP BY URLSegment HAVING count(*) > 1")->column()) . "'";
-        $pages = DataObject::get("SilverStripe\\CMS\\Model\\SiteTree", "\"SiteTree\".\"URLSegment\" IN ($badURLs)");
+        $table = DataObject::singleton(SiteTree::class)->baseTable();
+        $badURLs = "'" . implode("', '", DB::query("SELECT \"URLSegment\", count(*) FROM \"$table\" GROUP BY \"URLSegment\" HAVING count(*) > 1")->column()) . "'";
+        $pages = DataObject::get(SiteTree::class, "\"$table\".\"URLSegment\" IN ($badURLs)");
 
         foreach ($pages as $page) {
             echo "<li>$page->Title: ";


### PR DESCRIPTION
We assume to assuming SiteTree's table name as a constant.

That precludes some mad scientist from renaming that table in their YML config which I think should be a supported use case. e.g.:
```yml
SilverStripe\CMS\Model\SiteTree:
  table_name: SomethingOtherThanSiteTree
```