### PR TITLE
FIX Allow all types of content to be linked in dependent pages

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1812,8 +1812,8 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                 ->setFieldFormatting(array(
                     'Title' => function ($value, &$item) {
                         return sprintf(
-                            '<a href="admin/pages/edit/show/%d">%s</a>',
-                            (int)$item->ID,
+                            '<a href="%s">%s</a>',
+                            $item->CMSEditLink(),
                             Convert::raw2xml($item->Title)
                         );
                     },


### PR DESCRIPTION
This causes issues as content blocks can also be 'Dependent pages'. So it currently links to a page with the ID of the content block.
