### PR TITLE
add a new extension hook to SiteTree::RelativeLink()

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -666,7 +666,11 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             $action = null;
         }
 
-        return Controller::join_links($base, '/', $action);
+        $link = Controller::join_links($base, '/', $action);
+
+        $this->extend('updateFinalRelativeLink', $link);
+
+        return $link;
     }
 
     /**


### PR DESCRIPTION
The extension hook on https://github.com/silverstripe/silverstripe-cms/blob/4/code/Model/SiteTree.php#L661 (`updateRelativeLink`) is called before a trailing slash is added to page links without action (see #2631). 

To give a dev the option to remove the trailing slash we need an extension hook after the `join_links`, but I don't want to move the existing one because of the different parameters. But I'm happy to change that if requested.