### PR TITLE
Fix search form ending in dash error

### DIFF
--- a/code/Search/SearchForm.php
+++ b/code/Search/SearchForm.php
@@ -146,7 +146,7 @@ class SearchForm extends Form
             }
         }
 
-        $keywords = $request->requestVar('Search');
+        $keywords = rtrim($request->requestVar('Search'), '- ');
 
         $andProcessor = function ($matches) {
             return ' +' . $matches[2] . ' +' . $matches[4] . ' ';


### PR DESCRIPTION
On the search form if a user's search ends in a dash it will cause a server error.

This change fixes this problem by trimming dashes and spaces from the end of the search term.