### PR TITLE
Make Batch Actions button look like a button

### DIFF
--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSPagesController_ContentToolActions.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSPagesController_ContentToolActions.ss
@@ -4,7 +4,7 @@
             <a class="btn btn-primary cms-content-addpage-button tool-button font-icon-plus" href="$LinkPageAdd" data-url-addpage="{$LinkPageAdd('', 'ParentID=%s')}"><%t SilverStripe\CMS\Controllers\CMSMain.AddNewButton 'Add new' %></a>
 
             <% if $View == 'Tree' %>
-            <button type="button" class="cms-content-batchactions-button btn btn-secondary tool-button font-icon-check-mark-2 btn--last" data-toolid="batch-actions">
+            <button type="button" class="cms-content-batchactions-button btn btn-info tool-button font-icon-check-mark-2 btn--last" data-toolid="batch-actions">
                 <%t SilverStripe\CMS\Controllers\CMSPageHistoryController.MULTISELECT "Batch actions" %>
             </button>
             <% end_if %>


### PR DESCRIPTION
It's really not immediately obvious that it is clickable - not certain `-info` is best but it's an improvement.

![image](https://user-images.githubusercontent.com/9702648/131418626-32f72e2c-0fbf-4e11-a10e-b46ad217aa80.png)
