### PR TITLE
FIX Translate pagetype names in list view

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1653,7 +1653,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         // Don't allow navigating into children nodes on filtered lists
         $fields = [
             'getTreeTitle' => _t('SilverStripe\\CMS\\Model\\SiteTree.PAGETITLE', 'Page Title'),
-            'singular_name' => _t('SilverStripe\\CMS\\Model\\SiteTree.PAGETYPE', 'Page Type'),
+            'i18n_singular_name' => _t('SilverStripe\\CMS\\Model\\SiteTree.PAGETYPE', 'Page Type'),
             'LastEdited' => _t('SilverStripe\\CMS\\Model\\SiteTree.LASTUPDATED', 'Last Updated'),
         ];
         /** @var GridFieldSortableHeader $sortableHeader */


### PR DESCRIPTION
Currently the "Page Type" values in the sitetree list view aren't translated. e.g. in the below screenshot, the translation for "Virtual Page" isn't being pulled through.
![Screen Shot 2022-04-19 at 11 45 29 AM](https://user-images.githubusercontent.com/36352093/163918597-86ee91ad-74ba-4e27-955d-6f98fd6a93d9.png)