### PR TITLE
Changing to protected to match the rest of the changes

### DIFF
--- a/code/Model/RedirectorPage.php
+++ b/code/Model/RedirectorPage.php
@@ -136,7 +136,7 @@ class RedirectorPage extends Page
         }
     }
 
-    public function onBeforeWrite()
+    protected function onBeforeWrite()
     {
         parent::onBeforeWrite();
 


### PR DESCRIPTION
The `onBeforeWrite` and `onAfterWrite` methods have been changed to `protected` in `DataObject` and `SiteTree` but have been missed out from `RedirectorPage` so it errors out.