### PR TITLE
FIX Only add page font icon classes if there's no icon image defined

### DIFF
--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -43,15 +43,26 @@ class CMSPageAddController extends CMSPageEditController
     public function AddForm()
     {
         $pageTypes = array();
+        $defaultIcon = Config::inst()->get(SiteTree::class, 'icon_class');
+
         foreach ($this->PageTypes() as $type) {
+            $class = $type->getField('ClassName');
+            $icon = Config::inst()->get($class, 'icon_class') ?: $defaultIcon;
+
+            // If the icon is the SiteTree default and there's some specific icon being provided by `getPageIconURL`
+            // then we don't need to add the icon class. Otherwise the class take precedence.
+            if ($icon === $defaultIcon && !empty(singleton($class)->getPageIconURL())) {
+                $icon = '';
+            }
+
             $html = sprintf(
                 '<span class="page-icon %s class-%s"></span><span class="title">%s</span><span class="form__field-description">%s</span>',
-                Config::inst()->get($type->getField('ClassName'), 'icon_class'),
-                Convert::raw2htmlid($type->getField('ClassName')),
+                $icon,
+                Convert::raw2htmlid($class),
                 $type->getField('AddAction'),
                 $type->getField('Description')
             );
-            $pageTypes[$type->getField('ClassName')] = DBField::create_field('HTMLFragment', $html);
+            $pageTypes[$class] = DBField::create_field('HTMLFragment', $html);
         }
         // Ensure generic page type shows on top
         if (isset($pageTypes['Page'])) {

--- a/code/Controllers/LeftAndMainPageIconsExtension.php
+++ b/code/Controllers/LeftAndMainPageIconsExtension.php
@@ -31,6 +31,9 @@ class LeftAndMainPageIconsExtension extends Extension
         $css = '';
         $classes = ClassInfo::subclassesFor(SiteTree::class);
         foreach ($classes as $class) {
+            if (!empty(Config::inst()->get($class, 'icon_class', Config::UNINHERITED))) {
+                continue;
+            }
             $iconURL = SiteTree::singleton($class)->getPageIconURL();
             if ($iconURL) {
                 $cssClass = Convert::raw2htmlid($class);


### PR DESCRIPTION
Fixes silverstripe/silverstripe-admin#872