### PR TITLE
FIX Show 'No preview available' message for pages with no state

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "silverstripe/admin": "^1.7@dev",
+        "silverstripe/admin": "^1.9@dev",
         "silverstripe/campaign-admin": "^1.7@dev",
         "silverstripe/framework": "^4.7@dev",
         "silverstripe/reports": "^4.7@dev",

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -83,6 +83,7 @@ en:
     MENUTITLE: History
     MULTISELECT: 'Batch actions'
     NOTPUBLISHED: 'Not published'
+    NO_PREVIEW: 'No preview available'
     PREVIEW: 'Website preview'
     PUBLISHER: Publisher
     REVERTTOTHISVERSION: 'Revert to this version'

--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_PreviewPanel.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_PreviewPanel.ss
@@ -1,6 +1,9 @@
 <div class="cms-preview fill-height flexbox-area-grow" data-layout-type="border">
 	<div class="panel flexbox-area-grow fill-height">
-		<div class="preview-note"><span><!-- --></span><%t SilverStripe\CMS\Controllers\CMSPageHistoryController.PREVIEW 'Website preview' %></div>
+		<div class="preview-note">
+            <div class="icon font-icon-monitor display-1"></div>
+            <%t SilverStripe\CMS\Controllers\CMSPageHistoryController.NO_PREVIEW 'No preview available' %>
+        </div>
 		<div class="preview__device">
 			<div class="preview-device-outer">
 				<div class="preview-device-inner">
@@ -10,5 +13,4 @@
 		</div>
 	</div>
 	<div class="toolbar toolbar--south cms-content-controls cms-preview-controls"></div>
-	<div class="cms-preview-overlay ui-widget-overlay-light"></div>
 </div>


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-cms/issues/1945#issuecomment-869322412

This accompanies a [logic patch in the admin module](https://github.com/silverstripe/silverstripe-admin/pull/1086) to ensure that when no preview state is available for a pagetype, it renders a message stating this. Previously a broken layout would appear instead.