### PR TITLE
FIX: Treat absolute links in a consistent manner in get_by_link.

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -415,9 +415,8 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         $urlSegmentExpr = sprintf('"%s"."URLSegment"', $tableName);
         $parentIDExpr = sprintf('"%s"."ParentID"', $tableName);
 
-        if (trim($link, '/')) {
-            $link = trim(Director::makeRelative($link), '/');
-        } else {
+        $link = trim(Director::makeRelative($link), '/');
+        if (!$link) {
             $link = RootURLController::get_homepage_link();
         }
 

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -467,6 +467,21 @@ class SiteTreeTest extends SapphireTest
         );
     }
 
+    public function testGetByLinkAbsolute()
+    {
+        $home     = $this->objFromFixture('Page', 'home');
+        $about    = $this->objFromFixture('Page', 'about');
+        $staff    = $this->objFromFixture('Page', 'staff');
+        $product  = $this->objFromFixture('Page', 'product1');
+
+        $base = 'https://example.test/';
+        $this->assertEquals($home->ID, SiteTree::get_by_link(Controller::join_links($base, '/'), false)->ID);
+        $this->assertEquals($home->ID, SiteTree::get_by_link(Controller::join_links($base, '/home/'), false)->ID);
+        $this->assertEquals($about->ID, SiteTree::get_by_link(Controller::join_links($base, $about->Link()), false)->ID);
+        $this->assertEquals($staff->ID, SiteTree::get_by_link(Controller::join_links($base, $staff->Link()), false)->ID);
+        $this->assertEquals($product->ID, SiteTree::get_by_link(Controller::join_links($base, $product->Link()), false)->ID);
+    }
+
     public function testRelativeLink()
     {
         $about    = $this->objFromFixture('Page', 'about');


### PR DESCRIPTION
Fixes #2580 

The call to `Director::makeRelative` transforms absolute links into relative links, but is done separately to checking for a possible homepage URL. Previously, this meant that you could pass in "https://example.co.nz/about-us" or "about-us" and get the same result, but passing in "https://example.co.nz/" and "/"  would give _different_ results.
This commit performs the transformation to a relative link _before_ checking if the path should be for the home page, which leads to more consistent results.