### PR TITLE
DEP Set PHP 7.4 as the minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "silverstripe/siteconfig": "^4.7@dev",
         "silverstripe/versioned": "^1.7@dev",
         "silverstripe/vendor-plugin": "^1.0",
-        "php": "^7.3 || ^8.0"
+        "php": "^7.4 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219