### PR TITLE
Enforce canCreate() in "add page" controller

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1186,11 +1186,18 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         foreach ($classes as $class) {
             $instance = SiteTree::singleton($class);
+
+            // skip if implements HiddenClass
             if ($instance instanceof HiddenClass) {
                 continue;
             }
 
-            // skip this type if it is restricted
+            // skip if access is restricted via custom permission checks
+            if (!$instance->canCreate()) {
+                continue;
+            }
+
+            // skip this type if access is restricted via config
             $needPermissions = $instance->config()->get('need_permission');
             if ($needPermissions && !$this->can($needPermissions)) {
                 continue;

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -484,7 +484,8 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     }
 
     /**
-     * Return a subclass map of SiteTree that shouldn't be hidden through {@link SiteTree::$hide_ancestor}
+     * Return a subclass map of SiteTree that shouldn't be hidden through {@link SiteTree::$hide_ancestor}.
+     * Does not enforce permissions.
      *
      * @return array
      */

--- a/tests/php/Controllers/CMSMainTest_AdminOnly.php
+++ b/tests/php/Controllers/CMSMainTest_AdminOnly.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Controllers;
+
+use SilverStripe\Dev\TestOnly;
+use Page;
+use SilverStripe\Security\Permission;
+use SilverStripe\Security\Security;
+
+class CMSMainTest_AdminOnly extends Page implements TestOnly
+{
+    private static $table_name = 'CMSMainTest_AdminOnly';
+
+    public function canCreate($member = null, $context = array())
+    {
+        if (!$member) {
+            $member = Security::getCurrentUser();
+        }
+
+        if(!$member || !Permission::checkMember($member, 'ADMIN')) {
+            return false;
+        }
+
+        return parent::canCreate($member, $context);
+    }
+}


### PR DESCRIPTION
It's already enforced when processing the form,
so there's no reason to list those page types in the first place.
This is a common way to make the CMS less cluttered,
e.g. by creating a DataExtension to remove VirtualPage
from the page types unless you're an admin.

Technically, this changes the CMSMain->PageTypes() API,
but in practice it's only used in CMSPageAddController.
It already respects need_permission, which is described as follows:
> List of permission codes a user can have to allow a user to create a page of this type.

Hence I'm considering the lack of canCreate() checks a bug in this context.