### PR TITLE
SiteTreeLinkTracking_Parser should use the getAnchorsOnPage

### DIFF
--- a/code/Model/SiteTreeLinkTracking_Parser.php
+++ b/code/Model/SiteTreeLinkTracking_Parser.php
@@ -68,8 +68,7 @@ class SiteTreeLinkTracking_Parser
                     $broken = true;
                 } elseif (!empty($matches['anchor'])) {
                     // Ensure anchor isn't broken on target page
-                    $anchor = preg_quote($matches['anchor'], '/');
-                    $broken = !preg_match("/(name|id)=\"{$anchor}\"/", $page->Content);
+                    $broken = !in_array($matches['anchor'], $page->getAnchorsOnPage());
                 } else {
                     $broken = false;
                 }


### PR DESCRIPTION
Currently, the SiteTreeLinkTracking_Parser only checks the page's content for anchors.
As a result any anchors that have been added or modified by the updateAnchorsOnPage extension in the getAnchorsOnPage method are marked ss-broken.