### PR TITLE
NEW Add preview state for non-versioned DataObjects.

### DIFF
--- a/code/Controllers/SilverStripeNavigatorItem_Unversioned.php
+++ b/code/Controllers/SilverStripeNavigatorItem_Unversioned.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SilverStripe\CMS\Controllers;
+
+use SilverStripe\CMS\Controllers\SilverStripeNavigatorItem;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Convert;
+use SilverStripe\Security\Member;
+use SilverStripe\Versioned\Versioned;
+
+class SilverStripeNavigatorItem_Unversioned extends SilverStripeNavigatorItem
+{
+    public function getHTML()
+    {
+        $recordLink = Convert::raw2att($this->getLink());
+        $linkTitle = _t('SilverStripe\\CMS\\Controllers\\ContentController.UNVERSIONEDPREVIEW', 'Preview');
+        return "<a class=\"current\" href=\"$recordLink\">$linkTitle</a>";
+    }
+
+    public function getLink()
+    {
+        return $this->getRecord()->PreviewLink();
+    }
+
+    public function getTitle()
+    {
+        return  _t(
+            'SilverStripe\\CMS\\Controllers\\ContentController.UNVERSIONEDPREVIEW',
+            'Preview',
+            'Used for the Switch between states (if any other other states are added). Needs to be a short label'
+        );
+    }
+
+    /**
+     * True if the record doesn't have the Versioned extension and is configured to display this item.
+     *
+     * @param Member $member
+     * @return bool
+     */
+    public function canView($member = null)
+    {
+        return (
+            !$this->getRecord()->hasExtension(Versioned::class)
+            && $this->showUnversionedLink()
+        );
+    }
+
+    /**
+     * True if the record is configured to display this item.
+     *
+     * @return bool
+     */
+    public function showUnversionedLink(): bool
+    {
+        return (bool) Config::inst()->get(get_class($this->record), 'show_unversioned_preview_link');
+    }
+
+    /**
+     * This item is always active, as there are unlikely to be other preview states available for the record.
+     *
+     * @return bool
+     */
+    public function isActive()
+    {
+        return true;
+    }
+}

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -134,6 +134,7 @@ en:
     Password: Password
     PostInstallTutorialIntro: 'This website is a simplistic version of a SilverStripe 3 site. To extend this, please take a look at {link}.'
     StartEditing: 'You can start editing your content by opening <a href="{link}">the CMS</a>.'
+    UNVERSIONEDPREVIEW: 'Preview'
     UnableDeleteInstall: 'Unable to delete installation files. Please delete the files below manually'
     VIEWPAGEIN: 'View Page in:'
   SilverStripe\CMS\Controllers\SilverStripeNavigator:


### PR DESCRIPTION
Currently only Versioned DataObjects are enabled for the CMS preview. Without a navigator item, non-versioned DataObjects aren't allowed to display in the preview panel even if they implement CMSPreviewable.

![image](https://user-images.githubusercontent.com/36352093/136475694-90bca382-b1ca-484d-b308-b326062d90b6.png)

Note that this state will still need to be added to the list of allowed states in the .cms-preview entwine logic which can be done like so:
```js
$('.cms-preview').entwine('ss.preview').AllowedStates().push('Unversioned');
```
Allowing the state mannualy as above is unnecessary if silverstripe/silverstripe-admin#1258 gets merged in.

This isn't particularly useful without silverstripe/silverstripe-admin#1250 but I guess it would allow someone to preview non-versioned `SiteTree` objects (assuming it's even possible to remove the `Versioned` extension from `SiteTree` without causing issues) or to use non-versioned `DataObject`s in a custom `CMSMain` subclass controlller.