### PR TITLE
Negotiator amends: Make it possible to disable Preview links in the CMS

### DIFF
--- a/code/Controllers/SilverStripeNavigatorItem_LiveLink.php
+++ b/code/Controllers/SilverStripeNavigatorItem_LiveLink.php
@@ -58,9 +58,18 @@ class SilverStripeNavigatorItem_LiveLink extends SilverStripeNavigatorItem
             $record->hasExtension(Versioned::class)
             && $record->hasStages()
             && $this->getLivePage()
-            // Don't follow redirects in preview, they break the CMS editing form
-            && !($this->record instanceof RedirectorPage)
+            && $this->showLiveLink()
         );
+    }
+
+    public function showLiveLink()
+    {
+        try {
+            return $this->record->config()->get('show_live_link');
+        } catch (\BadMethodCallException $e) {
+            // Not using `config()` or similar
+            return false;
+        }
     }
 
     public function isActive()

--- a/code/Controllers/SilverStripeNavigatorItem_LiveLink.php
+++ b/code/Controllers/SilverStripeNavigatorItem_LiveLink.php
@@ -3,6 +3,7 @@ namespace SilverStripe\CMS\Controllers;
 
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
@@ -56,20 +57,18 @@ class SilverStripeNavigatorItem_LiveLink extends SilverStripeNavigatorItem
         $record = $this->record;
         return (
             $record->hasExtension(Versioned::class)
+            && $this->showLiveLink()
             && $record->hasStages()
             && $this->getLivePage()
-            && $this->showLiveLink()
         );
     }
 
+    /**
+     * @return bool
+     */
     public function showLiveLink()
     {
-        try {
-            return $this->record->config()->get('show_live_link');
-        } catch (\BadMethodCallException $e) {
-            // Not using `config()` or similar
-            return false;
-        }
+        return (bool)Config::inst()->get(get_class($this->record), 'show_live_link');
     }
 
     public function isActive()

--- a/code/Controllers/SilverStripeNavigatorItem_StageLink.php
+++ b/code/Controllers/SilverStripeNavigatorItem_StageLink.php
@@ -3,6 +3,7 @@ namespace SilverStripe\CMS\Controllers;
 
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\Control\Controller;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Convert;
 use SilverStripe\ORM\DataObject;
@@ -62,20 +63,18 @@ class SilverStripeNavigatorItem_StageLink extends SilverStripeNavigatorItem
         $record = $this->record;
         return (
             $record->hasExtension(Versioned::class)
+            && $this->showStageLink()
             && $record->hasStages()
             && $this->getDraftPage()
-            && $this->showStageLink()
         );
     }
 
+    /**
+     * @return bool
+     */
     public function showStageLink()
     {
-        try {
-            return $this->record->config()->get('show_stage_link');
-        } catch (\BadMethodCallException $e) {
-            // Not using `config()` or similar
-            return false;
-        }
+        return (bool)Config::inst()->get(get_class($this->record), 'show_stage_link');
     }
 
     public function isActive()

--- a/code/Controllers/SilverStripeNavigatorItem_StageLink.php
+++ b/code/Controllers/SilverStripeNavigatorItem_StageLink.php
@@ -64,9 +64,18 @@ class SilverStripeNavigatorItem_StageLink extends SilverStripeNavigatorItem
             $record->hasExtension(Versioned::class)
             && $record->hasStages()
             && $this->getDraftPage()
-            // Don't follow redirects in preview, they break the CMS editing form
-            && !($record instanceof RedirectorPage)
+            && $this->showStageLink()
         );
+    }
+
+    public function showStageLink()
+    {
+        try {
+            return $this->record->config()->get('show_stage_link');
+        } catch (\BadMethodCallException $e) {
+            // Not using `config()` or similar
+            return false;
+        }
     }
 
     public function isActive()

--- a/code/Model/RedirectorPage.php
+++ b/code/Model/RedirectorPage.php
@@ -24,6 +24,10 @@ class RedirectorPage extends Page
 
     private static $icon_class = 'font-icon-p-redirect';
 
+    private static $show_stage_link = false;
+
+    private static $show_live_link = false;
+
     private static $db = array(
         "RedirectionType" => "Enum('Internal,External','Internal')",
         "ExternalURL" => "Varchar(2083)" // 2083 is the maximum length of a URL in Internet Explorer.

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -137,8 +137,16 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     protected static $_allowedChildren = array();
 
+    /**
+     * Determines if the Draft Preview panel will appear when in the CMS admin
+     * @var bool
+     */
     private static $show_stage_link = true;
 
+    /**
+     * Determines if the Live Preview panel will appear when in the CMS admin
+     * @var bool
+     */
     private static $show_live_link = true;
 
     /**

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -137,6 +137,10 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     protected static $_allowedChildren = array();
 
+    private static $show_stage_link = true;
+
+    private static $show_live_link = true;
+
     /**
      * The default child class for this page.
      * Note: Value might be cached, see {@link $allowed_chilren}.


### PR DESCRIPTION
Existing functionality is limited to `RedirectorPage`

Another option would be to use the HiddenClass methodology