### PR TITLE
BUG: Unpublish permission decoupled from publish permission.

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2371,7 +2371,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         }
 
         // "unpublish"
-        if ($isPublished && $canPublish && $isOnDraft && $canUnpublish) {
+        if ($isPublished && $isOnDraft && $canUnpublish) {
             $moreOptions->push(
                 FormAction::create('unpublish', _t(__CLASS__.'.BUTTONUNPUBLISH', 'Unpublish'), 'delete')
                     ->setDescription(_t(__CLASS__.'.BUTTONUNPUBLISHDESC', 'Remove this page from the published site'))


### PR DESCRIPTION
# Unpublish permission decoupled from publish permission

* unpublish action no longer requires explicit publish permission

## Backwards compatibility

* projects with out of the box setup will not be impacted as unpublish permission falls back to publish permission
* the change only impacts projects which use explicit and separate permissions for publish / unpublish actions
* note that separating these permissions makes sense in cases where publishing requires an audit and is considered risky action while unpublishing not so much

## Related issues

https://github.com/silverstripe/silverstripe-cms/issues/2579