### PR TITLE
Making 3.7 build green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,16 @@ matrix:
   include:
     - php: 5.4
       env: DB=PGSQL
+    - php: 5.4
+      env: DB=MYSQL
     - php: 5.5
       env: DB=SQLITE
     - php: 5.6
       env: DB=MYSQL PDO=1
     - php: 5.6
       env: DB=MYSQL BEHAT_TEST=1
+    - php: 7.1
+      env: DB=PGSQL
     - php: 7.4
       env: DB=MYSQL
       dist: xenial


### PR DESCRIPTION
The 3.7 build is broken because of the 5.4/PostgreSQL matrix. First, I'll try to see if the problem is with 5.4 or PostgreSQL.