### PR TITLE
FIX: If no parent in RelativeLink() return null

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -645,7 +645,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             if ((!$parent || !$parent->exists()) && !$this->isOnDraft()) {
                 $parent = Versioned::get_latest_version(self::class, $this->ParentID);
             }
-            $base = $parent->RelativeLink($this->URLSegment);
+            $base = $parent ? $parent->RelativeLink($this->URLSegment) : null;
         } elseif (!$action && $this->URLSegment == RootURLController::get_homepage_link()) {
             // Unset base for root-level homepages.
             // Note: Homepages with action parameters (or $action === true)


### PR DESCRIPTION
Fixes issue - https://github.com/silverstripe/silverstripe-cms/issues/2502