### PR TITLE
BUG: Published pages filter correction (missing default filter)

### DIFF
--- a/code/Controllers/CMSSiteTreeFilter_PublishedPages.php
+++ b/code/Controllers/CMSSiteTreeFilter_PublishedPages.php
@@ -41,10 +41,14 @@ class CMSSiteTreeFilter_PublishedPages extends CMSSiteTreeFilter
      */
     public function getFilteredPages()
     {
-        return Versioned::get_including_deleted(SiteTree::class)
+        $pages = Versioned::get_including_deleted(SiteTree::class)
             ->innerJoin(
                 'SiteTree_Live',
                 '"SiteTree_Versions"."RecordID" = "SiteTree_Live"."ID"'
             );
+
+        $pages = $this->applyDefaultFilters($pages);
+
+        return $pages;
     }
 }


### PR DESCRIPTION
# Published pages filter correction

* published pages filter was missing the default filtering functionality

## Example test case

Search by specific page type and for published pages

**Actual result**

Published pages of any page type

**Expected result**

Published pages of specific page type

## Related issus

https://github.com/silverstripe/silverstripe-cms/issues/2540
https://github.com/silverstripe/silverstripe-cms/issues/2415