### PR TITLE
[ENHANCEMENT] Allow menu_title to be updated

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1053,7 +1053,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         if ($this->TreeIsFiltered()) {
             $items->push(new ArrayData([
-                'Title' => CMSPagesController::menu_title(),
+                'Title' => $this->menu_title(CMSPagesController::class),
                 'Link' => ($unlinked) ? false : $this->LinkPages()
             ]));
             $items->push(new ArrayData([
@@ -1071,7 +1071,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         $record = $this->currentPage();
         if (!$record) {
             $items->push(new ArrayData(array(
-                'Title' => CMSPagesController::menu_title(),
+                'Title' => $this->menu_title(CMSPagesController::class),
                 'Link' => ($unlinked) ? false : $this->LinkPages()
             )));
 


### PR DESCRIPTION
Currently, any class that extends from CMSMain has `Title` in the Breadcrumbs function set statically from; CMSPagesController::menu_title().

Using the function `$this->menu_title(CMSPagesController::class)` preserves the same functionality but also allows classes that extend from CMSMain to overwrite the returned value (if required).

Any feedback welcome.