### PR TITLE
remove trailing slash from SiteTree links if no action present

### DIFF
--- a/code/Controllers/OldPageRedirector.php
+++ b/code/Controllers/OldPageRedirector.php
@@ -103,7 +103,7 @@ class OldPageRedirector extends Extension
                     // No valid page found.
                     if ($redirect) {
                         // If we had some redirect to be done, lets do it. imagine /foo/action -> /bar/action, we still want this redirect to happen if action isn't a page
-                        return $page->Link() . implode('/', $params);
+                        return Controller::join_links($page->Link(), implode('/', $params));
                     }
                 }
             } else {

--- a/code/Forms/SiteTreeURLSegmentField.php
+++ b/code/Forms/SiteTreeURLSegmentField.php
@@ -134,7 +134,7 @@ class SiteTreeURLSegmentField extends TextField
      */
     public function getURLPrefix()
     {
-        return $this->urlPrefix;
+        return rtrim($this->urlPrefix, '/') . '/';
     }
 
     public function getURLSuffix()

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -666,7 +666,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             $action = null;
         }
 
-        return Controller::join_links($base, '/', $action);
+        return Controller::join_links($base, $action);
     }
 
     /**

--- a/tests/php/Controllers/ModelAsControllerTest.php
+++ b/tests/php/Controllers/ModelAsControllerTest.php
@@ -93,7 +93,7 @@ class ModelAsControllerTest extends FunctionalTest
         $response = $this->get('newlevel1/level2');
         $this->assertEquals($response->getStatusCode(), 301);
         $this->assertEquals(
-            Controller::join_links(Director::baseURL() . 'newlevel1/newlevel2/'),
+            Controller::join_links(Director::baseURL() . 'newlevel1/newlevel2'),
             $response->getHeader('Location')
         );
 
@@ -101,7 +101,7 @@ class ModelAsControllerTest extends FunctionalTest
         $response = $this->get('newlevel1/newlevel2/level3');
         $this->assertEquals($response->getStatusCode(), 301);
         $this->assertEquals(
-            Controller::join_links(Director::baseURL() . 'newlevel1/newlevel2/newlevel3/'),
+            Controller::join_links(Director::baseURL() . 'newlevel1/newlevel2/newlevel3'),
             $response->getHeader('Location')
         );
 
@@ -154,10 +154,10 @@ class ModelAsControllerTest extends FunctionalTest
         $page5->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
         // Test that the redirect still works fine when trying to access the most nested page
-        $response = $this->get('oldurl/level2/level3/level4/level5/');
+        $response = $this->get('oldurl/level2/level3/level4/level5');
         $this->assertEquals($response->getStatusCode(), 301);
         $this->assertEquals(
-            Controller::join_links(Director::baseURL() . 'newurl/level2/level3/level4/level5/'),
+            Controller::join_links(Director::baseURL() . 'newurl/level2/level3/level4/level5'),
             $response->getHeader('Location')
         );
     }
@@ -171,7 +171,7 @@ class ModelAsControllerTest extends FunctionalTest
         $response = $this->get('newlevel3');
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals(
-            Director::baseURL() . 'newlevel1/newlevel2/newlevel3/',
+            Director::baseURL() . 'newlevel1/newlevel2/newlevel3',
             $response->getHeader("Location")
         );
 
@@ -179,7 +179,7 @@ class ModelAsControllerTest extends FunctionalTest
         $response = $this->get('level3');
         $this->assertEquals(301, $response->getStatusCode());
         $this->assertEquals(
-            Director::baseURL() . 'newlevel1/newlevel2/newlevel3/',
+            Director::baseURL() . 'newlevel1/newlevel2/newlevel3',
             $response->getHeader("Location")
         );
     }
@@ -215,10 +215,10 @@ class ModelAsControllerTest extends FunctionalTest
         $this->generateNestedPagesFixture();
 
         // check third level URLSegment
-        $response = $this->get('newlevel1/newlevel2/level3/?foo=bar&test=test');
+        $response = $this->get('newlevel1/newlevel2/level3?foo=bar&test=test');
         $this->assertEquals($response->getStatusCode(), 301);
         $this->assertEquals(
-            Controller::join_links(Director::baseURL() . 'newlevel1/newlevel2/newlevel3/', '?foo=bar&test=test'),
+            Controller::join_links(Director::baseURL() . 'newlevel1/newlevel2/newlevel3', '?foo=bar&test=test'),
             $response->getHeader('Location')
         );
     }

--- a/tests/php/Model/RedirectorPageTest.php
+++ b/tests/php/Model/RedirectorPageTest.php
@@ -30,15 +30,15 @@ class RedirectorPageTest extends FunctionalTest
     {
         /* For good redirectors, the final destination URL will be returned */
         $this->assertEquals("http://www.google.com", $this->objFromFixture(RedirectorPage::class, 'goodexternal')->Link());
