### PR TITLE
NEW Return 404 when redirector page wants to link to missing page

### DIFF
--- a/code/Model/RedirectorPageController.php
+++ b/code/Model/RedirectorPageController.php
@@ -3,6 +3,7 @@ namespace SilverStripe\CMS\Model;
 
 use SilverStripe\Control\HTTPRequest;
 use PageController;
+use SilverStripe\Control\HTTPResponse_Exception;
 
 /**
  * Controller for the {@link RedirectorPage}.
@@ -12,18 +13,37 @@ class RedirectorPageController extends PageController
     private static $allowed_actions = ['index'];
 
     /**
+     * Should respond with HTTP 404 if the page or file being redirected to is missing
+     */
+    private static bool $missing_redirect_is_404 = true;
+
+    /**
      * Check we don't already have a redirect code set
      *
      * @param  HTTPRequest $request
      * @return \SilverStripe\Control\HTTPResponse
+     * @throws HTTPResponse_Exception
      */
     public function index(HTTPRequest $request)
     {
         /** @var RedirectorPage $page */
         $page = $this->data();
+
+        // Redirect if we can
         if (!$this->getResponse()->isFinished() && $link = $page->redirectionLink()) {
-            $this->redirect($link, 301);
+            return $this->redirect($link, 301);
         }
+
+        // Respond with 404 if redirecting to a missing file or page
+        if (($this->RedirectionType === 'Internal' && !$page->LinkTo()?->exists())
+            || ($this->RedirectionType === 'File' && !$page->LinkToFile()?->exists())
+        ) {
+            if (static::config()->get('missing_redirect_is_404')) {
+                $this->httpError(404);
+            }
+        }
+
+        // Fall back to a message about the bad setup
         return parent::handleAction($request, 'handleIndex');
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-cms/issues/2665

I recently got a ticket where content authors have quite a number of RedirectorPages 
and that they find it hard to track which ones to update whenever they unpublish the original page.
It makes more sense to them that whenever they unpublish a page, the RedirectorPage should display 404 as well.
This is quite opposite with the existing behaviour where the RedirectorPage maintains a published state.
Adding an extension point in this case provides additional flexibility.

- This extension is only applied whenever the link is null or not found
- One possible scenario is an internal link has been unpublished
- If lots of RedirectorPage then its hard to track and update
- An example use case is to change the content and status code to 404
- Another way is to redirect users to existing 404 page