### PR TITLE
FIX Use Bootstrap 4 alert for page type restriction message when adding a page

### DIFF
--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -89,7 +89,7 @@ class CMSPageAddController extends CMSPageEditController
             new LiteralField(
                 'RestrictedNote',
                 sprintf(
-                    '<p class="message notice message-restricted">%s</p>',
+                    '<p class="alert alert-info message-restricted">%s</p>',
                     _t(
                         'SilverStripe\\CMS\\Controllers\\CMSMain.AddPageRestriction',
                         'Note: Some page types are not allowed for this selection'


### PR DESCRIPTION
Bootstrap 4 alerts are the default in SilverStripe 4.4, this one is custom so was missed during the update