### PR TITLE
ENH Disable option to create top-level pages based on permissions

### DIFF
--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -21,6 +21,7 @@ use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\ValidationResult;
 use SilverStripe\Security\Member;
 use SilverStripe\Security\Security;
+use SilverStripe\SiteConfig\SiteConfig;
 
 class CMSPageAddController extends CMSPageEditController
 {
@@ -79,7 +80,7 @@ class CMSPageAddController extends CMSPageEditController
             $parentModeField = new SelectionGroup(
                 "ParentModeField",
                 [
-                    new SelectionGroup_Item(
+                    $topField = new SelectionGroup_Item(
                         "top",
                         null,
                         $topTitle
@@ -144,6 +145,13 @@ class CMSPageAddController extends CMSPageEditController
             $parentField->setValue((int)$parentID);
         } else {
             $parentModeField->setValue('top');
+        }
+
+        // Check if the current user has enough permissions to create top level pages
+        // If not, then disable the option to do that
+        if (!SiteConfig::current_site_config()->canCreateTopLevel()) {
+            $topField->setDisabled(true);
+            $parentModeField->setValue('child');
         }
 
         $actions = new FieldList(

--- a/tests/behat/features/create-a-page.feature
+++ b/tests/behat/features/create-a-page.feature
@@ -5,14 +5,14 @@ Feature: Create a page
 
   Background:
     Given a "page" "MyPage"
-    Given I am logged in with "ADMIN" permissions
-    And I go to "/admin/pages"
-    Then I should see "MyPage" in the tree
-    And I should see a "Add new" button in CMS Content Toolbar
+    And a "group" "AUTHOR group" has permissions "Access to 'Pages' section"
+    And I am logged in with "ADMIN" permissions
 
   @javascript
   Scenario: I can create a page from the pages section
-    Given I go to "/admin/pages"
+    When I go to "/admin/pages"
+    Then I should see "MyPage" in the tree
+    And I should see a "Add new" button in CMS Content Toolbar
     When I press the "Add new" button
     And I select the "Page" radio button
     And I press the "Create" button
@@ -20,10 +20,23 @@ Feature: Create a page
 
   @javascript
   Scenario: I can create a page under another page
-    Given I go to "/admin/pages"
+    When I go to "/admin/pages"
+    Then I should see "MyPage" in the tree
+    And I should see a "Add new" button in CMS Content Toolbar
     When I press the "Add new" button
     And I select the "Under another page" radio button
     And I select "MyPage" in the "#Form_AddForm_ParentID_Holder" tree dropdown
     And I select the "Page" radio button
     And I press the "Create" button
     Then I should see an edit page form
+
+  Scenario: I cannot add root level pages without permission
+    When I go to "/admin/settings"
+    And I click the "Access" CMS tab
+    And I click the "#Form_EditForm_CanCreateTopLevelType_OnlyTheseUsers" element
+    And I press the "Save" button
+    And I click the ".cms-login-status__logout-link" element
+    When I am logged in with "AUTHOR" permissions
+    And I press the "Add new" button
+    Then I see the "Top level" radio button "disabled" attribute equals "1"
+    And I see the "Under another page" radio button "checked" attribute equals "1"

--- a/tests/behat/src/FixtureContext.php
+++ b/tests/behat/src/FixtureContext.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\CMS\Tests\Behaviour;
 
+use Behat\Mink\Element\DocumentElement;
+use Behat\Mink\Element\NodeElement;
 use SilverStripe\BehatExtension\Context\FixtureContext as BehatFixtureContext;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
@@ -62,5 +64,53 @@ class FixtureContext extends BehatFixtureContext
         }
         $obj->write();
         $obj->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
+    }
+
+    /**
+     * @When /^I click the "([^"]+)" element$/
+     * @param $selector
+     */
+    public function iClickTheElement($selector)
+    {
+        /** @var DocumentElement $page */
+        $page = $this->getMainContext()->getSession()->getPage();
+        $element = $page->find('css', $selector);
+
+        assertNotNull($element, sprintf('Element %s not found', $selector));
+
+        $element->click();
+    }
+
+    /**
+     * @When /^I see the "([^"]+)" element$/
+     * @param $selector
+     */
+    public function iSeeTheElement($selector)
+    {
+        /** @var DocumentElement $page */
+        $page = $this->getMainContext()->getSession()->getPage();
+        $element = $page->find('css', $selector);
+
+        assertNotNull($element, sprintf('Element %s not found', $selector));
+    }
+
+    /**
+     * Selects the specified radio button
+     *
+     * @Given /^I see the "([^"]*)" radio button "([^"]*)" attribute equals "([^"]*)"$/
+     * @param string $radioLabel
+     * @param string $attribute
+     * @param string $value
+     */
+    public function iSeeTheRadioButtonAttributeEquals($radioLabel, $attribute, $value)
+    {
+        /** @var NodeElement $radioButton */
+        $session = $this->getMainContext()->getSession();
+        $radioButton = $session->getPage()->find('named', [
+            'radio',
+            $this->getMainContext()->getXpathEscaper()->escapeLiteral($radioLabel)
+        ]);
+        assertNotNull($radioButton);
+        assertEquals($value, $radioButton->getAttribute($attribute));
     }
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-cms/issues/2396

Blocked by https://github.com/silverstripe/silverstripe-framework/pull/9741

Failed behat test requires the above PR to be merged so that the radio button can be disabled

When a user lacks the permission to create top-level pages, the following will now happen:
a) Disables the "Top-level" radio input
b) Auto-selects the "Under another page" radio input

![image](https://user-images.githubusercontent.com/4809037/96825413-8a68cb80-148d-11eb-83c6-9b9939064dfb.png)
