### PR TITLE
FIX SiteTreeLinkTracking_Parser should use the getAnchorsOnPage

### DIFF
--- a/code/Model/SiteTreeLinkTracking_Parser.php
+++ b/code/Model/SiteTreeLinkTracking_Parser.php
@@ -68,8 +68,7 @@ class SiteTreeLinkTracking_Parser
                     $broken = true;
                 } elseif (!empty($matches['anchor'])) {
                     // Ensure anchor isn't broken on target page
-                    $anchor = preg_quote($matches['anchor'], '/');
-                    $broken = !preg_match("/(name|id)=\"{$anchor}\"/", $page->Content);
+                    $broken = !in_array($matches['anchor'], $page->getAnchorsOnPage());
                 } else {
                     $broken = false;
                 }

--- a/tests/php/Model/SiteTreeLinkTrackingTest.php
+++ b/tests/php/Model/SiteTreeLinkTrackingTest.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use Page;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\SiteTreeLinkTracking_Parser;
 use SilverStripe\Control\Director;
 use SilverStripe\Dev\SapphireTest;
@@ -31,6 +32,8 @@ class SiteTreeLinkTrackingTest extends SapphireTest
 
     public function testParser()
     {
+        SiteTree::add_extension(Page::class, SiteTreeLinkTracking_Extension::class);
+
         // Shortcodes
         $this->assertTrue($this->isBroken('<a href="[sitetree_link,id=123]">link</a>'));
         $this->assertTrue($this->isBroken('<a href="[sitetree_link,id=123]#no-such-anchor">link</a>'));
@@ -52,6 +55,7 @@ class SiteTreeLinkTrackingTest extends SapphireTest
         $this->assertFalse($this->isBroken('<a id="anchor">anchor</a>'));
         $this->assertTrue($this->isBroken('<a href="##anchor">anchor</a>'));
 
+
         $page = new Page();
         $page->Content = '<a name="yes-name-anchor">name</a><a id="yes-id-anchor">id</a>';
         $page->write();
@@ -60,6 +64,10 @@ class SiteTreeLinkTrackingTest extends SapphireTest
         $this->assertFalse($this->isBroken("<a href=\"[sitetree_link,id=$page->ID]#yes-name-anchor\">link</a>"));
         $this->assertFalse($this->isBroken("<a href=\"[sitetree_link,id=$page->ID]#yes-id-anchor\">link</a>"));
         $this->assertTrue($this->isBroken("<a href=\"[sitetree_link,id=$page->ID]#http://invalid-anchor.com\"></a>"));
+
+        // Anchors Via updateAnchorsOnPage Extension
+        $this->assertFalse($this->isBroken("<a href=\"[sitetree_link,id=$page->ID]#extension-anchor\">link</a>"));
+        $this->assertTrue($this->isBroken("<a href=\"[sitetree_link,id=$page->ID]#no-such-anchor\"></a>"));
     }
 
     protected function highlight($content)

--- a/tests/php/Model/SiteTreeLinkTracking_Extension.php
+++ b/tests/php/Model/SiteTreeLinkTracking_Extension.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Model;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataExtension;
+
+class SiteTreeLinkTracking_Extension extends DataExtension implements TestOnly
+{
+    public function updateAnchorsOnPage(&$anchors) {
+        array_push($anchors,
+            'extension-anchor',
+            'extension-anchor-1'
+        );
+    }
+}

--- a/tests/php/Model/SiteTreeLinkTracking_Extension.php
+++ b/tests/php/Model/SiteTreeLinkTracking_Extension.php
@@ -7,8 +7,10 @@ use SilverStripe\ORM\DataExtension;
 
 class SiteTreeLinkTracking_Extension extends DataExtension implements TestOnly
 {
-    public function updateAnchorsOnPage(&$anchors) {
-        array_push($anchors,
+    public function updateAnchorsOnPage(&$anchors)
+    {
+        array_push(
+            $anchors,
             'extension-anchor',
             'extension-anchor-1'
         );


### PR DESCRIPTION
Currently, the SiteTreeLinkTracking_Parser only checks the page's content for anchors.
As a result any anchors that have been added or modified by the updateAnchorsOnPage extension in the getAnchorsOnPage method are marked ss-broken.

This change updates SiteTreeLinkTracking_Parser to get the anchors from the getAnchorsOnPage function on SiteTree.
This will allow for more consistent RegEx matching and allow the updateAnchorsOnPage extension to be used when checking for broken links.