### PR TITLE
Cache page icons

### DIFF
--- a/_config/cache.yml
+++ b/_config/cache.yml
@@ -12,4 +12,7 @@ SilverStripe\Core\Injector\Injector:
     factory: SilverStripe\Core\Cache\CacheFactory
     constructor:
       namespace: "SiteTree_CreatableChildren"
-
+  Psr\SimpleCache\CacheInterface.SiteTree_PageIcons:
+    factory: SilverStripe\Core\Cache\CacheFactory
+    constructor:
+      namespace: "SiteTree_PageIcons"

--- a/code/Controllers/LeftAndMainPageIconsExtension.php
+++ b/code/Controllers/LeftAndMainPageIconsExtension.php
@@ -2,32 +2,59 @@
 
 namespace SilverStripe\CMS\Controllers;
 
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
+use ReflectionException;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Extension;
+use SilverStripe\Core\Flushable;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\View\Requirements;
 
 /**
  * Extension to include custom page icons
  */
-class LeftAndMainPageIconsExtension extends Extension
+class LeftAndMainPageIconsExtension extends Extension implements Flushable
 {
 
+    /**
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
+     */
     public function init()
     {
         Requirements::customCSS($this->generatePageIconsCss(), CMSMain::PAGE_ICONS_ID);
     }
 
     /**
+     * Just broadly clears the cache on flush
+     */
+    public static function flush()
+    {
+        Injector::inst()->get(CacheInterface::class . '.SiteTree_PageIcons')->clear();
+    }
+
+
+    /**
      * Include CSS for page icons. We're not using the JSTree 'types' option
      * because it causes too much performance overhead just to add some icons.
      *
      * @return string CSS
+     * @throws InvalidArgumentException
+     * @throws ReflectionException
      */
     public function generatePageIconsCss()
     {
+        /** @var CacheInterface $cache */
+        $cache = Injector::inst()->get(CacheInterface::class . '.SiteTree_PageIcons');
+
+        if ($cache->has('css')) {
+            return $cache->get('css');
+        }
+
         $css = '';
         $classes = ClassInfo::subclassesFor(SiteTree::class);
         foreach ($classes as $class) {
@@ -41,6 +68,9 @@ class LeftAndMainPageIconsExtension extends Extension
                 $css .= sprintf('%s { background: transparent url(\'%s\') 0 0 no-repeat; }', $selector, $iconURL);
             }
         }
+
+        $cache->set('css', $css);
+
         return $css;
     }
 }


### PR DESCRIPTION
We might be outliers but we've found that a good chunk of time (7ish%) on a request to the admin was being taken up by getting the page icons. These should only change when adding a new page which from my understanding would require a dev/build anyways so the cache wouldn't be any big issue

