### PR TITLE
NEW Set VersionedProvider labels for recipe-core and recipe-cms

### DIFF
--- a/_config/version.yml
+++ b/_config/version.yml
@@ -6,3 +6,4 @@ SilverStripe\Core\Manifest\VersionProvider:
   modules:
     silverstripe/framework: ''
     silverstripe/cms: CMS
+    silverstripe/recipe-cms: CMS Recipe


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-installer/issues/276

Related PR (merged) to add functionality https://github.com/silverstripe/silverstripe-framework/pull/9628

Reason that recipes are added here rather than within silverstripe/recipe-core/cms is because recipes are included in the projects vendor folder like normal modules

If we were to add the config in the recipes, then we would need to have a pair of seperate yml files copied into the project app/_config folder which would be pretty annoying for a relatively minor feature

