### PR TITLE
DOCS Change "SilverStripe" to "Silverstripe" in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## SilverStripe CMS
+## Silverstripe CMS
 
 [![Build Status](https://api.travis-ci.com/silverstripe/silverstripe-cms.svg?branch=4)](https://travis-ci.com/silverstripe/silverstripe-cms)
 [![Latest Stable Version](https://poser.pugx.org/silverstripe/cms/version.svg)](http://www.silverstripe.org/stable-download/)
@@ -21,7 +21,7 @@ Please read our [issue reporting guidelines](https://docs.silverstripe.org/en/co
 
 ## Development and Contribution 
 
-If you would like to make changes to the SilverStripe core codebase, we have an extensive [guide to contributing code](https://docs.silverstripe.org/en/contributing/code).
+If you would like to make changes to the Silverstripe core codebase, we have an extensive [guide to contributing code](https://docs.silverstripe.org/en/contributing/code).
 
 ## Links
 


### PR DESCRIPTION
There was a relatively recent branding change from "SilverStripe" to "Silverstripe". This PR makes that change in the readme.

Note that the repository's description also still uses the old "SilverStripe" capitalisation.
![image](https://user-images.githubusercontent.com/36352093/150059209-df32146e-2405-486f-a481-9c1b33e1d051.png)

See also silverstripe/silverstripe-framework#10206