### PR TITLE
BUG: URL segment filter correction for CMS page search.

### DIFF
--- a/code/Controllers/CMSSiteTreeFilter.php
+++ b/code/Controllers/CMSSiteTreeFilter.php
@@ -5,6 +5,7 @@ namespace SilverStripe\CMS\Controllers;
 use SilverStripe\Admin\LeftAndMain_SearchFilter;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Forms\DateField;
 use SilverStripe\ORM\DataList;
@@ -203,11 +204,17 @@ abstract class CMSSiteTreeFilter implements LeftAndMain_SearchFilter
             switch ($name) {
                 case 'Term':
                     $query = $query->filterAny(array(
-                        'URLSegment:PartialMatch' => $val,
+                        'URLSegment:PartialMatch' => Convert::raw2url($val),
                         'Title:PartialMatch' => $val,
                         'MenuTitle:PartialMatch' => $val,
                         'Content:PartialMatch' => $val
                     ));
+                    break;
+
+                case 'URLSegment':
+                    $query = $query->filter([
+                        'URLSegment:PartialMatch' => Convert::raw2url($val),
+                    ]);
                     break;
 
                 case 'LastEditedFrom':

--- a/tests/php/Controllers/CMSSiteTreeFilterTest.php
+++ b/tests/php/Controllers/CMSSiteTreeFilterTest.php
@@ -47,6 +47,17 @@ class CMSSiteTreeFilterTest extends SapphireTest
         );
     }
 
+    public function testUrlSegmentFilter()
+    {
+        $page = $this->objFromFixture(Page::class, 'page8');
+
+        $filter = CMSSiteTreeFilter_Search::create(['Term' => 'lake-wanaka+adventure']);
+        $this->assertTrue($filter->isPageIncluded($page));
+
+        $filter = CMSSiteTreeFilter_Search::create(['URLSegment' => 'lake-wanaka+adventure']);
+        $this->assertTrue($filter->isPageIncluded($page));
+    }
+
     public function testIncludesParentsForNestedMatches()
     {
         $parent = $this->objFromFixture('Page', 'page3');

--- a/tests/php/Controllers/CMSSiteTreeFilterTest.yml
+++ b/tests/php/Controllers/CMSSiteTreeFilterTest.yml
@@ -29,3 +29,6 @@ Page:
   page3b:
     Parent: =>Page.page3
     Title: Page 3b
+  page8:
+    Title: EncodedUrlSegment
+    URLSegment: lake-wanaka+adventure


### PR DESCRIPTION
# URL segment filter correction for CMS page search.

Affected version:

`4.5.1`

## Description

URL segment search lacks encoding which causes the search results to omit some pages.

## Example

Consider a page with the following URL segment:

`lake-wanaka+adventure`

Searching for this page will yield no results because the search matches raw value which doesn't work as the DB value is stored in encoded format which looks like this:

`lake-wanaka%2Badventure`

## Solution

Apply encoding to all places where URL segment value is passed to DB lookup.

## Notes

* we can't rely on `URLSegmentFilter` to sanitise the values in general because the sanitisation rules are configurable via the `default_replacements` configuration API
* we need to make sure any encoded values can be used for search

## Related issues

https://github.com/silverstripe/silverstripe-cms/issues/2359