### PR TITLE
FEATURE add config var for namespace mapping page->control

### DIFF
--- a/tests/php/Controllers/SiteTreeTest_NamespaceMapTestController.php
+++ b/tests/php/Controllers/SiteTreeTest_NamespaceMapTestController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Controllers;
+
+use SilverStripe\CMS\Controllers\ContentController;
+use SilverStripe\Dev\TestOnly;
+
+class SiteTreeTest_NamespaceMapTestController extends ContentController implements TestOnly
+{
+
+}

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -9,6 +9,8 @@ use ReflectionMethod;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\VirtualPage;
+use SilverStripe\CMS\Tests\Controllers\SiteTreeTest_NamespaceMapTestController;
+use SilverStripe\CMS\Tests\Page\SiteTreeTest_NamespaceMapTest;
 use SilverStripe\Control\ContentNegotiator;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
@@ -1649,6 +1651,19 @@ class SiteTreeTest extends SapphireTest
         Config::inst()->update(Page::class, 'controller_name', 'This\\Is\\A\\New\\Controller');
         $class = new Page;
         $this->assertSame('This\\Is\\A\\New\\Controller', $class->getControllerName());
+    }
+
+    /**
+     * Test that the controller name for a Namespaced SiteTree instance can be gathered when set via namespace map
+     */
+    public function testGetControllerNameFromNamespaceMappingConfig()
+    {
+        Config::inst()->update(SiteTree::class, 'namespace_mapping', [
+            'SilverStripe\\CMS\\Tests\\Page' => 'SilverStripe\\CMS\\Tests\\Controllers',
+        ]);
+
+        $namespacedSiteTree = new SiteTreeTest_NamespaceMapTest();
+        $this->assertSame(SiteTreeTest_NamespaceMapTestController::class, $namespacedSiteTree->getControllerName());
     }
 
     /**

--- a/tests/php/Page/SiteTreeTest_NamespaceMapTest.php
+++ b/tests/php/Page/SiteTreeTest_NamespaceMapTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Page;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\TestOnly;
+
+class SiteTreeTest_NamespaceMapTest extends SiteTree implements TestOnly
+{
+    private static $table_name = 'SiteTreeTest_NamespaceMapTestNode';
+}


### PR DESCRIPTION
Creates a config variable where you can define a mapping between your Pages namespace and your Controllers namespace.

A common desired pattern is to keep things properly organised by having `App\Pages\MyPageType` and `App\Control\MyPageTypeController` - but this isn't currently caught by the ✨ "magic" ✨ . This allows for a global setting, rather than the one-off afforded by `$controller_name`.

Opens the door for adding a default map in 5 - maybe auto-substituting Page => Control, but that's another debate to have.