-        $this->assertEquals("/redirection-dest/", $this->objFromFixture(RedirectorPage::class, 'goodinternal')->redirectionLink());
-        $this->assertEquals("/redirection-dest/", $this->objFromFixture(RedirectorPage::class, 'goodinternal')->Link());
+        $this->assertEquals("/redirection-dest", $this->objFromFixture(RedirectorPage::class, 'goodinternal')->redirectionLink());
+        $this->assertEquals("/redirection-dest", $this->objFromFixture(RedirectorPage::class, 'goodinternal')->Link());
     }
 
     public function testEmptyRedirectors()
     {
         /* If a redirector page is misconfigured, then its link method will just return the usual URLSegment-generated value */
         $page1 = $this->objFromFixture(RedirectorPage::class, 'badexternal');
-        $this->assertEquals('/bad-external/', $page1->Link());
+        $this->assertEquals('/bad-external', $page1->Link());
 
         /* An error message will be shown if you visit it */
         $content = $this->get(Director::makeRelative($page1->Link()))->getBody();
@@ -46,7 +46,7 @@ class RedirectorPageTest extends FunctionalTest
 
         /* This also applies for internal links */
         $page2 = $this->objFromFixture(RedirectorPage::class, 'badinternal');
-        $this->assertEquals('/bad-internal/', $page2->Link());
+        $this->assertEquals('/bad-internal', $page2->Link());
         $content = $this->get(Director::makeRelative($page2->Link()))->getBody();
         $this->assertContains('message-setupWithoutRedirect', $content);
     }
@@ -55,14 +55,14 @@ class RedirectorPageTest extends FunctionalTest
     {
         /* Reflexive redirectors are those that point to themselves.  They should behave the same as an empty redirector */
         $page = $this->objFromFixture(RedirectorPage::class, 'reflexive');
-        $this->assertEquals('/reflexive/', $page->Link());
+        $this->assertEquals('/reflexive', $page->Link());
         $content = $this->get(Director::makeRelative($page->Link()))->getBody();
         $this->assertContains('message-setupWithoutRedirect', $content);
 
         /* Transitive redirectors are those that point to another redirector page.  They should send people to the URLSegment
          * of the destination page - the middle-stop, so to speak.  That should redirect to the final destination */
         $page = $this->objFromFixture(RedirectorPage::class, 'transitive');
-        $this->assertEquals('/good-internal/', $page->Link());
+        $this->assertEquals('/good-internal', $page->Link());
 
         $this->autoFollowRedirection = false;
         $response = $this->get(Director::makeRelative($page->Link()));

--- a/tests/php/Model/RedirectorPageTest.php
+++ b/tests/php/Model/RedirectorPageTest.php
@@ -66,7 +66,7 @@ class RedirectorPageTest extends FunctionalTest
 
         $this->autoFollowRedirection = false;
         $response = $this->get(Director::makeRelative($page->Link()));
-        $this->assertEquals(Director::absoluteURL('/redirection-dest/'), $response->getHeader("Location"));
+        $this->assertEquals(Director::absoluteURL('/redirection-dest'), $response->getHeader("Location"));
     }
 
     public function testExternalURLGetsPrefixIfNotSet()

