### PR TITLE
FIX: Make test comparison less brittle in MigrateSiteTreeLinkingTaskTest

### DIFF
--- a/tests/php/Tasks/MigrateSiteTreeLinkingTaskTest.php
+++ b/tests/php/Tasks/MigrateSiteTreeLinkingTaskTest.php
@@ -80,10 +80,10 @@ class MigrateSiteTreeLinkingTaskTest extends SapphireTest
         $hash = $this->objFromFixture(SiteTree::class, 'hash_link');
 
         // Ensure all links are created
-        $this->assertListEquals([$about->toMap(), $staff->toMap()], $home->LinkTracking());
-        $this->assertListEquals([$home->toMap(), $staff->toMap()], $about->LinkTracking());
-        $this->assertListEquals([$home->toMap(), $about->toMap()], $staff->LinkTracking());
-        $this->assertListEquals([$home->toMap()], $action->LinkTracking());
-        $this->assertListEquals([$home->toMap(), $about->toMap()], $hash->LinkTracking());
+        $this->assertListEquals([['ID' => $about->ID], ['ID' => $staff->ID]], $home->LinkTracking());
+        $this->assertListEquals([['ID' => $home->ID], ['ID' => $staff->ID]], $about->LinkTracking());
+        $this->assertListEquals([['ID' => $home->ID], ['ID' => $about->ID]], $staff->LinkTracking());
+        $this->assertListEquals([['ID' => $home->ID]], $action->LinkTracking());
+        $this->assertListEquals([['ID' => $home->ID], ['ID' => $about->ID]], $hash->LinkTracking());
     }
 }


### PR DESCRIPTION
Comparing every single field is unnecessary and brittle, only the IDs
need to be compared.

Notably this tripped over a potential bug fix in
https://github.com/silverstripe/silverstripe-framework/pull/8591
but the change should be incorporated regardless.