### PR TITLE
FIX canonical tag on VirtualPage

### DIFF
--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -143,9 +143,10 @@ class VirtualPage extends Page
         $copied = $this->CopyContentFrom();
         if ($copied && $copied->exists()) {
             $tags['canonical'] = [
+                'tag' => 'link',
                 'attributes' => [
                     'rel' => 'canonical',
-                    'content' => $copied->AbsoluteLink(),
+                    'href' => $copied->AbsoluteLink(),
                 ],
             ];
         }

--- a/tests/php/Model/VirtualPageTest.php
+++ b/tests/php/Model/VirtualPageTest.php
@@ -7,6 +7,7 @@ use SilverStripe\CMS\Controllers\ModelAsController;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\VirtualPage;
+use SilverStripe\Control\ContentNegotiator;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\ORM\DataObject;
@@ -91,6 +92,22 @@ class VirtualPageTest extends FunctionalTest
         $this->assertEquals("New menutitle", $vp2->MenuTitle);
         $this->assertEquals("<p>New content</p>", $vp1->Content);
         $this->assertEquals("<p>New content</p>", $vp2->Content);
+    }
+
+    public function testMetaTags()
+    {
+        $this->logInWithPermission('ADMIN');
+        $master = $this->objFromFixture('Page', 'master');
+        $vp1 = $this->objFromFixture(VirtualPage::class, 'vp1');
+
+        // Test with title
+        $meta = $vp1->MetaTags();
+        $charset = Config::inst()->get(ContentNegotiator::class, 'encoding');
+        $this->assertContains('<meta http-equiv="Content-Type" content="text/html; charset='.$charset.'"', $meta);
+        $this->assertContains('<link rel="canonical" href="'.$master->AbsoluteLink().'"', $meta);
+        $this->assertContains('<meta name="x-page-id" content="'.$vp1->ID.'"', $meta);
+        $this->assertContains('<meta name="x-cms-edit-link" content="'.$vp1->CMSEditLink().'"', $meta);
+        $this->assertContains('<title>'.$master->Title.'</title>', $meta);
     }
 
     /**


### PR DESCRIPTION
The canonical tag should be a `link` tag not `meta`, see https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls#rel-canonical-link-method