### PR TITLE
NEW Add updateHintsCacheKey extension point to fix invalid caching

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -2272,7 +2272,11 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
      */
     protected function generateHintsCacheKey($memberID)
     {
-        return md5($memberID . '_' . __CLASS__);
+        $baseKey = $memberID . '_' . __CLASS__;
+
+        $this->extend('updateHintsCacheKey', $baseKey);
+
+        return md5($baseKey);
     }
 
     /**


### PR DESCRIPTION
If a module augments the allowed pagetypes based on external conditions, the Hints Cache Key will not cover these conditions and may cause incorrect output. An example of this is Subsites, which allows each Subsite to have a different set of allowed pagetypes.

Since this is technically new API, it'd normally require a new minor release, however this extension point is being introduced purely in pursuit of fixing a bug, so I'd like to get it in as a patch update for the last few minor releases.