### PR TITLE
FIX Remove coupling from SiteTree to campaign admin module

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -5,7 +5,6 @@ namespace SilverStripe\CMS\Model;
 use Page;
 use Psr\SimpleCache\CacheInterface;
 use SilverStripe\Assets\Shortcodes\FileLinkTracking;
-use SilverStripe\CampaignAdmin\AddToCampaignHandler_FormAction;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
 use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\CMS\Controllers\ModelAsController;
@@ -33,7 +32,6 @@ use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\GridField\GridFieldLazyLoader;
-use SilverStripe\Forms\GridField\GridFieldSortableHeader;
 use SilverStripe\Forms\HTMLEditor\HTMLEditorField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\OptionsetField;
@@ -2277,15 +2275,6 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                 ))->renderWith($infoTemplate)
             )
         );
-
-        // Add to campaign option if not-archived and has publish permission
-        if (($isPublished || $isOnDraft) && $canPublish) {
-            $moreOptions->push(
-                AddToCampaignHandler_FormAction::create()
-                    ->removeExtraClass('btn-primary')
-                    ->addExtraClass('btn-secondary')
-            );
-        }
 
         // "readonly"/viewing version that isn't the current version of the record
         /** @var SiteTree $stageRecord */

--- a/tests/php/Model/SiteTreeActionsTest.php
+++ b/tests/php/Model/SiteTreeActionsTest.php
@@ -41,7 +41,6 @@ class SiteTreeActionsTest extends FunctionalTest
         $page = Page::get()->byID($page->ID);
         $actions = $page->getCMSActions();
 
-        $this->assertNull($actions->dataFieldByName('action_addtocampaign'));
         $this->assertNull($actions->dataFieldByName('action_save'));
         $this->assertNull($actions->dataFieldByName('action_publish'));
         $this->assertNull($actions->dataFieldByName('action_unpublish'));
@@ -96,7 +95,6 @@ class SiteTreeActionsTest extends FunctionalTest
 
         $actions = $page->getCMSActions();
 
-        $this->assertNotNull($actions->dataFieldByName('action_addtocampaign'));
         $this->assertNotNull($actions->dataFieldByName('action_save'));
         $this->assertNotNull($actions->dataFieldByName('action_publish'));
         $this->assertNotNull($actions->dataFieldByName('action_unpublish'));
@@ -124,8 +122,6 @@ class SiteTreeActionsTest extends FunctionalTest
 
         $actions = $page->getCMSActions();
 
-        // Theoretically allow deletions to be staged via add to campaign
-        $this->assertNotNull($actions->dataFieldByName('action_addtocampaign'));
         $this->assertNull($actions->dataFieldByName('action_save'));
         $this->assertNull($actions->dataFieldByName('action_publish'));
         $this->assertNull($actions->dataFieldByName('action_unpublish'));
@@ -152,7 +148,6 @@ class SiteTreeActionsTest extends FunctionalTest
         $page = Page::get()->byID($page->ID);
 
         $actions = $page->getCMSActions();
-        $this->assertNotNull($actions->dataFieldByName('action_addtocampaign'));
         $this->assertNotNull($actions->dataFieldByName('action_save'));
         $this->assertNotNull($actions->dataFieldByName('action_publish'));
         $this->assertNotNull($actions->dataFieldByName('action_unpublish'));
@@ -173,7 +168,6 @@ class SiteTreeActionsTest extends FunctionalTest
         $version = DB::query('SELECT "Version" FROM "SiteTree_Versions" WHERE "Content" = \'test page first version\'')->value();
         $old = Versioned::get_version('Page', $p->ID, $version);
         $actions = $old->getCMSActions();
-        $this->assertNull($actions->dataFieldByName('action_addtocampaign'));
         $this->assertNull($actions->dataFieldByName('action_save'));
         $this->assertNull($actions->dataFieldByName('action_publish'));
         $this->assertNull($actions->dataFieldByName('action_unpublish'));


### PR DESCRIPTION
Add to Campaign button is now in an extension in the campaign-admin module.

Requires https://github.com/silverstripe/silverstripe-campaign-admin/pull/134

Issue: https://github.com/silverstripe/silverstripe-campaign-admin/issues/19