### PR TITLE
BUGFIX: Restore, refactor getByLink plugin

### DIFF
--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -15,7 +15,3 @@ SilverStripe\GraphQL\Schema\Schema:
     admin:
       src:
         - 'silverstripe/cms: _graphql'
-SilverStripe\Core\Injector\Injector:
-  SilverStripe\GraphQL\Schema\Registry\PluginRegistry:
-    constructor:
-      getByLink: '%$SilverStripe\CMS\GraphQL\LinkablePlugin'

--- a/_config/graphql.yml
+++ b/_config/graphql.yml
@@ -15,3 +15,7 @@ SilverStripe\GraphQL\Schema\Schema:
     admin:
       src:
         - 'silverstripe/cms: _graphql'
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\GraphQL\Schema\Registry\PluginRegistry:
+    constructor:
+      getByLink: '%$SilverStripe\CMS\GraphQL\LinkablePlugin'


### PR DESCRIPTION
It had been accidentally removed from the registry.

Refactored so that it's always its own argument to the query, and should not apply to list queries, only single record queries.