### PR TITLE
FIX updateAnchorsOnPage extension not always called

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -3294,13 +3294,12 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             $matches
         );
 
-        if (!$parseSuccess) {
-            return [];
+        $anchors = [];
+        if ($parseSuccess >= 1) {
+            $anchors = array_values(array_unique(array_filter(
+                array_merge($matches[3], $matches[5])
+            )));
         }
-
-        $anchors = array_values(array_unique(array_filter(
-            array_merge($matches[3], $matches[5])
-        )));
 
         $this->extend('updateAnchorsOnPage', $anchors);
 


### PR DESCRIPTION
Currently, if there are no anchors found in the page content, the updateAnchorsOnPage extension is not called.
This proposed change will call the updateAnchorsOnPage extension regardless of the page content.