### PR TITLE
BUG Prioritise same-level pages in OldPageRedirector

### DIFF
--- a/code/Controllers/OldPageRedirector.php
+++ b/code/Controllers/OldPageRedirector.php
@@ -29,7 +29,10 @@ class OldPageRedirector extends Extension
         $getvars = $request->getVars();
         unset($getvars['url']);
 
-        $page = static::find_old_page($params);
+        $page = self::find_old_page($params, 0);
+        if (!$page) {
+            $page = self::find_old_page($params);
+        }
         $cleanPage = trim(Director::makeRelative($page), '/');
         if (!$cleanPage) {
             $cleanPage = Director::makeRelative(RootURLController::get_homepage_link());
@@ -59,7 +62,7 @@ class OldPageRedirector extends Extension
      */
     public static function find_old_page($params, $parent = null, $redirect = false)
     {
-        $parent = is_numeric($parent) ? SiteTree::get()->byID($parent) : $parent;
+        $parent = is_numeric($parent) && $parent > 0 ? SiteTree::get()->byID($parent) : $parent;
         $params = (array)$params;
         $URL = rawurlencode(array_shift($params));
         if (empty($URL)) {
@@ -68,9 +71,9 @@ class OldPageRedirector extends Extension
         $pages = SiteTree::get()->filter(array(
             'URLSegment' => $URL,
         ));
-        if ($parent) {
+        if ($parent || is_numeric($parent)) {
             $pages = $pages->filter(array(
-                'ParentID' => $parent->ID,
+                'ParentID' => is_numeric($parent) ? $parent : $parent->ID,
             ));
         }
         /** @var SiteTree $page */


### PR DESCRIPTION
Issue #2522 was merged into wrong branch (4) and we'd like to use this bugfix as soon as possible. 
I'm requesting new PR to make it available sooner for us.

Original description:
_Added option to pass integer ParentID=0 to OldPageRedirector::find_old_page to ensure search through nested pages from the root of SiteTree structure. Added new call of function and still offering fallback to old behaviour if first call returns false (fixed #2522)_