### PR TITLE
FIX Ensure search form start var is not a negative number

### DIFF
--- a/code/Search/SearchForm.php
+++ b/code/Search/SearchForm.php
@@ -163,7 +163,7 @@ class SearchForm extends Form
         $keywords = $this->addStarsToKeywords($keywords);
 
         $pageLength = $this->getPageLength();
-        $start = $request->requestVar('start') ?: 0;
+        $start = max(0, (int)$request->requestVar('start'));
 
         $booleanSearch =
             strpos($keywords, '"') !== false ||


### PR DESCRIPTION
If a user changes the search form URL start parameter to a negative number (`&start=-10`), this will cause a server error.

This change fixes this problem by making sure start is always an int and is never less than zero.