### PR TITLE
FIX SiteTree visibility field name

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2214,7 +2214,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         );
 
         $parentType->addExtraClass('noborder');
-        $visibility->setTitle($this->fieldLabel('Visibility'));
+        $visibility->setName('Visibility')->setTitle($this->fieldLabel('Visibility'));
 
 
         // This filter ensures that the ParentID dropdown selection does not show this node,


### PR DESCRIPTION
If not set explicitly, the field name is taken from the title and changes if the site uses a different locale. 