### PR TITLE
BUGFIX: Ensure SiteTree and ancestors always available in the CMS

### DIFF
--- a/_config/graphql-legacy.yml
+++ b/_config/graphql-legacy.yml
@@ -8,6 +8,10 @@ SilverStripe\GraphQL\Manager:
     admin:
       scaffolding:
         types:
+          # Expose this so that Page can appear anywhere in the hierarchy, rather than assuming
+          # it is a direct descendant of SiteTree.
+          SilverStripe\CMS\Model\SiteTree:
+            fields: [ID]
           Page:
             fields: [ID, LastEdited, AbsoluteLink]
             operations:


### PR DESCRIPTION
Resolves https://github.com/silverstripe/silverstripe-graphql/issues/376