### PR TITLE
BUG Honour URL suffix on URL Segment field

### DIFF
--- a/code/Forms/SiteTreeURLSegmentField.php
+++ b/code/Forms/SiteTreeURLSegmentField.php
@@ -53,7 +53,7 @@ class SiteTreeURLSegmentField extends TextField
             parent::getAttributes(),
             [
                 'data-prefix' => $this->getURLPrefix(),
-                'data-suffix' => '?stage=Stage',
+                'data-suffix' => $this->getURLSuffix(),
                 'data-default-url' => $this->getDefaultURL()
             ]
         );

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2027,6 +2027,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
         $urlsegment = SiteTreeURLSegmentField::create("URLSegment", $this->fieldLabel('URLSegment'))
             ->setURLPrefix($baseLink)
+            ->setURLSuffix('?stage=Stage')
             ->setDefaultURL($this->generateURLSegment(_t(
                 'SilverStripe\\CMS\\Controllers\\CMSMain.NEWPAGE',
                 'New {pagetype}',

--- a/tests/php/Forms/SiteTreeURLSegmentFieldTest.php
+++ b/tests/php/Forms/SiteTreeURLSegmentFieldTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Controllers;
+
+use SilverStripe\CMS\BatchActions\CMSBatchAction_Archive;
+use SilverStripe\CMS\BatchActions\CMSBatchAction_Publish;
+use SilverStripe\CMS\BatchActions\CMSBatchAction_Restore;
+use SilverStripe\CMS\BatchActions\CMSBatchAction_Unpublish;
+use SilverStripe\CMS\Forms\SiteTreeURLSegmentField;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Tests CMS Specific subclasses of {@see CMSBatchAction}
+ */
+class SiteTreeURLSegmentFieldTest extends SapphireTest
+{
+    /**
+     * Test which pages can be published via batch actions
+     */
+    public function testURLSuffix()
+    {
+        $field = new SiteTreeURLSegmentField('URLSegment');
+        $field->setURLSuffix('?foo=bar');
+
+        $this->assertEquals('?foo=bar', $field->getURLSuffix());
+        $this->assertEquals('?foo=bar', $field->getAttributes()['data-suffix']);
+    }
+}


### PR DESCRIPTION
`SiteTreeURLSegmentField` accepts a URL Prefix property, but just ignores the value given to it.

# Parent issue
* #1364