### PR TITLE
ENH Prefer dependency injection for GridFieldComponents

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1632,9 +1632,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         }
         $list = $this->getList($params, $parentID);
         $gridFieldConfig = GridFieldConfig::create()->addComponents(
-            new GridFieldSortableHeader(),
-            new GridFieldDataColumns(),
-            new GridFieldPaginator($this->config()->get('page_length'))
+            Injector::inst()->create(GridFieldSortableHeader::class),
+            Injector::inst()->create(GridFieldDataColumns::class),
+            Injector::inst()->createWithArgs(GridFieldPaginator::class, [$this->config()->get('page_length')])
         );
         if ($parentID) {
             $linkSpec = $this->LinkListViewChildren('%d');
@@ -1645,7 +1645,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
             );
             $this->setCurrentPageID($parentID);
         }
-        $gridField = new GridField('Page', 'Pages', $list, $gridFieldConfig);
+        $gridField = GridField::create('Page', 'Pages', $list, $gridFieldConfig);
         $gridField->setAttribute('cms-loading-ignore-url-params', true);
         /** @var GridFieldDataColumns $columns */
         $columns = $gridField->getConfig()->getComponentByType(GridFieldDataColumns::class);

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1996,7 +1996,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                         );
                     }
                 ]);
-            $dependentTable->getConfig()->addComponent(new GridFieldLazyLoader());
+            $dependentTable->getConfig()->addComponent(Injector::inst()->create(GridFieldLazyLoader::class));
         }
 
         $baseLink = Controller::join_links(


### PR DESCRIPTION
GridFieldComponents packaged with silverstripe/framework are injectable as of 4.11.0 (see silverstripe/silverstripe-framework#10204)
Explicitly invoking the injector here instead of using `create()` allows backwards compatability with framework < 4.11.0 while ensuring dependency injection is still used from 4.11.0 onwards.
See silverstripe/silverstripe-admin#1286 for (brief) discussion of this approach vs using `::create()`.