### PR TITLE
FIX Use publishRecursive() over doPublish()

### DIFF
--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -1817,7 +1817,7 @@ class SiteTreeTest extends SapphireTest
         // END DRAFT
 
         // BEGIN PUBLISHED
-        $page->doPublish();
+        $page->publishRecursive();
         $actions = $page->getCMSActions();
         $this->assertNull(
             $actions->fieldByName('MajorActions.action_save'),
@@ -1936,7 +1936,7 @@ class SiteTreeTest extends SapphireTest
         // END DRAFT
 
         // BEGIN PUBLISHED
-        $page->doPublish();
+        $page->publishRecursive();
         $actions = $page->getCMSActions();
 
         $this->assertEmpty(

--- a/tests/php/Search/DatabaseSearchEngineTest.php
+++ b/tests/php/Search/DatabaseSearchEngineTest.php
@@ -41,7 +41,7 @@ class DatabaseSearchEngineTest extends SapphireTest
         $page = new SiteTree();
         $page->Title = "This page provides food as bar";
         $page->write();
-        $page->doPublish();
+        $page->publishRecursive();
 
         $results = DB::get_conn()->searchEngine([ SiteTree::class, File::class ], "foo* as* bar*", 0, 100, "\"Relevance\" DESC", "", true);
 


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-cms/commit/e68a5ea43595b8755d4a79be79c464af3813939c

`doPublish()` is deprecated and will be removed in CMS 5.
https://github.com/silverstripe/silverstripe-versioned/blob/1e92ce290221f2c5e433c252363af153a7832df9/src/Versioned.php#L1821-L1825

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350