### PR TITLE
BUGFIX: Ensure SiteTree is always available in the CMS, along with ancestors

### DIFF
--- a/_config/graphql-legacy.yml
+++ b/_config/graphql-legacy.yml
@@ -8,6 +8,10 @@ SilverStripe\GraphQL\Manager:
     admin:
       scaffolding:
         types:
+          # Expose this so that Page can appear anywhere in the hierarchy, rather than assuming
+          # it is a direct descendant of SiteTree.
+          SilverStripe\CMS\Model\SiteTree:
+            fields: [ID]
           Page:
             fields: [ID, LastEdited, AbsoluteLink]
             operations:


### PR DESCRIPTION
Backport #2651 to 4.8