### PR TITLE
FIX display recognisable names for dependent content with no title

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1559,7 +1559,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                 $this->URLSegment = "page-$this->ID";
             }
         }
-        
+
         // need to set the default values of a page e.g."Untitled [Page type]"
         if (empty($this->Title)) {
             $this->Title = _t(
@@ -1978,10 +1978,20 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                 ->setDisplayFields($dependentColumns)
                 ->setFieldFormatting(array(
                     'Title' => function ($value, &$item) {
+                        $title = $item->Title;
+                        $untitled = _t(
+                            __CLASS__ . '.UntitledDependentObject',
+                            'Untitled {instanceType}',
+                            ['instanceType' => $item->i18n_singular_name()]
+                        );
+                        $tag = $item->hasMethod('CMSEditLink') ? 'a' : 'span';
                         return sprintf(
-                            '<a href="admin/pages/edit/show/%d">%s</a>',
-                            (int)$item->ID,
-                            Convert::raw2xml($item->Title)
+                            '<%s%s class="dependent-content__edit-link %s">%s</%s>',
+                            $tag,
+                            $tag === 'a' ? sprintf(' href="%s"', $item->CMSEditLink()) : '',
+                            $title ? '' : 'dependent-content__edit-link--untitled',
+                            $title ? Convert::raw2xml($title) : $untitled,
+                            $tag
                         );
                     }
                 ));

--- a/tests/php/Model/SiteTreeBacklinksTest.yml
+++ b/tests/php/Model/SiteTreeBacklinksTest.yml
@@ -1,6 +1,5 @@
 Page:
   page1:
-    ID: 1
     Title: page1
     URLSegment: page1
 
@@ -11,7 +10,7 @@ Page:
   page3:
     Title: page3
     URLSegment: page3
-    Content: '<p><a href="[sitetree_link,id=1]">Testing page 1 link</a></p>'
+    Content: '<p><a href="[sitetree_link,id=$page1.ID]">Testing page 1 link</a></p>'
     LinkTracking: =>Page.page1
 
 

--- a/tests/php/Model/SiteTreeBacklinksTestContentObject.php
+++ b/tests/php/Model/SiteTreeBacklinksTestContentObject.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Model;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class SiteTreeBacklinksTestContentObject extends DataObject implements TestOnly
+{
+    private static $table_name = 'BacklinkContent';
+
+    private static $db = array(
+        'Title' => 'Text',
+        'Content' => 'HTMLText',
+    );
+
+    private static $singular_name = 'Backlink test content object';
+}


### PR DESCRIPTION
Content blocks and other DataObjects that contain HTMLText fields are
also used in the 'Dependent pages' report for each page in the CMS,
however these objects may have neither a Title field, nor a name to
describe them. Instead of showing an empty field in the Title column for
this table, we can instead show "Untitled " with the localised singular
name appended.

Resolves #2428