### PR TITLE
MINOR Clean up CMSMain::CanOrganiseSitetree

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -756,7 +756,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         if (!SecurityToken::inst()->checkRequest($request)) {
             return $this->httpError(400);
         }
-        if (!Permission::check('SITETREE_REORGANISE') && !Permission::check('ADMIN')) {
+        if (!$this->CanOrganiseSitetree()) {
             return $this->httpError(
                 403,
                 _t(
@@ -862,10 +862,15 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
             ->setBody(json_encode($statusUpdates));
     }
 
+    /**
+     * Whatever the current member has the permission to reorganise SiteTree objects.
+     * @return bool
+     */
     public function CanOrganiseSitetree()
     {
-        return !Permission::check('SITETREE_REORGANISE') && !Permission::check('ADMIN') ? false : true;
+        return Permission::check('SITETREE_REORGANISE');
     }
+
 
     /**
      * @return boolean

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -863,7 +863,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
     }
 
     /**
-     * Whatever the current member has the permission to reorganise SiteTree objects.
+     * Whether the current member has the permission to reorganise SiteTree objects.
      * @return bool
      */
     public function CanOrganiseSitetree()

--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -660,4 +660,24 @@ class CMSMainTest extends FunctionalTest
             $searchSchema
         );
     }
+
+    public function testCanOrganiseSitetree()
+    {
+        $cms = CMSMain::create();
+
+        $this->assertFalse($cms->CanOrganiseSitetree());
+
+        $this->logInWithPermission('CMS_ACCESS_CMSMain');
+        $this->assertFalse($cms->CanOrganiseSitetree());
+
+        $this->logOut();
+        $this->logInWithPermission('SITETREE_REORGANISE');
+        $this->assertTrue($cms->CanOrganiseSitetree());
+
+        $this->logOut();
+        $this->logInWithPermission('ADMIN');
+        $this->assertTrue($cms->CanOrganiseSitetree());
+
+
+    }
 }

--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -677,7 +677,5 @@ class CMSMainTest extends FunctionalTest
         $this->logOut();
         $this->logInWithPermission('ADMIN');
         $this->assertTrue($cms->CanOrganiseSitetree());
-
-
     }
 }


### PR DESCRIPTION
This is a follow up from this PR. https://github.com/silverstripe/silverstripe-cms/pull/2033

Basically `CMSMain::CanOrganiseSitetree` is kind of coded in a silly way right now.

This makes it unsilly.