--- a/tests/php/Model/SiteTreeBacklinksTest.php
+++ b/tests/php/Model/SiteTreeBacklinksTest.php
@@ -94,7 +94,7 @@ class SiteTreeBacklinksTest extends SapphireTest
 
         // assert hyperlink to page 1's current url exists on page 3
         $links = HTTP::getLinksIn($page3->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
+        $this->assertContains(Director::baseURL().'page1', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
 
         // change url of page 1
         $page1->URLSegment = 'new-url-segment';
@@ -105,7 +105,7 @@ class SiteTreeBacklinksTest extends SapphireTest
 
         // assert hyperlink to page 1's new url exists
         $links = HTTP::getLinksIn($page3->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s new url exists on page 3');
+        $this->assertContains(Director::baseURL().'new-url-segment', $links, 'Assert hyperlink to page 1\'s new url exists on page 3');
     }
 
     public function testChangingUrlOnLiveSiteRewritesLink()
@@ -125,7 +125,7 @@ class SiteTreeBacklinksTest extends SapphireTest
 
         // assert hyperlink to page 1's current url exists on page 3
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
+        $this->assertContains(Director::baseURL().'page1', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
 
         // change url of page 1
         $page1live->URLSegment = 'new-url-segment';
@@ -137,7 +137,7 @@ class SiteTreeBacklinksTest extends SapphireTest
         // assert hyperlink to page 1's new url exists
         Versioned::set_stage(Versioned::LIVE);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s new url exists on page 3');
+        $this->assertContains(Director::baseURL().'new-url-segment', $links, 'Assert hyperlink to page 1\'s new url exists on page 3');
     }
 
     public function testPublishingPageWithModifiedUrlRewritesLink()
@@ -154,7 +154,7 @@ class SiteTreeBacklinksTest extends SapphireTest
 
         // assert hyperlink to page 1's current url exists
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
+        $this->assertContains(Director::baseURL().'page1', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
 
         // rename url of page 1 on stage
         $page1->URLSegment = 'new-url-segment';
@@ -164,7 +164,7 @@ class SiteTreeBacklinksTest extends SapphireTest
         $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
         Versioned::set_stage(Versioned::LIVE);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
+        $this->assertContains(Director::baseURL().'page1', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
 
 
         // publish page 1
@@ -173,7 +173,7 @@ class SiteTreeBacklinksTest extends SapphireTest
         // assert hyperlink to page 1's new published url exists
         $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s new published url exists on page 3');
+        $this->assertContains(Director::baseURL().'new-url-segment', $links, 'Assert hyperlink to page 1\'s new published url exists on page 3');
     }
 
     public function testPublishingPageWithModifiedLinksRewritesLinks()
@@ -186,7 +186,7 @@ class SiteTreeBacklinksTest extends SapphireTest
 
         // assert hyperlink to page 1's current url exists
         $links = HTTP::getLinksIn($page3->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
+        $this->assertContains(Director::baseURL().'page1', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
 
         // change page 1 url on draft
         $page1->URLSegment = 'new-url-segment';
@@ -197,7 +197,7 @@ class SiteTreeBacklinksTest extends SapphireTest
         // assert page 3 on draft contains new page 1 url
         $page3 = $this->objFromFixture('Page', 'page3');
         $links = HTTP::getLinksIn($page3->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s current draft url exists on page 3');
+        $this->assertContains(Director::baseURL().'new-url-segment', $links, 'Assert hyperlink to page 1\'s current draft url exists on page 3');
 
         // publish page 3
         $this->assertTrue($page3->publishRecursive());
@@ -206,7 +206,7 @@ class SiteTreeBacklinksTest extends SapphireTest
         $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
         Versioned::set_stage(Versioned::LIVE);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
+        $this->assertContains(Director::baseURL().'page1', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
 
         // publish page 1
         $this->assertTrue($page1->publishRecursive());
@@ -214,7 +214,7 @@ class SiteTreeBacklinksTest extends SapphireTest
         // assert page 3 on published site contains new page 1 url
         $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
+        $this->assertContains(Director::baseURL().'new-url-segment', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
     }
 
     public function testLinkTrackingOnExtraContentFields()
@@ -244,17 +244,17 @@ class SiteTreeBacklinksTest extends SapphireTest
 
         // confirm that draft link on page2 has been rewritten
         $page2 = $this->objFromFixture('Page', 'page2');
-        $this->assertEquals('<p><a href="'.Director::baseURL().'page1-new-url/">Testing page 1 link</a></p>', $page2->obj('ExtraContent')->forTemplate());
+        $this->assertEquals('<p><a href="'.Director::baseURL().'page1-new-url">Testing page 1 link</a></p>', $page2->obj('ExtraContent')->forTemplate());
 
         // confirm that published link hasn't
         $page2Live = Versioned::get_one_by_stage("Page", "Live", "\"SiteTree\".\"ID\" = $page2->ID");
         Versioned::set_stage(Versioned::LIVE);
-        $this->assertEquals('<p><a href="'.Director::baseURL().'page1/">Testing page 1 link</a></p>', $page2Live->obj('ExtraContent')->forTemplate());
+        $this->assertEquals('<p><a href="'.Director::baseURL().'page1">Testing page 1 link</a></p>', $page2Live->obj('ExtraContent')->forTemplate());
 
         // publish page1 and confirm that the link on the published page2 has now been updated
         $page1->publishRecursive();
         $page2Live = Versioned::get_one_by_stage("Page", "Live", "\"SiteTree\".\"ID\" = $page2->ID");
-        $this->assertEquals('<p><a href="'.Director::baseURL().'page1-new-url/">Testing page 1 link</a></p>', $page2Live->obj('ExtraContent')->forTemplate());
+        $this->assertEquals('<p><a href="'.Director::baseURL().'page1-new-url">Testing page 1 link</a></p>', $page2Live->obj('ExtraContent')->forTemplate());
 
         // Edit draft again
         Versioned::set_stage(Versioned::DRAFT);

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -474,8 +474,8 @@ class SiteTreeTest extends SapphireTest
 
         Config::modify()->set(SiteTree::class, 'nested_urls', true);
 
-        $this->assertEquals('about-us/', $about->RelativeLink(), 'Matches URLSegment on top level without parameters');
-        $this->assertEquals('about-us/my-staff/', $staff->RelativeLink(), 'Matches URLSegment plus parent on second level without parameters');
+        $this->assertEquals('about-us', $about->RelativeLink(), 'Matches URLSegment on top level without parameters');
+        $this->assertEquals('about-us/my-staff', $staff->RelativeLink(), 'Matches URLSegment plus parent on second level without parameters');
         $this->assertEquals('about-us/edit', $about->RelativeLink('edit'), 'Matches URLSegment plus parameter on top level');
         $this->assertEquals('about-us/tom&jerry', $about->RelativeLink('tom&jerry'), 'Doesnt url encode parameter');
     }

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -502,8 +502,8 @@ class SiteTreeTest extends SapphireTest
         $parent->URLSegment = 'changed-on-draft';
         $parent->write();
 
-        $this->assertStringEndsWith('changed-on-live/my-staff/', $child->getAbsoluteLiveLink(false));
-        $this->assertStringEndsWith('changed-on-live/my-staff/?stage=Live', $child->getAbsoluteLiveLink());
+        $this->assertStringEndsWith('changed-on-live/my-staff', $child->getAbsoluteLiveLink(false));
+        $this->assertStringEndsWith('changed-on-live/my-staff?stage=Live', $child->getAbsoluteLiveLink());
     }
 
     public function testDuplicateChildrenRetainSort()


### PR DESCRIPTION
To my knowledge, `SiteTree::RelativeLink()` is currently the only place in SS where a trailing slash is added when there is no `$action` parameter given. 

`Controller::join_links` already adds slashes between sections of the path, this explicit slash is not needed.

This change would help with canonicalisation of URLs. 


