### PR TITLE
FIX Virtual page notice now uses Bootstrap 4 alerts

### DIFF
--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -279,7 +279,7 @@ class VirtualPage extends Page
 
             $fields->addFieldToTab("Root.Main", new LiteralField(
                 'VirtualPageMessage',
-                '<div class="message notice">' . implode('. ', $msgs) . '.</div>'
+                '<div class="alert alert-info">' . implode('. ', $msgs) . '.</div>'
             ), 'CopyContentFromID');
         });
 


### PR DESCRIPTION
4.4.x-dev uses Bootstrap 4 alerts, so this is a "bug fix" =)

Before:
![image](https://user-images.githubusercontent.com/5170590/58678365-96914c00-83b3-11e9-8fe5-e6b560e92896.png)

After:
![image](https://user-images.githubusercontent.com/5170590/58678368-9d1fc380-83b3-11e9-9eff-7e8eb17e1c7e.png)
