### PR TITLE
FIX Multibyte URL routing

### DIFF
--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -25,6 +25,7 @@ use SilverStripe\Security\Security;
 use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\ArrayData;
+use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\Requirements;
 use SilverStripe\View\SSViewer;
 use Translatable;
@@ -195,11 +196,16 @@ class ContentController extends Controller
             if (class_exists('Translatable')) {
                 Translatable::disable_locale_filter();
             }
+
+            $filter = URLSegmentFilter::create();
+
             // look for a page with this URLSegment
             $child = SiteTree::get()->filter([
                 'ParentID' => $this->ID,
-                'URLSegment' => rawurlencode($action),
+                // url encode unless it's multibyte (already pre-encoded in the database)
+                'URLSegment' => $filter->getAllowMultibyte() ? $action : rawurlencode($action),
             ])->first();
+
             if (class_exists('Translatable')) {
                 Translatable::enable_locale_filter();
             }

--- a/code/Controllers/ModelAsController.php
+++ b/code/Controllers/ModelAsController.php
@@ -16,6 +16,7 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\Debug;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
+use SilverStripe\View\Parsers\URLSegmentFilter;
 use Translatable;
 
 /**
@@ -127,8 +128,14 @@ class ModelAsController extends Controller implements NestedController
             Translatable::disable_locale_filter();
         }
 
+        // url encode unless it's multibyte (already pre-encoded in the database)
+        $filter = URLSegmentFilter::create();
+        if (!$filter->getAllowMultibyte()) {
+            $URLSegment = rawurlencode($URLSegment);
+        }
+
         // Select child page
-        $conditions = array('"SiteTree"."URLSegment"' => rawurlencode($URLSegment));
+        $conditions = array('"SiteTree"."URLSegment"' => $URLSegment);
         if (SiteTree::config()->get('nested_urls')) {
             $conditions[] = array('"SiteTree"."ParentID"' => 0);
         }

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1939,7 +1939,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         $helpText = (self::config()->get('nested_urls') && $this->numChildren())
             ? $this->fieldLabel('LinkChangeNote')
             : '';
-        if (!Config::inst()->get('SilverStripe\\View\\Parsers\\URLSegmentFilter', 'default_allow_multibyte')) {
+        if (!URLSegmentFilter::create()->getAllowMultibyte()) {
             $helpText .= _t('SilverStripe\\CMS\\Forms\\SiteTreeURLSegmentField.HelpChars', ' Special characters are automatically converted or removed.');
         }
         $urlsegment->setHelpText($helpText);


### PR DESCRIPTION
Was double url encoding (once in database value, then again in request)
Fixes https://github.com/silverstripe/silverstripe-framework/issues/8723