### PR TITLE
Rescue Master Branch PR: MNT Use SiteTree instead of Page in tests

### DIFF
--- a/tests/php/Controllers/CMSBatchActionsTest.php
+++ b/tests/php/Controllers/CMSBatchActionsTest.php
@@ -16,7 +16,6 @@ use SilverStripe\Versioned\Versioned;
  */
 class CMSBatchActionsTest extends SapphireTest
 {
-
     protected static $fixture_file = 'CMSBatchActionsTest.yml';
 
     protected function setUp(): void
@@ -145,7 +144,7 @@ class CMSBatchActionsTest extends SapphireTest
         $result = json_decode($action->run($list) ?? '', true);
         $this->assertEquals(
             [
-                $archivedxID => $archivedxID
+                $archivedxID => $archivedxID,
             ],
             $result['success']
         );
@@ -168,7 +167,7 @@ class CMSBatchActionsTest extends SapphireTest
                 // Order of archived is opposite to order items are passed in, as
                 // these are sorted by level first
                 $archivedID => $archivedID,
-                $archivedyID => $archivedyID
+                $archivedyID => $archivedyID,
             ],
             $result['success']
         );

--- a/tests/php/Controllers/CMSMainTest.yml
+++ b/tests/php/Controllers/CMSMainTest.yml
@@ -1,4 +1,4 @@
-Page:
+SilverStripe\CMS\Model\SiteTree:
   page1:
     Title: Page 1
     Sort: 1
@@ -10,11 +10,11 @@ Page:
     Sort: 3
   page31:
     Title: Page 3.1
-    Parent: =>Page.page3
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page3
     Sort: 1
   page32:
     Title: Page 3.2
-    Parent: =>Page.page3
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page3
     Sort: 2
   page4:
     Title: Page 4

--- a/tests/php/Controllers/CMSMainTest_ClassA.php
+++ b/tests/php/Controllers/CMSMainTest_ClassA.php
@@ -2,11 +2,11 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\ValidationException;
-use Page;
 
-class CMSMainTest_ClassA extends Page implements TestOnly
+class CMSMainTest_ClassA extends SiteTree implements TestOnly
 {
     private static $table_name = 'CMSMainTest_ClassA';
 

--- a/tests/php/Controllers/CMSMainTest_ClassB.php
+++ b/tests/php/Controllers/CMSMainTest_ClassB.php
@@ -2,11 +2,11 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\ValidationException;
-use Page;
 
-class CMSMainTest_ClassB extends Page implements TestOnly
+class CMSMainTest_ClassB extends SiteTree implements TestOnly
 {
     private static $table_name = 'CMSMainTest_ClassB';
 

--- a/tests/php/Controllers/CMSMainTest_HiddenClass.php
+++ b/tests/php/Controllers/CMSMainTest_HiddenClass.php
@@ -2,11 +2,10 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\HiddenClass;
-use Page;
 
-class CMSMainTest_HiddenClass extends Page implements TestOnly, HiddenClass
+class CMSMainTest_HiddenClass extends SiteTree implements TestOnly, HiddenClass
 {
-
 }

--- a/tests/php/Controllers/CMSMainTest_NotRoot.php
+++ b/tests/php/Controllers/CMSMainTest_NotRoot.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
-use Page;
 
-class CMSMainTest_NotRoot extends Page implements TestOnly
+class CMSMainTest_NotRoot extends SiteTree implements TestOnly
 {
     private static $table_name = 'CMSMainTest_NotRoot';
 

--- a/tests/php/Controllers/CMSPageHistoryControllerTest.php
+++ b/tests/php/Controllers/CMSPageHistoryControllerTest.php
@@ -2,16 +2,15 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
-use Page;
 use SilverStripe\CMS\Controllers\CMSPageHistoryController;
-use SilverStripe\CMS\Tests\Controllers\CMSPageHistoryControllerTest\HistoryController;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Forms\FieldGroup;
 use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\HTMLReadonlyField;
+use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\TextField;
 
 class CMSPageHistoryControllerTest extends FunctionalTest
@@ -40,7 +39,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
         $this->loginWithPermission('ADMIN');
 
         // creates a series of published, unpublished versions of a page
-        $this->page = new Page();
+        $this->page = new SiteTree();
         $this->page->URLSegment = "test";
         $this->page->Content = "new content";
         $this->page->write();
@@ -90,7 +89,12 @@ class CMSPageHistoryControllerTest extends FunctionalTest
         );
 
         // check that compare mode updates the message
-        $form = $controller->getEditForm($this->page->ID, null, $this->versionPublishCheck, $this->versionPublishCheck2);
+        $form = $controller->getEditForm(
+            $this->page->ID,
+            null,
+            $this->versionPublishCheck,
+            $this->versionPublishCheck2
+        );
         $this->assertStringContainsString(
             sprintf("Comparing versions %s", $this->versionPublishCheck),
             $form->Fields()->fieldByName('Root.Main.CurrentlyViewingMessage')->getContent()
@@ -108,7 +112,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
      */
     public function testVersionsForm()
     {
-        $this->get('admin/pages/legacyhistory/show/'. $this->page->ID);
+        $this->get('admin/pages/legacyhistory/show/' . $this->page->ID);
 
         $form = $this->cssParser()->getBySelector('#Form_VersionsForm');
 
@@ -127,7 +131,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
 
     public function testVersionsFormTableContainsInformation()
     {
-        $this->get('admin/pages/legacyhistory/show/'. $this->page->ID);
+        $this->get('admin/pages/legacyhistory/show/' . $this->page->ID);
         $form = $this->cssParser()->getBySelector('#Form_VersionsForm');
         $rows = $form[0]->xpath("fieldset/table/tbody/tr");
 
@@ -135,7 +139,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
             ['version' => $this->versionPublishCheck2, 'status' => 'published'],
             ['version' => $this->versionUnpublishedCheck2, 'status' => 'internal'],
             ['version' => $this->versionPublishCheck, 'status' => 'published'],
-            ['version' => $this->versionUnpublishedCheck, 'status' => 'internal']
+            ['version' => $this->versionUnpublishedCheck, 'status' => 'internal'],
         ];
 
         // goes the reverse order that we created in setUp()
@@ -153,7 +157,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
 
     public function testVersionsFormSelectsUnpublishedCheckbox()
     {
-        $this->get('admin/pages/legacyhistory/show/'. $this->page->ID);
+        $this->get('admin/pages/legacyhistory/show/' . $this->page->ID);
         $checkbox = $this->cssParser()->getBySelector('#Form_VersionsForm_ShowUnpublished');
 
         $this->assertThat($checkbox[0], $this->logicalNot($this->isNull()));
@@ -162,7 +166,7 @@ class CMSPageHistoryControllerTest extends FunctionalTest
         $this->assertThat($checked, $this->logicalNot($this->stringContains('checked')));
 
         // viewing an unpublished
-        $this->get('admin/pages/legacyhistory/show/'.$this->page->ID .'/'.$this->versionUnpublishedCheck);
+        $this->get('admin/pages/legacyhistory/show/' . $this->page->ID . '/' . $this->versionUnpublishedCheck);
         $checkbox = $this->cssParser()->getBySelector('#Form_VersionsForm_ShowUnpublished');
 
         $this->assertThat($checkbox[0], $this->logicalNot($this->isNull()));

--- a/tests/php/Controllers/CMSPageHistoryControllerTest.yml
+++ b/tests/php/Controllers/CMSPageHistoryControllerTest.yml
@@ -1,4 +1,4 @@
-Page:
+SilverStripe\CMS\Model\SiteTree:
   page1:
     Title: Page 1
     Sort: 1

--- a/tests/php/Controllers/CMSSiteTreeFilterTest.php
+++ b/tests/php/Controllers/CMSSiteTreeFilterTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
-use Page;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Versioned\Versioned;
 use SilverStripe\CMS\Controllers\CMSSiteTreeFilter_Search;
@@ -15,13 +14,12 @@ use SilverStripe\Dev\SapphireTest;
 
 class CMSSiteTreeFilterTest extends SapphireTest
 {
-
     protected static $fixture_file = 'CMSSiteTreeFilterTest.yml';
 
     public function testSearchFilterEmpty()
     {
-        $page1 = $this->objFromFixture('Page', 'page1');
-        $page2 = $this->objFromFixture('Page', 'page2');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
+        $page2 = $this->objFromFixture(SiteTree::class, 'page2');
 
         $f = new CMSSiteTreeFilter_Search();
         $results = $f->pagesIncluded();
@@ -32,8 +30,8 @@ class CMSSiteTreeFilterTest extends SapphireTest
 
     public function testSearchFilterByTitle()
     {
-        $page1 = $this->objFromFixture('Page', 'page1');
-        $page2 = $this->objFromFixture('Page', 'page2');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
+        $page2 = $this->objFromFixture(SiteTree::class, 'page2');
 
         $f = new CMSSiteTreeFilter_Search(['Title' => 'Page 1']);
         $results = $f->pagesIncluded();
@@ -49,7 +47,7 @@ class CMSSiteTreeFilterTest extends SapphireTest
 
     public function testUrlSegmentFilter()
     {
-        $page = $this->objFromFixture(Page::class, 'page8');
+        $page = $this->objFromFixture(SiteTree::class, 'page8');
 
         $filter = CMSSiteTreeFilter_Search::create(['Term' => 'lake-wanaka+adventure']);
         $this->assertTrue($filter->isPageIncluded($page));
@@ -60,8 +58,8 @@ class CMSSiteTreeFilterTest extends SapphireTest
 
     public function testIncludesParentsForNestedMatches()
     {
-        $parent = $this->objFromFixture('Page', 'page3');
-        $child = $this->objFromFixture('Page', 'page3b');
+        $parent = $this->objFromFixture(SiteTree::class, 'page3');
+        $child = $this->objFromFixture(SiteTree::class, 'page3b');
 
         $f = new CMSSiteTreeFilter_Search(['Title' => 'Page 3b']);
         $results = $f->pagesIncluded();
@@ -78,11 +76,11 @@ class CMSSiteTreeFilterTest extends SapphireTest
     public function testChangedPagesFilter()
     {
         /** @var Page $unchangedPage */
-        $unchangedPage = $this->objFromFixture('Page', 'page1');
+        $unchangedPage = $this->objFromFixture(SiteTree::class, 'page1');
         $unchangedPage->publishRecursive();
 
         /** @var Page $changedPage */
-        $changedPage = $this->objFromFixture('Page', 'page2');
+        $changedPage = $this->objFromFixture(SiteTree::class, 'page2');
         $changedPage->Title = 'Original';
         $changedPage->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
         $changedPage->Title = 'Changed';
@@ -121,7 +119,7 @@ class CMSSiteTreeFilterTest extends SapphireTest
 
     public function testDeletedPagesFilter()
     {
-        $deletedPage = $this->objFromFixture('Page', 'page2');
+        $deletedPage = $this->objFromFixture(SiteTree::class, 'page2');
         $deletedPage->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
         $deletedPageID = $deletedPage->ID;
         $deletedPage->delete();
@@ -141,7 +139,7 @@ class CMSSiteTreeFilterTest extends SapphireTest
 
     public function testStatusDraftPagesFilter()
     {
-        $draftPage = $this->objFromFixture('Page', 'page4');
+        $draftPage = $this->objFromFixture(SiteTree::class, 'page4');
         $draftPage = Versioned::get_one_by_stage(
             SiteTree::class,
             'Stage',
@@ -164,20 +162,23 @@ class CMSSiteTreeFilterTest extends SapphireTest
 
     public function testDateFromToLastSameDate()
     {
-        $draftPage = $this->objFromFixture('Page', 'page4');
+        $draftPage = $this->objFromFixture(SiteTree::class, 'page4');
         // Grab the date
         $date = substr($draftPage->LastEdited ?? '', 0, 10);
         // Filter with that date
         $filter = new CMSSiteTreeFilter_Search([
             'LastEditedFrom' => $date,
-            'LastEditedTo' => $date
+            'LastEditedTo' => $date,
         ]);
-        $this->assertTrue($filter->isPageIncluded($draftPage), 'Using the same date for from and to should show find that page');
+        $this->assertTrue(
+            $filter->isPageIncluded($draftPage),
+            'Using the same date for from and to should show find that page'
+        );
     }
 
     public function testStatusRemovedFromDraftFilter()
     {
-        $removedDraftPage = $this->objFromFixture('Page', 'page6');
+        $removedDraftPage = $this->objFromFixture(SiteTree::class, 'page6');
         $removedDraftPage->publishRecursive();
         $removedDraftPage->deleteFromStage('Stage');
         $removedDraftPage = Versioned::get_one_by_stage(
@@ -202,7 +203,7 @@ class CMSSiteTreeFilterTest extends SapphireTest
 
     public function testStatusDeletedFilter()
     {
-        $deletedPage = $this->objFromFixture('Page', 'page7');
+        $deletedPage = $this->objFromFixture(SiteTree::class, 'page7');
         $deletedPage->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
         $deletedPageID = $deletedPage->ID;
 

--- a/tests/php/Controllers/CMSSiteTreeFilterTest.yml
+++ b/tests/php/Controllers/CMSSiteTreeFilterTest.yml
@@ -1,4 +1,4 @@
-Page:
+SilverStripe\CMS\Model\SiteTree:
   page1:
     Title: Page 1
   page2:
@@ -15,19 +15,19 @@ Page:
   page7:
     Title: Page 7
   page7a:
-    Parent: =>Page.page7
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page7
     Title: Page 7a
   page2a:
-    Parent: =>Page.page2
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page2
     Title: Page 2a
   page2b:
-    Parent: =>Page.page2
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page2
     Title: Page 2b
   page3a:
-    Parent: =>Page.page3
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page3
     Title: Page 3a
   page3b:
-    Parent: =>Page.page3
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page3
     Title: Page 3b
   page8:
     Title: EncodedUrlSegment

--- a/tests/php/Controllers/CMSTreeTest.php
+++ b/tests/php/Controllers/CMSTreeTest.php
@@ -32,7 +32,7 @@ class CMSTreeTest extends FunctionalTest
         $data = [
             'SiblingIDs' => $siblingIDs,
             'ID' => $page2->ID,
-            'ParentID' => 0
+            'ParentID' => 0,
         ];
 
         $response = $this->post('admin/pages/edit/savetreenode', $data);
@@ -62,12 +62,12 @@ class CMSTreeTest extends FunctionalTest
         $siblingIDs = [
             $page31->ID,
             $page2->ID,
-            $page32->ID
+            $page32->ID,
         ];
         $data = [
             'SiblingIDs' => $siblingIDs,
             'ID' => $page2->ID,
-            'ParentID' => $page3->ID
+            'ParentID' => $page3->ID,
         ];
         $response = $this->post('admin/pages/edit/savetreenode', $data);
         $this->assertEquals(200, $response->getStatusCode());
@@ -95,7 +95,7 @@ class CMSTreeTest extends FunctionalTest
         $this->logInWithPermission('ADMIN');
 
         // Check page
-        $result = $this->get('admin/pages/edit/updatetreenodes?ids='.$page1->ID);
+        $result = $this->get('admin/pages/edit/updatetreenodes?ids=' . $page1->ID);
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertEquals('application/json', $result->getHeader('Content-Type'));
         $data = json_decode($result->getBody() ?? '', true);
@@ -105,7 +105,7 @@ class CMSTreeTest extends FunctionalTest
         $this->assertEmpty($pageData['PrevID']);
 
         // check subpage
-        $result = $this->get('admin/pages/edit/updatetreenodes?ids='.$page31->ID);
+        $result = $this->get('admin/pages/edit/updatetreenodes?ids=' . $page31->ID);
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertEquals('application/json', $result->getHeader('Content-Type'));
         $data = json_decode($result->getBody() ?? '', true);
@@ -115,7 +115,7 @@ class CMSTreeTest extends FunctionalTest
         $this->assertEmpty($pageData['PrevID']);
 
         // Multiple pages
-        $result = $this->get('admin/pages/edit/updatetreenodes?ids='.$page1->ID.','.$page2->ID);
+        $result = $this->get('admin/pages/edit/updatetreenodes?ids=' . $page1->ID . ',' . $page2->ID);
         $this->assertEquals(200, $result->getStatusCode());
         $this->assertEquals('application/json', $result->getHeader('Content-Type'));
         $data = json_decode($result->getBody() ?? '', true);

--- a/tests/php/Controllers/ContentControllerPermissionsTest.php
+++ b/tests/php/Controllers/ContentControllerPermissionsTest.php
@@ -6,7 +6,7 @@ use SilverStripe\Versioned\Versioned;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\FunctionalTest;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
 class ContentControllerPermissionsTest extends FunctionalTest
 {
@@ -17,7 +17,7 @@ class ContentControllerPermissionsTest extends FunctionalTest
     public function testCanViewStage()
     {
         // Create a new page
-        $page = new Page();
+        $page = new SiteTree();
         $page->URLSegment = 'testpage';
         $page->write();
         $page->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
@@ -38,7 +38,11 @@ class ContentControllerPermissionsTest extends FunctionalTest
             $response = $responseException->getResponse();
         }
         // should redirect to login
-        $this->assertEquals($response->getStatusCode(), 302, 'Redirects to login page when not logged in for draft stage');
+        $this->assertEquals(
+            $response->getStatusCode(),
+            302,
+            'Redirects to login page when not logged in for draft stage'
+        );
         $this->assertStringContainsString(
             Config::inst()->get('SilverStripe\\Security\\Security', 'login_url'),
             $response->getHeader('Location')
@@ -47,6 +51,10 @@ class ContentControllerPermissionsTest extends FunctionalTest
         $this->logInWithPermission('CMS_ACCESS_CMSMain');
 
         $response = $this->get('/testpage/?stage=Stage');
-        $this->assertEquals($response->getStatusCode(), 200, 'Doesnt redirect to login, but shows page for authenticated user');
+        $this->assertEquals(
+            $response->getStatusCode(),
+            200,
+            'Doesnt redirect to login, but shows page for authenticated user'
+        );
     }
 }

--- a/tests/php/Controllers/ContentControllerSearchExtensionTest.php
+++ b/tests/php/Controllers/ContentControllerSearchExtensionTest.php
@@ -4,23 +4,23 @@ namespace SilverStripe\CMS\Tests\Controllers;
 
 use SilverStripe\Assets\File;
 use SilverStripe\CMS\Controllers\ContentController;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Search\ContentControllerSearchExtension;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\Search\FulltextSearchable;
 use SilverStripe\Versioned\Versioned;
-use Page;
 
 class ContentControllerSearchExtensionTest extends SapphireTest
 {
     protected static $required_extensions = [
         ContentController::class => [
             ContentControllerSearchExtension::class,
-        ]
+        ],
     ];
 
     public function testCustomSearchFormClassesToTest()
     {
-        $page = new Page();
+        $page = new SiteTree();
         $page->URLSegment = 'whatever';
         $page->Content = 'oh really?';
         $page->write();

--- a/tests/php/Controllers/ContentControllerTest.php
+++ b/tests/php/Controllers/ContentControllerTest.php
@@ -10,7 +10,6 @@ use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Versioned\Versioned;
-use Page;
 
 class ContentControllerTest extends FunctionalTest
 {
@@ -31,8 +30,8 @@ class ContentControllerTest extends FunctionalTest
         Config::modify()->set(SiteTree::class, 'nested_urls', true);
 
         // Ensure all pages are published
-        /** @var Page $page */
-        foreach (Page::get() as $page) {
+        /** @var SiteTree $page */
+        foreach (SiteTree::get() as $page) {
             $page->publishSingle();
         }
     }
@@ -95,8 +94,7 @@ class ContentControllerTest extends FunctionalTest
 
     public function testDeepNestedURLs()
     {
-
-        $page = new Page();
+        $page = new SiteTree();
         $page->URLSegment = 'base-page';
         $page->write();
         $page->publishSingle();
@@ -174,7 +172,7 @@ class ContentControllerTest extends FunctionalTest
             $response = $this->get($page->RelativeLink());
             $this->assertEquals("ContentControllerTestPageWithoutController", trim($response->getBody() ?? ''));
 
-            // // This should fall over to user Page.ss
+            // This should fall over to user Page.ss
             $page = new ContentControllerTestPage();
             $page->URLSegment = "test";
             $page->write();

--- a/tests/php/Controllers/ContentControllerTestPage.php
+++ b/tests/php/Controllers/ContentControllerTestPage.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
-use Page;
 
-class ContentControllerTestPage extends Page implements TestOnly
+class ContentControllerTestPage extends SiteTree implements TestOnly
 {
     private static $table_name = 'ContentControllerTestPage';
 }

--- a/tests/php/Controllers/ContentControllerTestPageController.php
+++ b/tests/php/Controllers/ContentControllerTestPageController.php
@@ -9,7 +9,7 @@ class ContentControllerTestPageController extends PageController implements Test
 {
     private static $allowed_actions = [
         'test',
-        'testwithouttemplate'
+        'testwithouttemplate',
     ];
 
     public function testwithouttemplate()

--- a/tests/php/Controllers/ContentControllerTestPageWithoutController.php
+++ b/tests/php/Controllers/ContentControllerTestPageWithoutController.php
@@ -2,10 +2,9 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
-use Page;
 
-class ContentControllerTestPageWithoutController extends Page implements TestOnly
+class ContentControllerTestPageWithoutController extends SiteTree implements TestOnly
 {
-
 }

--- a/tests/php/Controllers/ContentControllerTest_Page.php
+++ b/tests/php/Controllers/ContentControllerTest_Page.php
@@ -2,10 +2,10 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\TestOnly;
-use Page;
 
-class ContentControllerTest_Page extends Page implements TestOnly
+class ContentControllerTest_Page extends SiteTree implements TestOnly
 {
     private static $table_name = 'ContentControllerTest_Page';
 }

--- a/tests/php/Controllers/ContentControllerTest_PageController.php
+++ b/tests/php/Controllers/ContentControllerTest_PageController.php
@@ -2,14 +2,13 @@
 
 namespace SilverStripe\CMS\Tests\Controllers;
 
+use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\Dev\TestOnly;
-use PageController;
 
-class ContentControllerTest_PageController extends PageController implements TestOnly
+class ContentControllerTest_PageController extends ContentController implements TestOnly
 {
-
     private static $allowed_actions = [
-        'second_index'
+        'second_index',
     ];
 
     public function index()

--- a/tests/php/Controllers/ModelAsControllerTest.php
+++ b/tests/php/Controllers/ModelAsControllerTest.php
@@ -10,7 +10,6 @@ use SilverStripe\Core\Config\Config;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\Controller;
 use SilverStripe\Dev\FunctionalTest;
-use Page;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 
 class ModelAsControllerTest extends FunctionalTest
@@ -34,7 +33,7 @@ class ModelAsControllerTest extends FunctionalTest
 
     protected function generateNestedPagesFixture()
     {
-        $level1 = new Page();
+        $level1 = new SiteTree();
         $level1->Title      = 'First Level';
         $level1->URLSegment = 'level1';
         $level1->write();
@@ -44,7 +43,7 @@ class ModelAsControllerTest extends FunctionalTest
         $level1->write();
         $level1->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
-        $level2 = new Page();
+        $level2 = new SiteTree();
         $level2->Title      = 'Second Level';
         $level2->URLSegment = 'level2';
         $level2->ParentID = $level1->ID;
@@ -55,7 +54,7 @@ class ModelAsControllerTest extends FunctionalTest
         $level2->write();
         $level2->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
-        $level3 = new Page();
+        $level3 = new SiteTree();
         $level3->Title = "Level 3";
         $level3->URLSegment = 'level3';
         $level3->ParentID = $level2->ID;
@@ -115,7 +114,7 @@ class ModelAsControllerTest extends FunctionalTest
      */
     public function testHeavilyNestedRenamedRedirectedPages()
     {
-        $page = new Page();
+        $page = new SiteTree();
         $page->Title      = 'First Level';
         $page->URLSegment = 'oldurl';
         $page->write();
@@ -125,28 +124,28 @@ class ModelAsControllerTest extends FunctionalTest
         $page->write();
         $page->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
-        $page2 = new Page();
+        $page2 = new SiteTree();
         $page2->Title      = 'Second Level Page';
         $page2->URLSegment = 'level2';
         $page2->ParentID = $page->ID;
         $page2->write();
         $page2->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
-        $page3 = new Page();
+        $page3 = new SiteTree();
         $page3->Title      = 'Third Level Page';
         $page3->URLSegment = 'level3';
         $page3->ParentID = $page2->ID;
         $page3->write();
         $page3->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
-        $page4 = new Page();
+        $page4 = new SiteTree();
         $page4->Title      = 'Fourth Level Page';
         $page4->URLSegment = 'level4';
         $page4->ParentID = $page3->ID;
         $page4->write();
         $page4->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
-        $page5 = new Page();
+        $page5 = new SiteTree();
         $page5->Title      = 'Fifth Level Page';
         $page5->URLSegment = 'level5';
         $page5->ParentID = $page4->ID;
@@ -188,8 +187,8 @@ class ModelAsControllerTest extends FunctionalTest
     {
         $this->generateNestedPagesFixture();
 
-        $otherParent = new Page([
-            'URLSegment' => 'otherparent'
+        $otherParent = new SiteTree([
+            'URLSegment' => 'otherparent',
         ]);
         $otherParent->write();
         $otherParent->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
@@ -232,9 +231,9 @@ class ModelAsControllerTest extends FunctionalTest
     {
         $this->generateNestedPagesFixture();
 
-        $otherLevel1 = new Page([
+        $otherLevel1 = new SiteTree([
             'Title' => "Other Level 1",
-            'URLSegment' => 'level1'
+            'URLSegment' => 'level1',
         ]);
         $otherLevel1->write();
         $otherLevel1->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
@@ -260,7 +259,7 @@ class ModelAsControllerTest extends FunctionalTest
      */
     public function testFindOldPage()
     {
-        $page = new Page();
+        $page = new SiteTree();
         $page->Title      = 'First Level';
         $page->URLSegment = 'oldurl';
         $page->write();
@@ -274,7 +273,7 @@ class ModelAsControllerTest extends FunctionalTest
         $matchedPage = SiteTree::get_by_link($url);
         $this->assertEquals('First Level', $matchedPage->Title);
 
-        $page2 = new Page();
+        $page2 = new SiteTree();
         $page2->Title      = 'Second Level Page';
         $page2->URLSegment = 'oldpage2';
         $page2->ParentID = $page->ID;
@@ -304,12 +303,12 @@ class ModelAsControllerTest extends FunctionalTest
         RootURLController::reset();
         Config::modify()->set(SiteTree::class, 'nested_urls', true);
 
-        $draft = new Page();
+        $draft = new SiteTree();
         $draft->Title = 'Root Leve Draft Page';
         $draft->URLSegment = 'root';
         $draft->write();
 
-        $published = new Page();
+        $published = new SiteTree();
         $published->Title = 'Published Page Under Draft Page';
         $published->URLSegment = 'sub-root';
         $published->write();
@@ -319,7 +318,8 @@ class ModelAsControllerTest extends FunctionalTest
         $this->assertEquals(
             $response->getStatusCode(),
             404,
-            'The page should not be found since its parent has not been published, in this case http://<yousitename>/root/sub-root or http://<yousitename>/sub-root'
+            'The page should not be found since its parent has not been published, in this case ' .
+            'http://<yousitename>/root/sub-root or http://<yousitename>/sub-root'
         );
     }
 
@@ -327,13 +327,13 @@ class ModelAsControllerTest extends FunctionalTest
     {
         Config::modify()->set(URLSegmentFilter::class, 'default_allow_multibyte', true);
 
-        $parent = new Page();
+        $parent = new SiteTree();
         $parent->Title = 'Multibyte test';
         $parent->URLSegment = 'بلاگ';
         $parent->write();
         $parent->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
-        $child = new Page();
+        $child = new SiteTree();
         $child->Title = 'Multibyte test';
         $child->URLSegment = 'فضة';
         $child->ParentID = $parent->ID;

--- a/tests/php/Controllers/RootURLControllerTest.php
+++ b/tests/php/Controllers/RootURLControllerTest.php
@@ -13,7 +13,7 @@ class RootURLControllerTest extends SapphireTest
 
     public function testGetHomepageLink()
     {
-        $default = $this->objFromFixture('Page', 'home');
+        $default = $this->objFromFixture(SiteTree::class, 'home');
 
         Config::modify()->set(SiteTree::class, 'nested_urls', false);
         $this->assertEquals('home', RootURLController::get_homepage_link());

--- a/tests/php/Controllers/RootURLControllerTest.yml
+++ b/tests/php/Controllers/RootURLControllerTest.yml
@@ -1,9 +1,9 @@
-Page:
+SilverStripe\CMS\Model\SiteTree:
   home:
     Title: Home
   nested:
     Title: Nested Home
-    Parent: =>Page.home
+    Parent: =>SilverStripe\CMS\Model\SiteTree.home
   page1:
     Title: First Page
     URLSegment: page1

--- a/tests/php/Controllers/SilverStripeNavigatorTest.php
+++ b/tests/php/Controllers/SilverStripeNavigatorTest.php
@@ -8,7 +8,6 @@ use SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_LiveLink;
 use SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_StageLink;
 use SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_Unversioned;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Security\Member;
 
 class SilverStripeNavigatorTest extends SapphireTest
 {

--- a/tests/php/GraphQL/LinkablePluginTest.php
+++ b/tests/php/GraphQL/LinkablePluginTest.php
@@ -44,7 +44,7 @@ class LinkablePluginTest extends SapphireTest
 
     public function testResolver()
     {
-        $page = SiteTree::create([
+        $page = new SiteTree([
             'Title' => 'Test page',
             'URLSegment' => 'test-page',
             'ParentID' => 0,
@@ -52,7 +52,7 @@ class LinkablePluginTest extends SapphireTest
         $page->write();
         $page->publishRecursive();
 
-        $page = SiteTree::create([
+        $page = new SiteTree([
             'Title' => 'Other test page',
             'URLSegment' => 'other-test-page',
             'ParentID' => 0,

--- a/tests/php/Model/RedirectorPageTest.php
+++ b/tests/php/Model/RedirectorPageTest.php
@@ -2,7 +2,7 @@
 
 namespace SilverStripe\CMS\Tests\Model;
 
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\RedirectorPageController;
 use SilverStripe\Control\Director;
@@ -36,31 +36,41 @@ class RedirectorPageTest extends FunctionalTest
         Director::config()->update('alternate_base_url', 'http://www.mysite.com/');
 
         // Ensure all pages are published
-        /** @var Page $page */
-        foreach (Page::get() as $page) {
+        /** @var SiteTree $page */
+        foreach (SiteTree::get() as $page) {
             $page->publishSingle();
         }
     }
 
     public function testGoodRedirectors()
     {
-        /* For good redirectors, the final destination URL will be returned */
-        $this->assertEquals("http://www.google.com", $this->objFromFixture(RedirectorPage::class, 'goodexternal')->Link());
-        $this->assertEquals("/redirection-dest/", $this->objFromFixture(RedirectorPage::class, 'goodinternal')->redirectionLink());
-        $this->assertEquals("/redirection-dest/", $this->objFromFixture(RedirectorPage::class, 'goodinternal')->Link());
+        // For good redirectors, the final destination URL will be returned
+        $this->assertEquals(
+            "http://www.google.com",
+            $this->objFromFixture(RedirectorPage::class, 'goodexternal')->Link()
+        );
+        $this->assertEquals(
+            "/redirection-dest/",
+            $this->objFromFixture(RedirectorPage::class, 'goodinternal')->redirectionLink()
+        );
+        $this->assertEquals(
+            "/redirection-dest/",
+            $this->objFromFixture(RedirectorPage::class, 'goodinternal')->Link()
+        );
     }
 
     public function testEmptyRedirectors()
     {
-        /* If a redirector page is misconfigured, then its link method will just return the usual URLSegment-generated value */
+        // If a redirector page is misconfigured, then its link method will just return the usual
+        // URLSegment-generated value
         $page1 = $this->objFromFixture(RedirectorPage::class, 'badexternal');
         $this->assertEquals('/bad-external/', $page1->Link());
 
-        /* An error message will be shown if you visit it */
+        // An error message will be shown if you visit it
         $content = $this->get(Director::makeRelative($page1->Link()))->getBody();
         $this->assertStringContainsString('message-setupWithoutRedirect', $content);
 
-        /* This also applies for internal links */
+        // This also applies for internal links
         $page2 = $this->objFromFixture(RedirectorPage::class, 'badinternal');
         $this->assertEquals('/bad-internal/', $page2->Link());
         $content = $this->get(Director::makeRelative($page2->Link()))->getBody();
@@ -69,14 +79,16 @@ class RedirectorPageTest extends FunctionalTest
 
     public function testReflexiveAndTransitiveInternalRedirectors()
     {
-        /* Reflexive redirectors are those that point to themselves.  They should behave the same as an empty redirector */
+        // Reflexive redirectors are those that point to themselves.
+        // They should behave the same as an empty redirector
         $page = $this->objFromFixture(RedirectorPage::class, 'reflexive');
         $this->assertEquals('/reflexive/', $page->Link());
         $content = $this->get(Director::makeRelative($page->Link()))->getBody();
         $this->assertStringContainsString('message-setupWithoutRedirect', $content);
 
-        /* Transitive redirectors are those that point to another redirector page.  They should send people to the URLSegment
-         * of the destination page - the middle-stop, so to speak.  That should redirect to the final destination */
+        // Transitive redirectors are those that point to another redirector page.
+        // They should send people to the URLSegment of the destination page - the middle-stop, so to speak.
+        // That should redirect to the final destination
         $page = $this->objFromFixture(RedirectorPage::class, 'transitive');
         $this->assertEquals('/good-internal/', $page->Link());
 
@@ -90,7 +102,11 @@ class RedirectorPageTest extends FunctionalTest
         $page = $this->objFromFixture(RedirectorPage::class, 'externalnoprefix');
         $this->assertEquals($page->ExternalURL, 'http://google.com', 'onBeforeWrite has prefixed with http');
         $page->write();
-        $this->assertEquals($page->ExternalURL, 'http://google.com', 'onBeforeWrite will not double prefix if written again!');
+        $this->assertEquals(
+            $page->ExternalURL,
+            'http://google.com',
+            'onBeforeWrite will not double prefix if written again!'
+        );
     }
 
     public function testAllowsProtocolRelative()

--- a/tests/php/Model/RedirectorPageTest.yml
+++ b/tests/php/Model/RedirectorPageTest.yml
@@ -1,4 +1,4 @@
-Page:
+SilverStripe\CMS\Model\SiteTree:
   dest:
     Title: Redirection Dest
     URLSegment: redirection-dest
@@ -17,7 +17,7 @@ SilverStripe\CMS\Model\RedirectorPage:
     Title: Good Internal
     URLSegment: good-internal
     RedirectionType: Internal
-    LinkTo: =>Page.dest
+    LinkTo: =>SilverStripe\CMS\Model\SiteTree.dest
   badexternal:
     Title: Bad External
     RedirectionType: External

--- a/tests/php/Model/SiteTreeActionsTest.php
+++ b/tests/php/Model/SiteTreeActionsTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Tests\Model;
 
-use Page;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\ORM\DB;
@@ -21,7 +20,6 @@ use SilverStripe\Versioned\Versioned;
  */
 class SiteTreeActionsTest extends FunctionalTest
 {
-
     protected static $fixture_file = 'SiteTreeActionsTest.yml';
 
     public function testActionsReadonly()
@@ -38,7 +36,7 @@ class SiteTreeActionsTest extends FunctionalTest
         Security::setCurrentUser($readonlyEditor);
 
         // Reload latest version
-        $page = Page::get()->byID($page->ID);
+        $page = SiteTree::get()->byID($page->ID);
         $actions = $page->getCMSActions();
 
         $this->assertNull($actions->dataFieldByName('action_save'));
@@ -84,14 +82,14 @@ class SiteTreeActionsTest extends FunctionalTest
         $author = $this->objFromFixture(Member::class, 'cmseditor');
         Security::setCurrentUser($author);
 
-        /** @var Page $page */
-        $page = new Page();
+        /** @var SiteTree $page */
+        $page = new SiteTree();
         $page->CanEditType = 'LoggedInUsers';
         $page->write();
         $page->publishRecursive();
 
         // Reload latest version
-        $page = Page::get()->byID($page->ID);
+        $page = SiteTree::get()->byID($page->ID);
 
         $actions = $page->getCMSActions();
 
@@ -108,7 +106,7 @@ class SiteTreeActionsTest extends FunctionalTest
         $author = $this->objFromFixture(Member::class, 'cmseditor');
         Security::setCurrentUser($author);
 
-        $page = new Page();
+        $page = new SiteTree();
         $page->CanEditType = 'LoggedInUsers';
         $page->write();
         $this->assertTrue($page->canPublish());
@@ -135,7 +133,7 @@ class SiteTreeActionsTest extends FunctionalTest
         $author = $this->objFromFixture(Member::class, 'cmseditor');
         Security::setCurrentUser($author);
 
-        $page = new Page();
+        $page = new SiteTree();
         $page->CanEditType = 'LoggedInUsers';
         $page->write();
         $this->assertTrue($page->canPublish());
@@ -145,7 +143,7 @@ class SiteTreeActionsTest extends FunctionalTest
         $page->flushCache();
 
         // Reload latest version
-        $page = Page::get()->byID($page->ID);
+        $page = SiteTree::get()->byID($page->ID);
 
         $actions = $page->getCMSActions();
         $this->assertNotNull($actions->dataFieldByName('action_save'));
@@ -158,15 +156,17 @@ class SiteTreeActionsTest extends FunctionalTest
 
     public function testActionsViewingOldVersion()
     {
-        $p = new Page();
+        $p = new SiteTree();
         $p->Content = 'test page first version';
         $p->write();
         $p->Content = 'new content';
         $p->write();
 
         // Looking at the old version, the ability to rollback to that version is available
-        $version = DB::query('SELECT "Version" FROM "SiteTree_Versions" WHERE "Content" = \'test page first version\'')->value();
-        $old = Versioned::get_version('Page', $p->ID, $version);
+        $version = DB::query(
+            'SELECT "Version" FROM "SiteTree_Versions" WHERE "Content" = \'test page first version\''
+        )->value();
+        $old = Versioned::get_version(SiteTree::class, $p->ID, $version);
         $actions = $old->getCMSActions();
         $this->assertNull($actions->dataFieldByName('action_save'));
         $this->assertNull($actions->dataFieldByName('action_publish'));

--- a/tests/php/Model/SiteTreeActionsTest_Page.php
+++ b/tests/php/Model/SiteTreeActionsTest_Page.php
@@ -4,9 +4,9 @@ namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\Security\Permission;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeActionsTest_Page extends Page implements TestOnly
+class SiteTreeActionsTest_Page extends SiteTree implements TestOnly
 {
     public function canEdit($member = null)
     {

--- a/tests/php/Model/SiteTreeBacklinksTest.php
+++ b/tests/php/Model/SiteTreeBacklinksTest.php
@@ -18,7 +18,7 @@ class SiteTreeBacklinksTest extends SapphireTest
 
     protected static $required_extensions = [
         SiteTree::class => [
-            SiteTreeBacklinksTest_DOD::class
+            SiteTreeBacklinksTest_DOD::class,
         ],
     ];
 
@@ -34,10 +34,10 @@ class SiteTreeBacklinksTest extends SapphireTest
         // testing here.
         $this->logInWithPermission('ADMIN');
 
-        $page3 = $this->objFromFixture('Page', 'page3');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
         $page3->Content = str_replace(
             '$page1.ID',
-            $this->objFromFixture('Page', 'page1')->ID ?? '',
+            $this->objFromFixture(SiteTree::class, 'page1')->ID ?? '',
             $page3->Content ?? ''
         );
         $page3->write();
@@ -46,18 +46,22 @@ class SiteTreeBacklinksTest extends SapphireTest
     public function testSavingPageWithLinkAddsBacklink()
     {
         // load page 1
-        $page1 = $this->objFromFixture('Page', 'page1');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
 
         // assert backlink to page 2 doesn't exist
-        $page2 = $this->objFromFixture('Page', 'page2');
-        $this->assertNotContains($page2->ID, $page1->BackLinkTracking()->column('ID'), 'Assert backlink to page 2 doesn\'t exist');
+        $page2 = $this->objFromFixture(SiteTree::class, 'page2');
+        $this->assertNotContains(
+            $page2->ID,
+            $page1->BackLinkTracking()->column('ID'),
+            'Assert backlink to page 2 doesn\'t exist'
+        );
 
         // add hyperlink to page 1 on page 2
-        $page2->Content .= '<p><a href="[sitetree_link,id='.$page1->ID.']">Testing page 1 link</a></p>';
+        $page2->Content .= '<p><a href="[sitetree_link,id=' . $page1->ID . ']">Testing page 1 link</a></p>';
         $page2->write();
 
         // load page 1
-        $page1 = $this->objFromFixture('Page', 'page1');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
 
         // assert backlink to page 2 exists
         $this->assertContains($page2->ID, $page1->BackLinkTracking()->column('ID'), 'Assert backlink to page 2 exists');
@@ -66,10 +70,10 @@ class SiteTreeBacklinksTest extends SapphireTest
     public function testRemovingLinkFromPageRemovesBacklink()
     {
         // load page 1
-        $page1 = $this->objFromFixture('Page', 'page1');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
 
         // assert backlink to page 3 exits
-        $page3 = $this->objFromFixture('Page', 'page3');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
         $this->assertContains($page3->ID, $page1->BackLinkTracking()->column('ID'), 'Assert backlink to page 3 exists');
 
         // remove hyperlink to page 1
@@ -77,116 +81,156 @@ class SiteTreeBacklinksTest extends SapphireTest
         $page3->write();
 
         // load page 1
-        $page1 = $this->objFromFixture('Page', 'page1');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
 
         // assert backlink to page 3 exists
-        $this->assertNotContains($page3->ID, $page1->BackLinkTracking()->column('ID'), 'Assert backlink to page 3 doesn\'t exist');
+        $this->assertNotContains(
+            $page3->ID,
+            $page1->BackLinkTracking()->column('ID'),
+            'Assert backlink to page 3 doesn\'t exist'
+        );
     }
 
     public function testChangingUrlOnDraftSiteRewritesLink()
     {
         // load page 1
-        $page1 = $this->objFromFixture('Page', 'page1');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
 
         // assert backlink to page 3 exists
-        $page3 = $this->objFromFixture('Page', 'page3');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
         $this->assertContains($page3->ID, $page1->BackLinkTracking()->column('ID'), 'Assert backlink to page 3 exists');
 
         // assert hyperlink to page 1's current url exists on page 3
         $links = HTTP::getLinksIn($page3->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'page1/',
+            $links,
+            'Assert hyperlink to page 1\'s current url exists on page 3'
+        );
 
         // change url of page 1
         $page1->URLSegment = 'new-url-segment';
         $page1->write();
 
         // load page 3
-        $page3 = $this->objFromFixture('Page', 'page3');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
 
         // assert hyperlink to page 1's new url exists
         $links = HTTP::getLinksIn($page3->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s new url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'new-url-segment/',
+            $links,
+            'Assert hyperlink to page 1\'s new url exists on page 3'
+        );
     }
 
     public function testChangingUrlOnLiveSiteRewritesLink()
     {
         // publish page 1 & 3
-        $page1 = $this->objFromFixture('Page', 'page1');
-        $page3 = $this->objFromFixture('Page', 'page3');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
         $this->assertTrue($page1->publishRecursive());
         $this->assertTrue($page3->publishRecursive());
 
         // load pages from live
-        $page1live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page1->ID);
-        $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
+        $page1live = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $page1->ID);
+        $page3live = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $page3->ID);
 
         // assert backlink to page 3 exists
-        $this->assertContains($page3live->ID, $page1live->BackLinkTracking()->column('ID'), 'Assert backlink to page 3 exists');
+        $this->assertContains(
+            $page3live->ID,
+            $page1live->BackLinkTracking()->column('ID'),
+            'Assert backlink to page 3 exists'
+        );
 
         // assert hyperlink to page 1's current url exists on page 3
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'page1/',
+            $links,
+            'Assert hyperlink to page 1\'s current url exists on page 3'
+        );
 
         // change url of page 1
         $page1live->URLSegment = 'new-url-segment';
         $page1live->writeToStage('Live');
 
         // load page 3 from live
-        $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
+        $page3live = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $page3->ID);
 
         // assert hyperlink to page 1's new url exists
         Versioned::set_stage(Versioned::LIVE);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s new url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'new-url-segment/',
+            $links,
+            'Assert hyperlink to page 1\'s new url exists on page 3'
+        );
     }
 
     public function testPublishingPageWithModifiedUrlRewritesLink()
     {
         // publish page 1 & 3
-        $page1 = $this->objFromFixture('Page', 'page1');
-        $page3 = $this->objFromFixture('Page', 'page3');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
 
         $this->assertTrue($page1->publishRecursive());
         $this->assertTrue($page3->publishRecursive());
 
         // load page 3 from live
-        $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
+        $page3live = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $page3->ID);
 
         // assert hyperlink to page 1's current url exists
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'page1/',
+            $links,
+            'Assert hyperlink to page 1\'s current url exists on page 3'
+        );
 
         // rename url of page 1 on stage
         $page1->URLSegment = 'new-url-segment';
         $page1->write();
 
         // assert hyperlink to page 1's current publish url exists
-        $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
+        $page3live = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $page3->ID);
         Versioned::set_stage(Versioned::LIVE);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'page1/',
+            $links,
+            'Assert hyperlink to page 1\'s current published url exists on page 3'
+        );
 
 
         // publish page 1
         $this->assertTrue($page1->publishRecursive());
 
         // assert hyperlink to page 1's new published url exists
-        $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
+        $page3live = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $page3->ID);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s new published url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'new-url-segment/',
+            $links,
+            'Assert hyperlink to page 1\'s new published url exists on page 3'
+        );
     }
 
     public function testPublishingPageWithModifiedLinksRewritesLinks()
     {
         // publish page 1 & 3
-        $page1 = $this->objFromFixture('Page', 'page1');
-        $page3 = $this->objFromFixture('Page', 'page3');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
         $this->assertTrue($page1->publishRecursive());
         $this->assertTrue($page3->publishRecursive());
 
         // assert hyperlink to page 1's current url exists
         $links = HTTP::getLinksIn($page3->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'page1/',
+            $links,
+            'Assert hyperlink to page 1\'s current published url exists on page 3'
+        );
 
         // change page 1 url on draft
         $page1->URLSegment = 'new-url-segment';
@@ -195,42 +239,58 @@ class SiteTreeBacklinksTest extends SapphireTest
         $page1->write();
 
         // assert page 3 on draft contains new page 1 url
-        $page3 = $this->objFromFixture('Page', 'page3');
+        $page3 = $this->objFromFixture(SiteTree::class, 'page3');
         $links = HTTP::getLinksIn($page3->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s current draft url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'new-url-segment/',
+            $links,
+            'Assert hyperlink to page 1\'s current draft url exists on page 3'
+        );
 
         // publish page 3
         $this->assertTrue($page3->publishRecursive());
 
         // assert page 3 on published site contains old page 1 url
-        $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
+        $page3live = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $page3->ID);
         Versioned::set_stage(Versioned::LIVE);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'page1/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'page1/',
+            $links,
+            'Assert hyperlink to page 1\'s current published url exists on page 3'
+        );
 
         // publish page 1
         $this->assertTrue($page1->publishRecursive());
 
         // assert page 3 on published site contains new page 1 url
-        $page3live = Versioned::get_one_by_stage('Page', 'Live', '"SiteTree"."ID" = ' . $page3->ID);
+        $page3live = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $page3->ID);
         $links = HTTP::getLinksIn($page3live->obj('Content')->forTemplate());
-        $this->assertContains(Director::baseURL().'new-url-segment/', $links, 'Assert hyperlink to page 1\'s current published url exists on page 3');
+        $this->assertContains(
+            Director::baseURL() . 'new-url-segment/',
+            $links,
+            'Assert hyperlink to page 1\'s current published url exists on page 3'
+        );
     }
 
     public function testLinkTrackingOnExtraContentFields()
     {
-        /** @var Page $page1 */
-        $page1 = $this->objFromFixture('Page', 'page1');
-        /** @var Page $page2 */
-        $page2 = $this->objFromFixture('Page', 'page2');
+        /** @var SiteTree $page1 */
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
+        /** @var SiteTree $page2 */
+        $page2 = $this->objFromFixture(SiteTree::class, 'page2');
         $page1->publishRecursive();
         $page2->publishRecursive();
 
         // assert backlink to page 2 doesn't exist
-        $this->assertNotContains($page2->ID, $page1->BackLinkTracking()->column('ID'), 'Assert backlink to page 2 doesn\'t exist');
+        $this->assertNotContains(
+            $page2->ID,
+            $page1->BackLinkTracking()->column('ID'),
+            'Assert backlink to page 2 doesn\'t exist'
+        );
 
         // add hyperlink to page 1 on page 2
-        $page2->ExtraContent .= '<p><a href="[sitetree_link,id='.$page1->ID.']">Testing page 1 link</a></p>';
+        $page2->ExtraContent .= '<p><a href="[sitetree_link,id=' . $page1->ID . ']">Testing page 1 link</a></p>';
         $page2->write();
         $page2->publishRecursive();
 
@@ -238,23 +298,32 @@ class SiteTreeBacklinksTest extends SapphireTest
         $this->assertContains($page2->ID, $page1->BackLinkTracking()->column('ID'), 'Assert backlink to page 2 exists');
 
         // update page1 url
-        $page1 = $this->objFromFixture('Page', 'page1');
+        $page1 = $this->objFromFixture(SiteTree::class, 'page1');
         $page1->URLSegment = "page1-new-url";
         $page1->write();
 
         // confirm that draft link on page2 has been rewritten
-        $page2 = $this->objFromFixture('Page', 'page2');
-        $this->assertEquals('<p><a href="'.Director::baseURL().'page1-new-url/">Testing page 1 link</a></p>', $page2->obj('ExtraContent')->forTemplate());
+        $page2 = $this->objFromFixture(SiteTree::class, 'page2');
+        $this->assertEquals(
+            '<p><a href="' . Director::baseURL() . 'page1-new-url/">Testing page 1 link</a></p>',
+            $page2->obj('ExtraContent')->forTemplate()
+        );
 
         // confirm that published link hasn't
-        $page2Live = Versioned::get_one_by_stage("Page", "Live", "\"SiteTree\".\"ID\" = $page2->ID");
+        $page2Live = Versioned::get_one_by_stage(SiteTree::class, "Live", "\"SiteTree\".\"ID\" = $page2->ID");
         Versioned::set_stage(Versioned::LIVE);
-        $this->assertEquals('<p><a href="'.Director::baseURL().'page1/">Testing page 1 link</a></p>', $page2Live->obj('ExtraContent')->forTemplate());
+        $this->assertEquals(
+            '<p><a href="' . Director::baseURL() . 'page1/">Testing page 1 link</a></p>',
+            $page2Live->obj('ExtraContent')->forTemplate()
+        );
 
         // publish page1 and confirm that the link on the published page2 has now been updated
         $page1->publishRecursive();
-        $page2Live = Versioned::get_one_by_stage("Page", "Live", "\"SiteTree\".\"ID\" = $page2->ID");
-        $this->assertEquals('<p><a href="'.Director::baseURL().'page1-new-url/">Testing page 1 link</a></p>', $page2Live->obj('ExtraContent')->forTemplate());
+        $page2Live = Versioned::get_one_by_stage(SiteTree::class, "Live", "\"SiteTree\".\"ID\" = $page2->ID");
+        $this->assertEquals(
+            '<p><a href="' . Director::baseURL() . 'page1-new-url/">Testing page 1 link</a></p>',
+            $page2Live->obj('ExtraContent')->forTemplate()
+        );
 
         // Edit draft again
         Versioned::set_stage(Versioned::DRAFT);
@@ -262,12 +331,16 @@ class SiteTreeBacklinksTest extends SapphireTest
         $page2->write();
 
         // assert backlink to page 2 no longer exists
-        $this->assertNotContains($page2->ID, $page1->BackLinkTracking()->column('ID'), 'Assert backlink to page 2 has been removed');
+        $this->assertNotContains(
+            $page2->ID,
+            $page1->BackLinkTracking()->column('ID'),
+            'Assert backlink to page 2 has been removed'
+        );
     }
 
     public function testLinkTrackingWithUntitledObjectsDisplaysAReadableIdentifier()
     {
-        $page = $this->objFromFixture('Page', 'page2');
+        $page = $this->objFromFixture(SiteTree::class, 'page2');
 
         $referencingObject = new SiteTreeBacklinksTestContentObject();
         $referencingObject->Content = '<p><a href="[sitetree_link,id='

--- a/tests/php/Model/SiteTreeBacklinksTest.yml
+++ b/tests/php/Model/SiteTreeBacklinksTest.yml
@@ -1,4 +1,4 @@
-Page:
+SilverStripe\CMS\Model\SiteTree:
   page1:
     Title: page1
     URLSegment: page1
@@ -11,6 +11,6 @@ Page:
     Title: page3
     URLSegment: page3
     Content: '<p><a href="[sitetree_link,id=$page1.ID]">Testing page 1 link</a></p>'
-    LinkTracking: =>Page.page1
+    LinkTracking: =>SilverStripe\CMS\Model\SiteTree.page1
 
 

--- a/tests/php/Model/SiteTreeBrokenLinksTest.php
+++ b/tests/php/Model/SiteTreeBrokenLinksTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Tests\Model;
 
-use Page;
 use Silverstripe\Assets\Dev\TestAssetStore;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
@@ -42,15 +41,15 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
     public function testBrokenLinksBetweenPages()
     {
-        /** @var Page $obj */
-        $obj = $this->objFromFixture('Page', 'content');
+        /** @var SiteTree $obj */
+        $obj = $this->objFromFixture(SiteTree::class, 'content');
 
         $obj->Content = '<a href="[sitetree_link,id=3423423]">this is a broken link</a>';
         $obj->syncLinkTracking();
         $this->assertTrue($obj->HasBrokenLink, 'Page has a broken link');
 
         $obj->Content = '<a href="[sitetree_link,id=' . $this->idFromFixture(
-            'Page',
+            SiteTree::class,
             'about'
         ) . ']">this is not a broken link</a>';
         $obj->syncLinkTracking();
@@ -62,8 +61,8 @@ class SiteTreeBrokenLinksTest extends SapphireTest
      */
     public function testBrokenLinksNonPage()
     {
-        /** @var Page $aboutPage */
-        $aboutPage = $this->objFromFixture('Page', 'about');
+        /** @var SiteTree $aboutPage */
+        $aboutPage = $this->objFromFixture(SiteTree::class, 'about');
 
         /** @var NotPageObject $obj */
         $obj = $this->objFromFixture(NotPageObject::class, 'object1');
@@ -94,7 +93,7 @@ class SiteTreeBrokenLinksTest extends SapphireTest
         // About-page backlinks contains this object
         $this->assertListEquals(
             [
-                ['ID' => $obj->ID]
+                ['ID' => $obj->ID],
             ],
             $aboutPage->BackLinkTracking()
         );
@@ -102,9 +101,9 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
     public function testBrokenAnchorBetweenPages()
     {
-        /** @var Page $obj */
-        $obj = $this->objFromFixture('Page', 'content');
-        $target = $this->objFromFixture('Page', 'about');
+        /** @var SiteTree $obj */
+        $obj = $this->objFromFixture(SiteTree::class, 'content');
+        $target = $this->objFromFixture(SiteTree::class, 'about');
 
         $obj->Content = "<a href=\"[sitetree_link,id={$target->ID}]#no-anchor-here\">this is a broken link</a>";
         $obj->syncLinkTracking();
@@ -117,7 +116,7 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
     public function testBrokenVirtualPages()
     {
-        $obj = $this->objFromFixture('Page', 'content');
+        $obj = $this->objFromFixture(SiteTree::class, 'content');
         $vp = new VirtualPage();
 
         $vp->CopyContentFromID = $obj->ID;
@@ -131,7 +130,7 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
     public function testBrokenInternalRedirectorPages()
     {
-        $obj = $this->objFromFixture('Page', 'content');
+        $obj = $this->objFromFixture(SiteTree::class, 'content');
         $rp = new RedirectorPage();
 
         $rp->RedirectionType = 'Internal';
@@ -148,10 +147,10 @@ class SiteTreeBrokenLinksTest extends SapphireTest
     public function testDeletingMarksBackLinkedPagesAsBroken()
     {
         // Set up two published pages with a link from content -> about
-        $linkDest = $this->objFromFixture('Page', 'about');
+        $linkDest = $this->objFromFixture(SiteTree::class, 'about');
 
-        /** @var Page $linkSrc */
-        $linkSrc = $this->objFromFixture('Page', 'content');
+        /** @var SiteTree $linkSrc */
+        $linkSrc = $this->objFromFixture(SiteTree::class, 'content');
         $linkSrc->Content = "<p><a href=\"[sitetree_link,id=$linkDest->ID]\">about us</a></p>";
         $linkSrc->write();
 
@@ -163,7 +162,7 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
         // Confirm draft has broken link
         $linkSrc->flushCache();
-        $linkSrc = $this->objFromFixture('Page', 'content');
+        $linkSrc = $this->objFromFixture(SiteTree::class, 'content');
 
         $this->assertEquals(1, (int)$linkSrc->HasBrokenLink);
     }
@@ -173,13 +172,13 @@ class SiteTreeBrokenLinksTest extends SapphireTest
         $this->logInWithPermission('ADMIN');
 
         // Set up two draft pages with a link from content -> about
-        /** @var Page $linkDest */
-        $linkDest = $this->objFromFixture('Page', 'about');
+        /** @var SiteTree $linkDest */
+        $linkDest = $this->objFromFixture(SiteTree::class, 'about');
         // Ensure that it's not on the published site
         $linkDest->doUnpublish();
 
-        /** @var Page $linkSrc */
-        $linkSrc = $this->objFromFixture('Page', 'content');
+        /** @var SiteTree $linkSrc */
+        $linkSrc = $this->objFromFixture(SiteTree::class, 'content');
         $linkSrc->Content = "<p><a href=\"[sitetree_link,id=$linkDest->ID]\">about us</a></p>";
         $linkSrc->write();
 
@@ -191,20 +190,20 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
         // Live doesn't have separate broken link tracking
         $this->assertEquals(0, DB::query("SELECT \"HasBrokenLink\" FROM \"SiteTree_Live\"
-			WHERE \"ID\" = $linkSrc->ID")->value());
+            WHERE \"ID\" = $linkSrc->ID")->value());
     }
 
     public function testRestoreFixesBrokenLinks()
     {
         // Create page and virtual page
-        $p = new Page();
+        $p = new SiteTree();
         $p->Title = "source";
         $p->write();
         $pageID = $p->ID;
         $this->assertTrue($p->publishRecursive());
 
         // Content links are one kind of link to pages
-        $p2 = new Page();
+        $p2 = new SiteTree();
         $p2->Title = "regular link";
         $p2->Content = "<a href=\"[sitetree_link,id=$p->ID]\">test</a>";
         $p2->write();
@@ -264,14 +263,14 @@ class SiteTreeBrokenLinksTest extends SapphireTest
     public function testRevertToLiveFixesBrokenLinks()
     {
         // Create page and virutal page
-        $page = new Page();
+        $page = new SiteTree();
         $page->Title = "source";
         $page->write();
         $pageID = $page->ID;
         $this->assertTrue($page->publishRecursive());
 
         // Content links are one kind of link to pages
-        $page2 = new Page();
+        $page2 = new SiteTree();
         $page2->Title = "regular link";
         $page2->Content = "<a href=\"[sitetree_link,id={$pageID}]\">test</a>";
         $page2->write();
@@ -302,7 +301,7 @@ class SiteTreeBrokenLinksTest extends SapphireTest
         $this->assertEquals(1, $redirectorPage->HasBrokenLink);
 
         // Call doRevertToLive and confirm that broken links are restored
-        /** @var Page $pageLive */
+        /** @var SiteTree $pageLive */
         $pageLive = Versioned::get_one_by_stage(SiteTree::class, 'Live', '"SiteTree"."ID" = ' . $pageID);
         $pageLive->doRevertToLive();
 
@@ -316,15 +315,17 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
     public function testBrokenAnchorLinksInAPage()
     {
-        /** @var Page $obj */
-        $obj = $this->objFromFixture('Page', 'content');
+        /** @var SiteTree $obj */
+        $obj = $this->objFromFixture(SiteTree::class, 'content');
         $origContent = $obj->Content;
 
-        $obj->Content = $origContent . '<a href="#no-anchor-here">this links to a non-existent in-page anchor or skiplink</a>';
+        $obj->Content = $origContent . '<a href="#no-anchor-here">this links to a non-existent in-page anchor or ' .
+            'skiplink</a>';
         $obj->syncLinkTracking();
         $this->assertTrue($obj->HasBrokenLink, 'Page has a broken anchor/skiplink');
 
-        $obj->Content = $origContent . '<a href="#yes-anchor-here">this links to an existent in-page anchor/skiplink</a>';
+        $obj->Content = $origContent . '<a href="#yes-anchor-here">this links to an existent in-page ' .
+            'anchor/skiplink</a>';
         $obj->syncLinkTracking();
         $this->assertFalse($obj->HasBrokenLink, 'Page doesn\'t have a broken anchor or skiplink');
     }

--- a/tests/php/Model/SiteTreeBrokenLinksTest.yml
+++ b/tests/php/Model/SiteTreeBrokenLinksTest.yml
@@ -1,4 +1,4 @@
-Page:
+SilverStripe\CMS\Model\SiteTree:
   content:
     Title: ContentPage
     Content: 'This is some partially happy content. It has one missing a skiplink, but does have another <a name="yes-anchor-here">skiplink here</a>.'
@@ -13,7 +13,7 @@ Page:
   workingInternalRedirector:
     RedirectionType: Internal
     Title: RedirectorPageToBrokenInteralPage
-    LinkTo: =>Page.content
+    LinkTo: =>SilverStripe\CMS\Model\SiteTree.content
 SilverStripe\CMS\Tests\Model\SiteTreeBrokenLinksTest\NotPageObject:
   object1:
     Content: 'Everything will be ok'

--- a/tests/php/Model/SiteTreeHTMLEditorFieldTest.php
+++ b/tests/php/Model/SiteTreeHTMLEditorFieldTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Tests\Model;
 
-use Page;
 use SilverStripe\Assets\Dev\TestAssetStore;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Filesystem;
@@ -31,8 +30,8 @@ class SiteTreeHTMLEditorFieldTest extends FunctionalTest
         }
 
         // Ensure all pages are published
-        /** @var Page $page */
-        foreach (Page::get() as $page) {
+        /** @var SiteTree $page */
+        foreach (SiteTree::get() as $page) {
             $page->publishSingle();
         }
     }
@@ -55,7 +54,11 @@ class SiteTreeHTMLEditorFieldTest extends FunctionalTest
         $editor->setValue("<a href=\"[sitetree_link,id=$aboutID]\">Example Link</a>");
         $editor->saveInto($sitetree);
         $sitetree->write();
-        $this->assertEquals([$aboutID => $aboutID], $sitetree->LinkTracking()->getIdList(), 'Basic link tracking works.');
+        $this->assertEquals(
+            [$aboutID => $aboutID],
+            $sitetree->LinkTracking()->getIdList(),
+            'Basic link tracking works.'
+        );
 
         $editor->setValue(
             "<a href=\"[sitetree_link,id=$aboutID]\"></a><a href=\"[sitetree_link,id=$contactID]\"></a>"

--- a/tests/php/Model/SiteTreeLinkTrackingTest.php
+++ b/tests/php/Model/SiteTreeLinkTrackingTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Tests\Model;
 
-use Page;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\SiteTreeLinkTracking_Parser;
 use SilverStripe\Control\Director;
@@ -32,7 +31,7 @@ class SiteTreeLinkTrackingTest extends SapphireTest
 
     public function testParser()
     {
-        SiteTree::add_extension(Page::class, SiteTreeLinkTracking_Extension::class);
+        SiteTree::add_extension(SiteTree::class, SiteTreeLinkTracking_Extension::class);
 
         // Shortcodes
         $this->assertTrue($this->isBroken('<a href="[sitetree_link,id=123]">link</a>'));
@@ -55,8 +54,7 @@ class SiteTreeLinkTrackingTest extends SapphireTest
         $this->assertFalse($this->isBroken('<a id="anchor">anchor</a>'));
         $this->assertTrue($this->isBroken('<a href="##anchor">anchor</a>'));
 
-
-        $page = new Page();
+        $page = new SiteTree();
         $page->Content = '<a name="yes-name-anchor">name</a><a id="yes-id-anchor">id</a>';
         $page->write();
 
@@ -72,7 +70,7 @@ class SiteTreeLinkTrackingTest extends SapphireTest
 
     protected function highlight($content)
     {
-        $page = new Page();
+        $page = new SiteTree();
         $page->Content = $content;
         $page->write();
         return $page->Content;
@@ -87,7 +85,7 @@ class SiteTreeLinkTrackingTest extends SapphireTest
         $content = $this->highlight('<a href="[sitetree_link,id=123]">link</a>');
         $this->assertEquals(substr_count($content ?? '', 'ss-broken'), 1, 'ss-broken class is added to the broken link.');
 
-        $otherPage = new Page();
+        $otherPage = new SiteTree();
         $otherPage->Content = '';
         $otherPage->write();
 

--- a/tests/php/Model/SiteTreePermissionsTest.php
+++ b/tests/php/Model/SiteTreePermissionsTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Tests\Model;
 
-use Page;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Dev\FunctionalTest;
@@ -33,8 +32,8 @@ class SiteTreePermissionsTest extends FunctionalTest
         $this->autoFollowRedirection = false;
 
         // Ensure all pages are published
-        /** @var Page $page */
-        foreach (Page::get() as $page) {
+        /** @var SiteTree $page */
+        foreach (SiteTree::get() as $page) {
             if ($page->URLSegment !== 'draft-only') {
                 $page->publishSingle();
             }
@@ -46,8 +45,8 @@ class SiteTreePermissionsTest extends FunctionalTest
     {
         $this->autoFollowRedirection = false;
 
-        /** @var Page $draftOnlyPage */
-        $draftOnlyPage = $this->objFromFixture(Page::class, 'draftOnlyPage');
+        /** @var SiteTree $draftOnlyPage */
+        $draftOnlyPage = $this->objFromFixture(SiteTree::class, 'draftOnlyPage');
         $this->logOut();
 
         $response = $this->get($draftOnlyPage->URLSegment . '?stage=Live');
@@ -85,7 +84,7 @@ class SiteTreePermissionsTest extends FunctionalTest
     {
         // Set up fixture - a published page deleted from draft
         $this->logInWithPermission("ADMIN");
-        $page = $this->objFromFixture(Page::class, 'restrictedEditOnlySubadminGroup');
+        $page = $this->objFromFixture(SiteTree::class, 'restrictedEditOnlySubadminGroup');
         $pageID = $page->ID;
         $this->assertTrue($page->publishRecursive());
         $page->delete();
@@ -112,7 +111,7 @@ class SiteTreePermissionsTest extends FunctionalTest
     {
         // Set up fixture - an unpublished page
         $this->logInWithPermission("ADMIN");
-        $page = $this->objFromFixture(Page::class, 'restrictedEditOnlySubadminGroup');
+        $page = $this->objFromFixture(SiteTree::class, 'restrictedEditOnlySubadminGroup');
         $pageID = $page->ID;
         $page->doUnpublish();
 
@@ -135,7 +134,7 @@ class SiteTreePermissionsTest extends FunctionalTest
     {
         // Find a page that exists and delete it from both stage and published
         $this->logInWithPermission("ADMIN");
-        $page = $this->objFromFixture(Page::class, 'restrictedEditOnlySubadminGroup');
+        $page = $this->objFromFixture(SiteTree::class, 'restrictedEditOnlySubadminGroup');
         $pageID = $page->ID;
         $page->doUnpublish();
         $page->delete();
@@ -153,8 +152,8 @@ class SiteTreePermissionsTest extends FunctionalTest
     public function testCanViewStage()
     {
         // Get page & make sure it exists on Live
-        /** @var Page $page */
-        $page = $this->objFromFixture(Page::class, 'standardpage');
+        /** @var SiteTree $page */
+        $page = $this->objFromFixture(SiteTree::class, 'standardpage');
         $page->publishSingle();
 
         // Then make sure there's a new version on Stage
@@ -173,7 +172,7 @@ class SiteTreePermissionsTest extends FunctionalTest
 
     public function testAccessTabOnlyDisplaysWithGrantAccessPermissions()
     {
-        $page = $this->objFromFixture(Page::class, 'standardpage');
+        $page = $this->objFromFixture(SiteTree::class, 'standardpage');
 
         $subadminuser = $this->objFromFixture(Member::class, 'subadmin');
         Security::setCurrentUser($subadminuser);
@@ -204,7 +203,7 @@ class SiteTreePermissionsTest extends FunctionalTest
 
     public function testRestrictedViewLoggedInUsers()
     {
-        $page = $this->objFromFixture(Page::class, 'restrictedViewLoggedInUsers');
+        $page = $this->objFromFixture(SiteTree::class, 'restrictedViewLoggedInUsers');
 
         // unauthenticated users
         $this->assertFalse(
@@ -223,21 +222,23 @@ class SiteTreePermissionsTest extends FunctionalTest
         $websiteuser = $this->objFromFixture(Member::class, 'websiteuser');
         $this->assertTrue(
             $page->canView($websiteuser),
-            'Authenticated members can view a page marked as "Viewable for any logged in users" even if they dont have access to the CMS'
+            'Authenticated members can view a page marked as "Viewable for any logged in users" even if they dont ' .
+            'have access to the CMS'
         );
         $this->logInAs($websiteuser);
         $response = $this->get($page->RelativeLink());
         $this->assertEquals(
             $response->getStatusCode(),
             200,
-            'Authenticated members can view a page marked as "Viewable for any logged in users" even if they dont have access to the CMS'
+            'Authenticated members can view a page marked as "Viewable for any logged in users" even if they dont ' .
+            'have access to the CMS'
         );
         $this->logOut();
     }
 
     public function testRestrictedViewOnlyTheseUsers()
     {
-        $page = $this->objFromFixture(Page::class, 'restrictedViewOnlyWebsiteUsers');
+        $page = $this->objFromFixture(SiteTree::class, 'restrictedViewOnlyWebsiteUsers');
 
         // unauthenticcated users
         $this->assertFalse(
@@ -256,14 +257,16 @@ class SiteTreePermissionsTest extends FunctionalTest
         $subadminuser = $this->objFromFixture(Member::class, 'subadmin');
         $this->assertFalse(
             $page->canView($subadminuser),
-            'Authenticated members cant view a page marked as "Viewable by these groups" if theyre not in the listed groups'
+            'Authenticated members cant view a page marked as "Viewable by these groups" if theyre not in the listed ' .
+            'groups'
         );
         $this->LogInAs($subadminuser);
         $response = $this->get($page->RelativeLink());
         $this->assertEquals(
             $response->getStatusCode(),
             403,
-            'Authenticated members cant view a page marked as "Viewable by these groups" if theyre not in the listed groups'
+            'Authenticated members cant view a page marked as "Viewable by these groups" if theyre not in the listed ' .
+            'groups'
         );
         $this->logOut();
 
@@ -285,7 +288,7 @@ class SiteTreePermissionsTest extends FunctionalTest
 
     public function testRestrictedEditLoggedInUsers()
     {
-        $page = $this->objFromFixture(Page::class, 'restrictedEditLoggedInUsers');
+        $page = $this->objFromFixture(SiteTree::class, 'restrictedEditLoggedInUsers');
 
         // unauthenticcated users
         $this->assertFalse(
@@ -298,20 +301,22 @@ class SiteTreePermissionsTest extends FunctionalTest
         Security::setCurrentUser($websiteuser);
         $this->assertFalse(
             $page->canEdit($websiteuser),
-            'Authenticated members cant edit a page marked as "Editable by logged in users" if they dont have cms permissions'
+            'Authenticated members cant edit a page marked as "Editable by logged in users" if they dont have cms ' .
+            'permissions'
         );
 
         // subadmin users
         $subadminuser = $this->objFromFixture(Member::class, 'subadmin');
         $this->assertTrue(
             $page->canEdit($subadminuser),
-            'Authenticated members can edit a page marked as "Editable by logged in users" if they have cms permissions and belong to any of these groups'
+            'Authenticated members can edit a page marked as "Editable by logged in users" if they have cms ' .
+            'permissions and belong to any of these groups'
         );
     }
 
     public function testRestrictedEditOnlySubadminGroup()
     {
-        $page = $this->objFromFixture(Page::class, 'restrictedEditOnlySubadminGroup');
+        $page = $this->objFromFixture(SiteTree::class, 'restrictedEditOnlySubadminGroup');
 
         // unauthenticated users
         $this->assertFalse(
@@ -330,14 +335,15 @@ class SiteTreePermissionsTest extends FunctionalTest
         $websiteuser = $this->objFromFixture(Member::class, 'websiteuser');
         $this->assertFalse(
             $page->canEdit($websiteuser),
-            'Authenticated members cant edit a page marked as "Editable by these groups" if theyre not in the listed groups'
+            'Authenticated members cant edit a page marked as "Editable by these groups" if theyre not in the listed ' .
+            'groups'
         );
     }
 
     public function testRestrictedViewInheritance()
     {
-        $parentPage = $this->objFromFixture(Page::class, 'parent_restrictedViewOnlySubadminGroup');
-        $childPage = $this->objFromFixture(Page::class, 'child_restrictedViewOnlySubadminGroup');
+        $parentPage = $this->objFromFixture(SiteTree::class, 'parent_restrictedViewOnlySubadminGroup');
+        $childPage = $this->objFromFixture(SiteTree::class, 'child_restrictedViewOnlySubadminGroup');
 
         // unauthenticated users
         $this->assertFalse(
@@ -356,22 +362,24 @@ class SiteTreePermissionsTest extends FunctionalTest
         $subadminuser = $this->objFromFixture(Member::class, 'subadmin');
         $this->assertTrue(
             $childPage->canView($subadminuser),
-            'Authenticated members can view a page marked as "Viewable by these groups" if theyre in the listed groups by inherited permission'
+            'Authenticated members can view a page marked as "Viewable by these groups" if theyre in the listed ' .
+            'groups by inherited permission'
         );
         $this->logInAs($subadminuser);
         $response = $this->get($childPage->RelativeLink());
         $this->assertEquals(
             $response->getStatusCode(),
             200,
-            'Authenticated members can view a page marked as "Viewable by these groups" if theyre in the listed groups by inherited permission'
+            'Authenticated members can view a page marked as "Viewable by these groups" if theyre in the listed ' .
+            'groups by inherited permission'
         );
         $this->logOut();
     }
 
     public function testRestrictedEditInheritance()
     {
-        $parentPage = $this->objFromFixture(Page::class, 'parent_restrictedEditOnlySubadminGroup');
-        $childPage = $this->objFromFixture(Page::class, 'child_restrictedEditOnlySubadminGroup');
+        $parentPage = $this->objFromFixture(SiteTree::class, 'parent_restrictedEditOnlySubadminGroup');
+        $childPage = $this->objFromFixture(SiteTree::class, 'child_restrictedEditOnlySubadminGroup');
 
         // unauthenticated users
         $this->assertFalse(
@@ -383,14 +391,15 @@ class SiteTreePermissionsTest extends FunctionalTest
         $subadminuser = $this->objFromFixture(Member::class, 'subadmin');
         $this->assertTrue(
             $childPage->canEdit($subadminuser),
-            'Authenticated members can edit a page marked as "Editable by these groups" if theyre in the listed groups by inherited permission'
+            'Authenticated members can edit a page marked as "Editable by these groups" if theyre in the listed ' .
+            'groups by inherited permission'
         );
     }
 
     public function testDeleteRestrictedChild()
     {
-        $parentPage = $this->objFromFixture(Page::class, 'deleteTestParentPage');
-        $childPage = $this->objFromFixture(Page::class, 'deleteTestChildPage');
+        $parentPage = $this->objFromFixture(SiteTree::class, 'deleteTestParentPage');
+        $childPage = $this->objFromFixture(SiteTree::class, 'deleteTestChildPage');
 
         // unauthenticated users
         $this->assertFalse(
@@ -405,7 +414,7 @@ class SiteTreePermissionsTest extends FunctionalTest
 
     public function testRestrictedEditLoggedInUsersDeletedFromStage()
     {
-        $page = $this->objFromFixture(Page::class, 'restrictedEditLoggedInUsers');
+        $page = $this->objFromFixture(SiteTree::class, 'restrictedEditLoggedInUsers');
         $pageID = $page->ID;
 
         $this->logInWithPermission("ADMIN");
@@ -421,39 +430,60 @@ class SiteTreePermissionsTest extends FunctionalTest
         $subadminuser = $this->objFromFixture(Member::class, 'subadmin');
         $this->assertTrue(
             $page->canEdit($subadminuser),
-            'Authenticated members can edit a page that was deleted from stage and marked as "Editable by logged in users" if they have cms permissions and belong to any of these groups'
+            'Authenticated members can edit a page that was deleted from stage and marked as "Editable by logged ' .
+            'in users" if they have cms permissions and belong to any of these groups'
         );
     }
 
     public function testInheritCanViewFromSiteConfig()
     {
-        $page = $this->objFromFixture(Page::class, 'inheritWithNoParent');
+        $page = $this->objFromFixture(SiteTree::class, 'inheritWithNoParent');
         $siteconfig = $this->objFromFixture(SiteConfig::class, 'default');
         $editor = $this->objFromFixture(Member::class, 'editor');
         $editorGroup = $this->objFromFixture(Group::class, 'editorgroup');
 
         $siteconfig->CanViewType = 'Anyone';
         $siteconfig->write();
-        $this->assertTrue($page->canView(false), 'Anyone can view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to LoggedInUsers');
+        $this->assertTrue(
+            $page->canView(false),
+            'Anyone can view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to ' .
+            'LoggedInUsers'
+        );
 
         $siteconfig->CanViewType = 'LoggedInUsers';
         $siteconfig->write();
-        $this->assertFalse($page->canView(false), 'Anonymous can\'t view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to LoggedInUsers');
+        $this->assertFalse(
+            $page->canView(false),
+            'Anonymous can\'t view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to ' .
+            'LoggedInUsers'
+        );
 
         $siteconfig->CanViewType = 'LoggedInUsers';
         $siteconfig->write();
-        $this->assertTrue($page->canView($editor), 'Users can view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to LoggedInUsers');
+        $this->assertTrue(
+            $page->canView($editor),
+            'Users can view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to ' .
+            'LoggedInUsers'
+        );
 
         $siteconfig->CanViewType = 'OnlyTheseUsers';
         $siteconfig->ViewerGroups()->add($editorGroup);
         $siteconfig->write();
-        $this->assertTrue($page->canView($editor), 'Editors can view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to OnlyTheseUsers');
-        $this->assertFalse($page->canView(false), 'Anonymous can\'t view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to OnlyTheseUsers');
+        $this->assertTrue(
+            $page->canView($editor),
+            'Editors can view a page when set to inherit from the SiteConfig, and SiteConfig has canView set to ' .
+            'OnlyTheseUsers'
+        );
+        $this->assertFalse(
+            $page->canView(false),
+            'Anonymous can\'t view a page when set to inherit from the SiteConfig, and SiteConfig has canView set ' .
+            'to OnlyTheseUsers'
+        );
     }
 
     public function testInheritCanEditFromSiteConfig()
     {
-        $page = $this->objFromFixture(Page::class, 'inheritWithNoParent');
+        $page = $this->objFromFixture(SiteTree::class, 'inheritWithNoParent');
         $siteconfig = $this->objFromFixture(SiteConfig::class, 'default');
         $editor = $this->objFromFixture(Member::class, 'editor');
         $user = $this->objFromFixture(Member::class, 'websiteuser');
@@ -462,17 +492,37 @@ class SiteTreePermissionsTest extends FunctionalTest
         $siteconfig->CanEditType = 'LoggedInUsers';
         $siteconfig->write();
 
-        $this->assertFalse($page->canEdit(false), 'Anonymous can\'t edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set to LoggedInUsers');
+        $this->assertFalse(
+            $page->canEdit(false),
+            'Anonymous can\'t edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set ' .
+            'to LoggedInUsers'
+        );
         Security::setCurrentUser($editor);
-        $this->assertTrue($page->canEdit(), 'Users can edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set to LoggedInUsers');
+        $this->assertTrue(
+            $page->canEdit(),
+            'Users can edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set to ' .
+            'LoggedInUsers'
+        );
 
         $siteconfig->CanEditType = 'OnlyTheseUsers';
         $siteconfig->EditorGroups()->add($editorGroup);
         $siteconfig->write();
-        $this->assertTrue($page->canEdit($editor), 'Editors can edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set to OnlyTheseUsers');
+        $this->assertTrue(
+            $page->canEdit($editor),
+            'Editors can edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set to ' .
+            'OnlyTheseUsers'
+        );
         Security::setCurrentUser(null);
-        $this->assertFalse($page->canEdit(false), 'Anonymous can\'t edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set to OnlyTheseUsers');
+        $this->assertFalse(
+            $page->canEdit(false),
+            'Anonymous can\'t edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set ' .
+            'to OnlyTheseUsers'
+        );
         Security::setCurrentUser($user);
-        $this->assertFalse($page->canEdit($user), 'Website user can\'t edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set to OnlyTheseUsers');
+        $this->assertFalse(
+            $page->canEdit($user),
+            'Website user can\'t edit a page when set to inherit from the SiteConfig, and SiteConfig has canEdit set ' .
+            'to OnlyTheseUsers'
+        );
     }
 }

--- a/tests/php/Model/SiteTreePermissionsTest.yml
+++ b/tests/php/Model/SiteTreePermissionsTest.yml
@@ -35,7 +35,7 @@ SilverStripe\Security\Member:
     Email: websiteuser@test.com
     Password: test
     Groups: =>SilverStripe\Security\Group.websiteusers
-Page:
+SilverStripe\CMS\Model\SiteTree:
   standardpage:
     URLSegment: standardpage
   restrictedViewLoggedInUsers:
@@ -66,7 +66,7 @@ Page:
     URLSegment: parent-restrictedViewOnlySubadminGroup
   child_restrictedViewOnlySubadminGroup:
     CanViewType: Inherit
-    Parent: =>Page.parent_restrictedViewOnlySubadminGroup
+    Parent: =>SilverStripe\CMS\Model\SiteTree.parent_restrictedViewOnlySubadminGroup
     URLSegment: child-restrictedViewOnlySubadminGroup
   parent_restrictedEditOnlySubadminGroup:
     CanEditType: OnlyTheseUsers
@@ -74,7 +74,7 @@ Page:
     URLSegment: parent-restrictedEditOnlySubadminGroup
   child_restrictedEditOnlySubadminGroup:
     CanEditType: Inherit
-    Parent: =>Page.parent_restrictedEditOnlySubadminGroup
+    Parent: =>SilverStripe\CMS\Model\SiteTree.parent_restrictedEditOnlySubadminGroup
     URLSegment: child-restrictedEditOnlySubadminGroup
   deleteTestParentPage:
     CanEditType: Inherit

--- a/tests/php/Model/SiteTreeTest.yml
+++ b/tests/php/Model/SiteTreeTest.yml
@@ -44,7 +44,7 @@ SilverStripe\Security\Member:
   securityadmin:
     Groups: =>SilverStripe\Security\Group.securityadmins
 
-Page:
+SilverStripe\CMS\Model\SiteTree:
   home:
     Title: Home
     CanEditType: OnlyTheseUsers
@@ -56,14 +56,14 @@ Page:
   staff:
     Title: Staff
     URLSegment: my-staff
-    Parent: =>Page.about
+    Parent: =>SilverStripe\CMS\Model\SiteTree.about
   ceo:
     Title: CEO
-    Parent: =>Page.staff
+    Parent: =>SilverStripe\CMS\Model\SiteTree.staff
   staffduplicate:
     Title: Staff
     URLSegment: my-staff
-    Parent: =>Page.about
+    Parent: =>SilverStripe\CMS\Model\SiteTree.about
     ShowInMenus: 0
   products:
     Title: Products
@@ -71,19 +71,19 @@ Page:
     EditorGroups: =>SilverStripe\Security\Group.editors
   product1:
     Title: 1.1 Test Product
-    Parent: =>Page.products
+    Parent: =>SilverStripe\CMS\Model\SiteTree.products
     CanEditType: Inherit
   product2:
     Title: Another Product
-    Parent: =>Page.products
+    Parent: =>SilverStripe\CMS\Model\SiteTree.products
     CanEditType: Inherit
   product3:
     Title: Another Product
-    Parent: =>Page.products
+    Parent: =>SilverStripe\CMS\Model\SiteTree.products
     CanEditType: Inherit
   product4:
     Title: Another Product
-    Parent: =>Page.products
+    Parent: =>SilverStripe\CMS\Model\SiteTree.products
     CanEditType: OnlyTheseUsers
     EditorGroups: =>SilverStripe\Security\Group.admins
   contact:
@@ -102,16 +102,16 @@ Page:
     Title: 'Breadcrumbs'
   breadcrumbs2:
     Title: 'Breadcrumbs 2'
-    Parent: =>Page.breadcrumbs
+    Parent: =>SilverStripe\CMS\Model\SiteTree.breadcrumbs
   breadcrumbs3:
     Title: 'Breadcrumbs 3'
-    Parent: =>Page.breadcrumbs2
+    Parent: =>SilverStripe\CMS\Model\SiteTree.breadcrumbs2
   breadcrumbs4:
     Title: 'Breadcrumbs 4'
-    Parent: =>Page.breadcrumbs3
+    Parent: =>SilverStripe\CMS\Model\SiteTree.breadcrumbs3
   breadcrumbs5:
     Title: 'Breadcrumbs 5'
-    Parent: =>Page.breadcrumbs4
+    Parent: =>SilverStripe\CMS\Model\SiteTree.breadcrumbs4
 
 SilverStripe\CMS\Tests\Model\SiteTreeTest_Conflicted:
   parent:
@@ -127,4 +127,4 @@ SilverStripe\CMS\Model\RedirectorPage:
 SilverStripe\CMS\Tests\Model\SiteTreeTest_DataObject:
   relations:
     Title: 'Linked DataObject'
-    Pages: =>Page.home,=>Page.about,=>Page.staff
+    Pages: =>SilverStripe\CMS\Model\SiteTree.home,=>SilverStripe\CMS\Model\SiteTree.about,=>SilverStripe\CMS\Model\SiteTree.staff

--- a/tests/php/Model/SiteTreeTest_AdminDenied.php
+++ b/tests/php/Model/SiteTreeTest_AdminDenied.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_AdminDenied extends Page implements TestOnly
+class SiteTreeTest_AdminDenied extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_AdminDenied';
 

--- a/tests/php/Model/SiteTreeTest_ClassA.php
+++ b/tests/php/Model/SiteTreeTest_ClassA.php
@@ -3,18 +3,18 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_ClassA extends Page implements TestOnly
+class SiteTreeTest_ClassA extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_ClassA';
 
     private static $need_permission = [
         'ADMIN',
-        'CMS_ACCESS_CMSMain'
+        'CMS_ACCESS_CMSMain',
     ];
 
     private static $allowed_children = [
-        SiteTreeTest_ClassB::class
+        SiteTreeTest_ClassB::class,
     ];
 }

--- a/tests/php/Model/SiteTreeTest_ClassB.php
+++ b/tests/php/Model/SiteTreeTest_ClassB.php
@@ -3,14 +3,14 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_ClassB extends Page implements TestOnly
+class SiteTreeTest_ClassB extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_ClassB';
 
     // Also allowed subclasses
     private static $allowed_children = [
-        SiteTreeTest_ClassC::class
+        SiteTreeTest_ClassC::class,
     ];
 }

--- a/tests/php/Model/SiteTreeTest_ClassC.php
+++ b/tests/php/Model/SiteTreeTest_ClassC.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_ClassC extends Page implements TestOnly
+class SiteTreeTest_ClassC extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_ClassC';
 

--- a/tests/php/Model/SiteTreeTest_ClassCext.php
+++ b/tests/php/Model/SiteTreeTest_ClassCext.php
@@ -10,6 +10,6 @@ class SiteTreeTest_ClassCext extends SiteTreeTest_ClassC implements TestOnly
 
     // Override SiteTreeTest_ClassC definitions
     private static $allowed_children = [
-        SiteTreeTest_ClassB::class
+        SiteTreeTest_ClassB::class,
     ];
 }

--- a/tests/php/Model/SiteTreeTest_ClassD.php
+++ b/tests/php/Model/SiteTreeTest_ClassD.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_ClassD extends Page implements TestOnly
+class SiteTreeTest_ClassD extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_ClassD';
 

--- a/tests/php/Model/SiteTreeTest_ClassE.php
+++ b/tests/php/Model/SiteTreeTest_ClassE.php
@@ -4,9 +4,9 @@ namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\HiddenClass;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_ClassE extends Page implements TestOnly, HiddenClass
+class SiteTreeTest_ClassE extends SiteTree implements TestOnly, HiddenClass
 {
     private static $table_name = 'SiteTreeTest_ClassE';
 }

--- a/tests/php/Model/SiteTreeTest_Conflicted.php
+++ b/tests/php/Model/SiteTreeTest_Conflicted.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_Conflicted extends Page implements TestOnly
+class SiteTreeTest_Conflicted extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_Conflicted';
 }

--- a/tests/php/Model/SiteTreeTest_ConflictedController.php
+++ b/tests/php/Model/SiteTreeTest_ConflictedController.php
@@ -3,12 +3,12 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use PageController;
+use SilverStripe\CMS\Controllers\ContentController;
 
-class SiteTreeTest_ConflictedController extends PageController implements TestOnly
+class SiteTreeTest_ConflictedController extends ContentController implements TestOnly
 {
     private static $allowed_actions = [
-        'conflicted-action'
+        'conflicted-action',
     ];
 
     public function hasActionTemplate($template)

--- a/tests/php/Model/SiteTreeTest_LegacyControllerName.php
+++ b/tests/php/Model/SiteTreeTest_LegacyControllerName.php
@@ -3,12 +3,12 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
 /**
  * An empty SiteTree instance with a controller to test that legacy controller names can still be loaded
  */
-class SiteTreeTest_LegacyControllerName extends Page implements TestOnly
+class SiteTreeTest_LegacyControllerName extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_LegacyControllerName';
 }

--- a/tests/php/Model/SiteTreeTest_LegacyControllerName_Controller.php
+++ b/tests/php/Model/SiteTreeTest_LegacyControllerName_Controller.php
@@ -3,9 +3,8 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use PageController;
+use SilverStripe\CMS\Controllers\ContentController;
 
-class SiteTreeTest_LegacyControllerName_Controller extends PageController implements TestOnly
+class SiteTreeTest_LegacyControllerName_Controller extends ContentController implements TestOnly
 {
-
 }

--- a/tests/php/Model/SiteTreeTest_NotRoot.php
+++ b/tests/php/Model/SiteTreeTest_NotRoot.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_NotRoot extends Page implements TestOnly
+class SiteTreeTest_NotRoot extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_NotRoot';
 

--- a/tests/php/Model/SiteTreeTest_PageNode.php
+++ b/tests/php/Model/SiteTreeTest_PageNode.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class SiteTreeTest_PageNode extends Page implements TestOnly
+class SiteTreeTest_PageNode extends SiteTree implements TestOnly
 {
     private static $table_name = 'SiteTreeTest_PageNode';
 }

--- a/tests/php/Model/SiteTreeTest_PageNodeController.php
+++ b/tests/php/Model/SiteTreeTest_PageNodeController.php
@@ -3,8 +3,8 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use PageController;
+use SilverStripe\CMS\Controllers\ContentController;
 
-class SiteTreeTest_PageNodeController extends PageController implements TestOnly
+class SiteTreeTest_PageNodeController extends ContentController implements TestOnly
 {
 }

--- a/tests/php/Model/VirtualPageTest.php
+++ b/tests/php/Model/VirtualPageTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Tests\Model;
 
-use Page;
 use SilverStripe\CMS\Controllers\ModelAsController;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
@@ -43,8 +42,8 @@ class VirtualPageTest extends FunctionalTest
 
     protected static $required_extensions = [
         SiteTree::class => [
-            VirtualPageTest_PageExtension::class
-        ]
+            VirtualPageTest_PageExtension::class,
+        ],
     ];
 
     protected function setUp(): void
@@ -63,8 +62,8 @@ class VirtualPageTest extends FunctionalTest
         );
 
         // Ensure all pages are published
-        /** @var Page $page */
-        foreach (Page::get() as $page) {
+        /** @var SiteTree $page */
+        foreach (SiteTree::get() as $page) {
             $page->publishSingle();
         }
     }
@@ -75,8 +74,8 @@ class VirtualPageTest extends FunctionalTest
      */
     public function testEditingSourcePageUpdatesVirtualPages()
     {
-        /** @var Page $master */
-        $master = $this->objFromFixture('Page', 'master');
+        /** @var SiteTree $master */
+        $master = $this->objFromFixture(SiteTree::class, 'master');
         $master->Title = "New title";
         $master->MenuTitle = "New menutitle";
         $master->Content = "<p>New content</p>";
@@ -97,7 +96,7 @@ class VirtualPageTest extends FunctionalTest
     public function testMetaTags()
     {
         $this->logInWithPermission('ADMIN');
-        $master = $this->objFromFixture('Page', 'master');
+        $master = $this->objFromFixture(SiteTree::class, 'master');
         $vp1 = $this->objFromFixture(VirtualPage::class, 'vp1');
 
         // Test with title
@@ -118,8 +117,8 @@ class VirtualPageTest extends FunctionalTest
     {
         $this->logInWithPermission('ADMIN');
 
-        /** @var Page $master */
-        $master = $this->objFromFixture('Page', 'master');
+        /** @var SiteTree $master */
+        $master = $this->objFromFixture(SiteTree::class, 'master');
         $master->publishRecursive();
 
         $master->Title = "New title";
@@ -160,13 +159,13 @@ class VirtualPageTest extends FunctionalTest
         $vp = new VirtualPage();
         $vp->write();
 
-        $vp->CopyContentFromID = $this->idFromFixture('Page', 'master');
+        $vp->CopyContentFromID = $this->idFromFixture(SiteTree::class, 'master');
         $vp->write();
 
         $this->assertEquals("My Page", $vp->Title);
         $this->assertEquals("My Page Nav", $vp->MenuTitle);
 
-        $vp->CopyContentFromID = $this->idFromFixture('Page', 'master2');
+        $vp->CopyContentFromID = $this->idFromFixture(SiteTree::class, 'master2');
         $vp->write();
 
         $this->assertEquals("My Other Page", $vp->Title);
@@ -180,7 +179,7 @@ class VirtualPageTest extends FunctionalTest
      */
     public function testPublishingAVirtualPageCopiedPublishedContentNotDraftContent()
     {
-        $p = new Page();
+        $p = new SiteTree();
         $p->Content = "published content";
         $p->write();
         $p->publishRecursive();
@@ -220,7 +219,7 @@ class VirtualPageTest extends FunctionalTest
     public function testCantPublishVirtualPagesBeforeTheirSource()
     {
         // An unpublished source page
-        $p = new Page();
+        $p = new SiteTree();
         $p->Content = "test content";
         $p->write();
 
@@ -241,7 +240,7 @@ class VirtualPageTest extends FunctionalTest
 
     public function testCanEdit()
     {
-        $parentPage = $this->objFromFixture('Page', 'master3');
+        $parentPage = $this->objFromFixture(SiteTree::class, 'master3');
         $virtualPage = $this->objFromFixture(VirtualPage::class, 'vp3');
         $bob = $this->objFromFixture(Member::class, 'bob');
         $andrew = $this->objFromFixture(Member::class, 'andrew');
@@ -259,8 +258,8 @@ class VirtualPageTest extends FunctionalTest
 
     public function testCanView()
     {
-        /** @var Page $parentPage */
-        $parentPage = $this->objFromFixture('Page', 'master3');
+        /** @var SiteTree $parentPage */
+        $parentPage = $this->objFromFixture(SiteTree::class, 'master3');
         $parentPage->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
 
         /** @var VirtualPage $virtualPage */
@@ -283,7 +282,7 @@ class VirtualPageTest extends FunctionalTest
     public function testVirtualPagesArentInappropriatelyPublished()
     {
         // Fixture
-        $p = new Page();
+        $p = new SiteTree();
         $p->Content = "test content";
         $p->write();
         $vp = new VirtualPage();
@@ -332,7 +331,7 @@ class VirtualPageTest extends FunctionalTest
     public function testUnpublishingSourcePageOfAVirtualPageAlsoUnpublishesVirtualPage()
     {
         // Create page and virutal page
-        $p = new Page();
+        $p = new SiteTree();
         $p->Title = "source";
         $p->write();
         $this->assertTrue($p->publishRecursive());
@@ -364,7 +363,7 @@ class VirtualPageTest extends FunctionalTest
     public function testDeletingFromLiveSourcePageOfAVirtualPageAlsoUnpublishesVirtualPage()
     {
         // Create page and virutal page
-        $p = new Page();
+        $p = new SiteTree();
         $p->Title = "source";
         $p->write();
         $this->assertTrue($p->publishRecursive());
@@ -384,7 +383,7 @@ class VirtualPageTest extends FunctionalTest
             ->byID($pID);
         $this->assertNull($vpDraft);
         // Delete the source page form live, confirm that the virtual page has also been unpublished
-        /** @var Page $pLive */
+        /** @var SiteTree $pLive */
         $pLive = Versioned::get_by_stage(SiteTree::class, Versioned::LIVE)
             ->byID($pID);
         $this->assertTrue($pLive->doUnpublish());

--- a/tests/php/Model/VirtualPageTest.yml
+++ b/tests/php/Model/VirtualPageTest.yml
@@ -31,7 +31,7 @@ SilverStripe\Security\Member:
   alice:
     Email: alice@alice.com
     Groups: =>SilverStripe\Security\Group.alicegroup
-Page:
+SilverStripe\CMS\Model\SiteTree:
   master:
     Title: My Page
     MenuTitle: My Page Nav
@@ -52,15 +52,15 @@ SilverStripe\CMS\Tests\Model\VirtualPageTest_ClassA:
 SilverStripe\CMS\Model\VirtualPage:
   vp1:
     Title: vp1
-    CopyContentFrom: =>Page.master
-    Parent: =>Page.holder
+    CopyContentFrom: =>SilverStripe\CMS\Model\SiteTree.master
+    Parent: =>SilverStripe\CMS\Model\SiteTree.holder
   vp2:
     Title: vp2
-    CopyContentFrom: =>Page.master
-    Parent: =>Page.holder
+    CopyContentFrom: =>SilverStripe\CMS\Model\SiteTree.master
+    Parent: =>SilverStripe\CMS\Model\SiteTree.holder
   vp3:
-    CopyContentFrom: =>Page.master3
-    Parent: =>Page.holder
+    CopyContentFrom: =>SilverStripe\CMS\Model\SiteTree.master3
+    Parent: =>SilverStripe\CMS\Model\SiteTree.holder
     CanEditType: OnlyTheseUsers
     CanViewType: OnlyTheseUsers
     EditorGroups: =>SilverStripe\Security\Group.andrewgroup

--- a/tests/php/Model/VirtualPageTest_ClassA.php
+++ b/tests/php/Model/VirtualPageTest_ClassA.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class VirtualPageTest_ClassA extends Page implements TestOnly
+class VirtualPageTest_ClassA extends SiteTree implements TestOnly
 {
     private static $table_name = 'VirtualPageTest_ClassA';
 

--- a/tests/php/Model/VirtualPageTest_ClassAController.php
+++ b/tests/php/Model/VirtualPageTest_ClassAController.php
@@ -3,12 +3,12 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use PageController;
+use SilverStripe\CMS\Controllers\ContentController;
 
-class VirtualPageTest_ClassAController extends PageController implements TestOnly
+class VirtualPageTest_ClassAController extends ContentController implements TestOnly
 {
     private static $allowed_actions = [
-        'testaction'
+        'testaction',
     ];
 
     public function testMethod()

--- a/tests/php/Model/VirtualPageTest_ClassB.php
+++ b/tests/php/Model/VirtualPageTest_ClassB.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class VirtualPageTest_ClassB extends Page implements TestOnly
+class VirtualPageTest_ClassB extends SiteTree implements TestOnly
 {
     private static $table_name = 'VirtualPageTest_ClassB';
 

--- a/tests/php/Model/VirtualPageTest_ClassC.php
+++ b/tests/php/Model/VirtualPageTest_ClassC.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class VirtualPageTest_ClassC extends Page implements TestOnly
+class VirtualPageTest_ClassC extends SiteTree implements TestOnly
 {
     private static $table_name = 'VirtualPageTest_ClassC';
 

--- a/tests/php/Model/VirtualPageTest_NotRoot.php
+++ b/tests/php/Model/VirtualPageTest_NotRoot.php
@@ -3,9 +3,9 @@
 namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class VirtualPageTest_NotRoot extends Page implements TestOnly
+class VirtualPageTest_NotRoot extends SiteTree implements TestOnly
 {
     private static $table_name = 'VirtualPageTest_NotRoot';
 

--- a/tests/php/Model/VirtualPageTest_PageExtension.php
+++ b/tests/php/Model/VirtualPageTest_PageExtension.php
@@ -9,7 +9,8 @@ class VirtualPageTest_PageExtension extends DataExtension implements TestOnly
 {
     private static $db = [
         // These fields are just on an extension to simulate shared properties between Page and VirtualPage.
-        // Not possible through direct $db definitions due to VirtualPage inheriting from Page, and Page being defined elsewhere.
+        // Not possible through direct $db definitions due to VirtualPage inheriting from Page,
+        // and Page being defined elsewhere.
         'MySharedVirtualField' => 'Text',
         'MySharedNonVirtualField' => 'Text',
     ];

--- a/tests/php/Model/VirtualPageTest_PageWithAllowedChildren.php
+++ b/tests/php/Model/VirtualPageTest_PageWithAllowedChildren.php
@@ -4,9 +4,9 @@ namespace SilverStripe\CMS\Tests\Model;
 
 use SilverStripe\CMS\Model\VirtualPage;
 use SilverStripe\Dev\TestOnly;
-use Page;
+use SilverStripe\CMS\Model\SiteTree;
 
-class VirtualPageTest_PageWithAllowedChildren extends Page implements TestOnly
+class VirtualPageTest_PageWithAllowedChildren extends SiteTree implements TestOnly
 {
     private static $table_name = 'VirtualPageTest_PageWithAllowedChildren';
 

--- a/tests/php/Reports/CmsReportsTest.php
+++ b/tests/php/Reports/CmsReportsTest.php
@@ -2,24 +2,22 @@
 
 namespace SilverStripe\CMS\Tests\Reports;
 
+use SilverStripe\Assets\File;
+use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\CMS\Model\VirtualPage;
+use SilverStripe\CMS\Reports\BrokenFilesReport;
+use SilverStripe\CMS\Reports\BrokenLinksReport;
+use SilverStripe\CMS\Reports\BrokenRedirectorPagesReport;
+use SilverStripe\CMS\Reports\BrokenVirtualPagesReport;
+use SilverStripe\CMS\Reports\RecentlyEditedReport;
+use SilverStripe\Dev\SapphireTest;
 use SilverStripe\ORM\DB;
 use SilverStripe\ORM\FieldType\DBDatetime;
-use SilverStripe\CMS\Reports\RecentlyEditedReport;
-use SilverStripe\CMS\Reports\BrokenLinksReport;
-use SilverStripe\CMS\Reports\BrokenFilesReport;
-use SilverStripe\CMS\Model\VirtualPage;
-use SilverStripe\CMS\Reports\BrokenVirtualPagesReport;
-use SilverStripe\CMS\Model\RedirectorPage;
-use SilverStripe\CMS\Reports\BrokenRedirectorPagesReport;
 use SilverStripe\Reports\Report;
-use SilverStripe\Assets\File;
-use SilverStripe\Dev\SapphireTest;
-use Page;
 
 class CmsReportsTest extends SapphireTest
 {
-
     protected static $fixture_file = 'CmsReportsTest.yml';
 
     private static $daysAgo = 14;
@@ -29,14 +27,19 @@ class CmsReportsTest extends SapphireTest
         parent::setUp();
 
         // set the dates by hand: impossible to set via yml
-        $afterThreshold = strtotime('-'.(self::$daysAgo-1).' days', strtotime('31-06-2009 00:00:00'));
-        $beforeThreshold = strtotime('-'.(self::$daysAgo+1).' days', strtotime('31-06-2009 00:00:00'));
+        $afterThreshold = strtotime('-' . (self::$daysAgo - 1) . ' days', strtotime('31-06-2009 00:00:00'));
+        $beforeThreshold = strtotime('-' . (self::$daysAgo + 1) . ' days', strtotime('31-06-2009 00:00:00'));
 
         $after = $this->objFromFixture(SiteTree::class, 'after');
         $before = $this->objFromFixture(SiteTree::class, 'before');
-
-        DB::query("UPDATE \"SiteTree\" SET \"Created\"='2009-01-01 00:00:00', \"LastEdited\"='".date('Y-m-d H:i:s', $afterThreshold)."' WHERE \"ID\"='".$after->ID."'");
-        DB::query("UPDATE \"SiteTree\" SET \"Created\"='2009-01-01 00:00:00', \"LastEdited\"='".date('Y-m-d H:i:s', $beforeThreshold)."' WHERE \"ID\"='".$before->ID."'");
+        DB::query(
+            "UPDATE \"SiteTree\" SET \"Created\"='2009-01-01 00:00:00', \"LastEdited\"='" .
+            date('Y-m-d H:i:s', $afterThreshold) . "' WHERE \"ID\"='" . $after->ID . "'"
+        );
+        DB::query(
+            "UPDATE \"SiteTree\" SET \"Created\"='2009-01-01 00:00:00', \"LastEdited\"='" .
+            date('Y-m-d H:i:s', $beforeThreshold) . "' WHERE \"ID\"='" . $before->ID . "'"
+        );
     }
 
     /**
@@ -52,13 +55,27 @@ class CmsReportsTest extends SapphireTest
 
         // ASSERT that the "draft" report is returning the correct results.
         $parameters = ['CheckSite' => 'Draft'];
-        $results = count($report->sourceRecords($parameters, null, null) ?? []) > 0;
-        $isDraftBroken ? $this->assertTrue($results, "{$class} has NOT returned the correct DRAFT results, as NO pages were found.") : $this->assertFalse($results, "{$class} has NOT returned the correct DRAFT results, as pages were found.");
+        $results = count($report->sourceRecords($parameters, null, null)) > 0;
+        $isDraftBroken
+            ? $this->assertTrue(
+                $results,
+                "{$class} has NOT returned the correct DRAFT results, as NO pages were found."
+            ) : $this->assertFalse(
+                $results,
+                "{$class} has NOT returned the correct DRAFT results, as pages were found."
+            );
 
         // ASSERT that the "published" report is returning the correct results.
         $parameters = ['CheckSite' => 'Published', 'OnLive' => 1];
         $results = count($report->sourceRecords($parameters, null, null) ?? []) > 0;
-        $isPublishedBroken ? $this->assertTrue($results, "{$class} has NOT returned the correct PUBLISHED results, as NO pages were found.") : $this->assertFalse($results, "{$class} has NOT returned the correct PUBLISHED results, as pages were found.");
+        $isPublishedBroken
+            ? $this->assertTrue(
+                $results,
+                "{$class} has NOT returned the correct PUBLISHED results, as NO pages were found."
+            ) : $this->assertFalse(
+                $results,
+                "{$class} has NOT returned the correct PUBLISHED results, as pages were found."
+            );
     }
 
     public function testRecentlyEdited()
@@ -81,18 +98,14 @@ class CmsReportsTest extends SapphireTest
     /**
      *  Test the broken links side report.
      */
-
     public function testBrokenLinks()
     {
-
         // Create a "draft" page with a broken link.
-
-        $page = Page::create();
+        $page = new SiteTree();
         $page->Content = "<a href='[sitetree_link,id=987654321]'>This</a> is a broken link.";
         $page->writeToStage('Stage');
 
         // Retrieve the broken links side report.
-
         $reports = Report::get_reports();
         $brokenLinksReport = null;
         foreach ($reports as $report) {
@@ -109,12 +122,11 @@ class CmsReportsTest extends SapphireTest
         }
 
         // ASSERT that the "draft" report has detected the page having a broken link.
-        // ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
-
+        // ASSERT that the "published" report has NOT detected the page having a broken link,
+        // as the page has not been "published" yet.
         $this->isReportBroken($brokenLinksReport, true, false);
 
         // Make sure the page is now "published".
-
         $page->writeToStage('Live');
 
         // ASSERT that the "draft" report has detected the page having a broken link.
@@ -123,17 +135,15 @@ class CmsReportsTest extends SapphireTest
         $this->isReportBroken($brokenLinksReport, true, true);
 
         // Correct the "draft" broken link.
-
         $page->Content = str_replace('987654321', $page->ID ?? '', $page->Content ?? '');
         $page->writeToStage('Stage');
 
         // ASSERT that the "draft" report has NOT detected the page having a broken link.
-        // ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
-
+        // ASSERT that the "published" report has detected the page having a broken link,
+        // as the previous content remains "published".
         $this->isReportBroken($brokenLinksReport, false, true);
 
         // Make sure the change has now been "published".
-
         $page->writeToStage('Live');
 
         // ASSERT that the "draft" report has NOT detected the page having a broken link.
@@ -145,18 +155,14 @@ class CmsReportsTest extends SapphireTest
     /**
      *  Test the broken files side report.
      */
-
     public function testBrokenFiles()
     {
-
         // Create a "draft" page with a broken file.
-
-        $page = Page::create();
+        $page = new SiteTree();
         $page->Content = "<a href='[file_link,id=987654321]'>This</a> is a broken file.";
         $page->writeToStage('Stage');
 
         // Retrieve the broken files side report.
-
         $reports = Report::get_reports();
         $brokenFilesReport = null;
         foreach ($reports as $report) {
@@ -173,21 +179,18 @@ class CmsReportsTest extends SapphireTest
         }
 
         // ASSERT that the "draft" report has detected the page having a broken file.
-        // ASSERT that the "published" report has NOT detected the page having a broken file, as the page has not been "published" yet.
-
+        // ASSERT that the "published" report has NOT detected the page having a broken file,
+        // as the page has not been "published" yet.
         $this->isReportBroken($brokenFilesReport, true, false);
 
         // Make sure the page is now "published".
-
         $page->writeToStage('Live');
 
         // ASSERT that the "draft" report has detected the page having a broken file.
         // ASSERT that the "published" report has detected the page having a broken file.
-
         $this->isReportBroken($brokenFilesReport, true, true);
 
         // Correct the "draft" broken file.
-
         $file = File::create();
         $file->Filename = 'name.pdf';
         $file->write();
@@ -195,17 +198,15 @@ class CmsReportsTest extends SapphireTest
         $page->writeToStage('Stage');
 
         // ASSERT that the "draft" report has NOT detected the page having a broken file.
-        // ASSERT that the "published" report has detected the page having a broken file, as the previous content remains "published".
-
+        // ASSERT that the "published" report has detected the page having a broken file,
+        // as the previous content remains "published".
         $this->isReportBroken($brokenFilesReport, false, true);
 
         // Make sure the change has now been "published".
-
         $page->writeToStage('Live');
 
         // ASSERT that the "draft" report has NOT detected the page having a broken file.
         // ASSERT that the "published" report has NOT detected the page having a broken file.
-
         $this->isReportBroken($brokenFilesReport, false, false);
     }
 
@@ -215,15 +216,12 @@ class CmsReportsTest extends SapphireTest
 
     public function testBrokenVirtualPages()
     {
-
         // Create a "draft" virtual page with a broken link.
-
         $page = VirtualPage::create();
         $page->CopyContentFromID = 987654321;
         $page->writeToStage('Stage');
 
         // Retrieve the broken virtual pages side report.
-
         $reports = Report::get_reports();
         $brokenVirtualPagesReport = null;
         foreach ($reports as $report) {
@@ -240,22 +238,19 @@ class CmsReportsTest extends SapphireTest
         }
 
         // ASSERT that the "draft" report has detected the page having a broken link.
-        // ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
-
+        // ASSERT that the "published" report has NOT detected the page having a broken link,
+        // as the page has not been "published" yet.
         $this->isReportBroken($brokenVirtualPagesReport, true, false);
 
         // Make sure the page is now "published".
-
         $page->writeToStage('Live');
 
         // ASSERT that the "draft" report has detected the page having a broken link.
         // ASSERT that the "published" report has detected the page having a broken link.
-
         $this->isReportBroken($brokenVirtualPagesReport, true, true);
 
         // Correct the "draft" broken link.
-
-        $contentPage = Page::create();
+        $contentPage = new SiteTree();
         $contentPage->Content = 'This is some content.';
         $contentPage->writeToStage('Stage');
         $contentPage->writeToStage('Live');
@@ -263,36 +258,30 @@ class CmsReportsTest extends SapphireTest
         $page->writeToStage('Stage');
 
         // ASSERT that the "draft" report has NOT detected the page having a broken link.
-        // ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
-
+        // ASSERT that the "published" report has detected the page having a broken link,
+        // as the previous content remains "published".
         $this->isReportBroken($brokenVirtualPagesReport, false, true);
 
         // Make sure the change has now been "published".
-
         $page->writeToStage('Live');
 
         // ASSERT that the "draft" report has NOT detected the page having a broken link.
         // ASSERT that the "published" report has NOT detected the page having a broken link.
-
         $this->isReportBroken($brokenVirtualPagesReport, false, false);
     }
 
     /**
      *  Test the broken redirector pages side report.
      */
-
     public function testBrokenRedirectorPages()
     {
-
         // Create a "draft" redirector page with a broken link.
-
         $page = RedirectorPage::create();
         $page->RedirectionType = 'Internal';
         $page->LinkToID = 987654321;
         $page->writeToStage('Stage');
 
         // Retrieve the broken redirector pages side report.
-
         $reports = Report::get_reports();
         $brokenRedirectorPagesReport = null;
         foreach ($reports as $report) {
@@ -309,22 +298,19 @@ class CmsReportsTest extends SapphireTest
         }
 
         // ASSERT that the "draft" report has detected the page having a broken link.
-        // ASSERT that the "published" report has NOT detected the page having a broken link, as the page has not been "published" yet.
-
+        // ASSERT that the "published" report has NOT detected the page having a broken link,
+        // as the page has not been "published" yet.
         $this->isReportBroken($brokenRedirectorPagesReport, true, false);
 
         // Make sure the page is now "published".
-
         $page->writeToStage('Live');
 
         // ASSERT that the "draft" report has detected the page having a broken link.
         // ASSERT that the "published" report has detected the page having a broken link.
-
         $this->isReportBroken($brokenRedirectorPagesReport, true, true);
 
         // Correct the "draft" broken link.
-
-        $contentPage = Page::create();
+        $contentPage = new SiteTree();
         $contentPage->Content = 'This is some content.';
         $contentPage->writeToStage('Stage');
         $contentPage->writeToStage('Live');
@@ -332,17 +318,15 @@ class CmsReportsTest extends SapphireTest
         $page->writeToStage('Stage');
 
         // ASSERT that the "draft" report has NOT detected the page having a broken link.
-        // ASSERT that the "published" report has detected the page having a broken link, as the previous content remains "published".
-
+        // ASSERT that the "published" report has detected the page having a broken link,
+        // as the previous content remains "published".
         $this->isReportBroken($brokenRedirectorPagesReport, false, true);
 
         // Make sure the change has now been "published".
-
         $page->writeToStage('Live');
 
         // ASSERT that the "draft" report has NOT detected the page having a broken link.
         // ASSERT that the "published" report has NOT detected the page having a broken link.
-
         $this->isReportBroken($brokenRedirectorPagesReport, false, false);
     }
 }

--- a/tests/php/Search/CMSMainSearchFormTest.php
+++ b/tests/php/Search/CMSMainSearchFormTest.php
@@ -20,7 +20,7 @@ class CMSMainSearchFormTest extends FunctionalTest
                 'q' => [
                     'Term' => 'Page 10',
                     'FilterClass' => CMSSiteTreeFilter_Search::class,
-                ]
+                ],
             ])
         );
 

--- a/tests/php/Search/SearchFormTest.php
+++ b/tests/php/Search/SearchFormTest.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Tests\Search;
 
-use Page;
 use SilverStripe\Assets\File;
 use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\CMS\Controllers\ModelAsController;
@@ -29,7 +28,6 @@ use TractorCow\Fluent\Extension\FluentSiteTreeExtension;
  */
 class ZZZSearchFormTest extends FunctionalTest
 {
-
     protected static $fixture_file = 'SearchFormTest.yml';
 
     protected static $illegal_extensions = [

--- a/tests/php/Tasks/RemoveOrphanedPagesTaskTest.php
+++ b/tests/php/Tasks/RemoveOrphanedPagesTaskTest.php
@@ -3,8 +3,8 @@
 namespace SilverStripe\CMS\Tests\Tasks;
 
 use SilverStripe\CMS\Tasks\RemoveOrphanedPagesTask;
-use SilverStripe\Versioned\Versioned;
 use SilverStripe\Dev\FunctionalTest;
+use SilverStripe\CMS\Model\SiteTree;
 
 /**
  * <h2>Fixture tree</h2>
@@ -42,54 +42,54 @@ class RemoveOrphanedPagesTaskTest extends FunctionalTest
     {
         parent::setUp();
 
-        $parent1_published = $this->objFromFixture('Page', 'parent1_published');
+        $parent1_published = $this->objFromFixture(SiteTree::class, 'parent1_published');
         $parent1_published->publishSingle();
 
-        $child1_1_published = $this->objFromFixture('Page', 'child1_1_published');
+        $child1_1_published = $this->objFromFixture(SiteTree::class, 'child1_1_published');
         $child1_1_published->publishSingle();
 
-        $child1_2_published = $this->objFromFixture('Page', 'child1_2_published');
+        $child1_2_published = $this->objFromFixture(SiteTree::class, 'child1_2_published');
         $child1_2_published->publishSingle();
 
-        $child1_3_orphaned = $this->objFromFixture('Page', 'child1_3_orphaned');
+        $child1_3_orphaned = $this->objFromFixture(SiteTree::class, 'child1_3_orphaned');
         $child1_3_orphaned->ParentID = 9999;
         $child1_3_orphaned->write();
 
-        $child1_4_orphaned_published = $this->objFromFixture('Page', 'child1_4_orphaned_published');
+        $child1_4_orphaned_published = $this->objFromFixture(SiteTree::class, 'child1_4_orphaned_published');
         $child1_4_orphaned_published->ParentID = 9999;
         $child1_4_orphaned_published->write();
         $child1_4_orphaned_published->publishSingle();
 
-        $grandchild1_1_2_published = $this->objFromFixture('Page', 'grandchild1_1_2_published');
+        $grandchild1_1_2_published = $this->objFromFixture(SiteTree::class, 'grandchild1_1_2_published');
         $grandchild1_1_2_published->publishSingle();
 
-        $grandchild1_1_3_orphaned = $this->objFromFixture('Page', 'grandchild1_1_3_orphaned');
+        $grandchild1_1_3_orphaned = $this->objFromFixture(SiteTree::class, 'grandchild1_1_3_orphaned');
         $grandchild1_1_3_orphaned->ParentID = 9999;
         $grandchild1_1_3_orphaned->write();
 
         $grandchild1_1_4_orphaned_published = $this->objFromFixture(
-            'Page',
+            SiteTree::class,
             'grandchild1_1_4_orphaned_published'
         );
         $grandchild1_1_4_orphaned_published->ParentID = 9999;
         $grandchild1_1_4_orphaned_published->write();
         $grandchild1_1_4_orphaned_published->publishSingle();
 
-        $child2_1_published_orphaned = $this->objFromFixture('Page', 'child2_1_published_orphaned');
+        $child2_1_published_orphaned = $this->objFromFixture(SiteTree::class, 'child2_1_published_orphaned');
         $child2_1_published_orphaned->publishSingle();
     }
 
     public function testGetOrphansByStage()
     {
         // all orphans
-        $child1_3_orphaned = $this->objFromFixture('Page', 'child1_3_orphaned');
-        $child1_4_orphaned_published = $this->objFromFixture('Page', 'child1_4_orphaned_published');
-        $grandchild1_1_3_orphaned = $this->objFromFixture('Page', 'grandchild1_1_3_orphaned');
+        $child1_3_orphaned = $this->objFromFixture(SiteTree::class, 'child1_3_orphaned');
+        $child1_4_orphaned_published = $this->objFromFixture(SiteTree::class, 'child1_4_orphaned_published');
+        $grandchild1_1_3_orphaned = $this->objFromFixture(SiteTree::class, 'grandchild1_1_3_orphaned');
         $grandchild1_1_4_orphaned_published = $this->objFromFixture(
-            'Page',
+            SiteTree::class,
             'grandchild1_1_4_orphaned_published'
         );
-        $child2_1_published_orphaned = $this->objFromFixture('Page', 'child2_1_published_orphaned');
+        $child2_1_published_orphaned = $this->objFromFixture(SiteTree::class, 'child2_1_published_orphaned');
 
         $task = singleton(RemoveOrphanedPagesTask::class);
         $orphans = $task->getOrphanedPages();
@@ -100,7 +100,7 @@ class RemoveOrphanedPagesTaskTest extends FunctionalTest
             $child1_4_orphaned_published->ID,
             $grandchild1_1_3_orphaned->ID,
             $grandchild1_1_4_orphaned_published->ID,
-            $child2_1_published_orphaned->ID
+            $child2_1_published_orphaned->ID,
         ];
         sort($compareIDs);
 

--- a/tests/php/Tasks/RemoveOrphanedPagesTaskTest.yml
+++ b/tests/php/Tasks/RemoveOrphanedPagesTaskTest.yml
@@ -1,32 +1,32 @@
-Page:
+SilverStripe\CMS\Model\SiteTree:
   parent1_published:
     Title: Parent1
   child1_1_published:
     Title: Child1.1
-    Parent: =>Page.parent1_published
+    Parent: =>SilverStripe\CMS\Model\SiteTree.parent1_published
   child1_2_published:
     Title: Child1.2
-    Parent: =>Page.parent1_published
+    Parent: =>SilverStripe\CMS\Model\SiteTree.parent1_published
   child1_3_orphaned:
     Title: Child1.3
-    Parent: =>Page.parent1_published
+    Parent: =>SilverStripe\CMS\Model\SiteTree.parent1_published
   child1_4_orphaned_published:
     Title: Child1.4
-    Parent: =>Page.parent1_published
+    Parent: =>SilverStripe\CMS\Model\SiteTree.parent1_published
   grandchild1_1_1:
     Title: Grandchild1.1.1
-    Parent: =>Page.child1_1_published
+    Parent: =>SilverStripe\CMS\Model\SiteTree.child1_1_published
   grandchild1_1_2_published:
     Title: Grandchild1.1.2
-    Parent: =>Page.child1_1_published
+    Parent: =>SilverStripe\CMS\Model\SiteTree.child1_1_published
   grandchild1_1_3_orphaned:
     Title: Grandchild1.1.3
-    Parent: =>Page.child1_1_published
+    Parent: =>SilverStripe\CMS\Model\SiteTree.child1_1_published
   grandchild1_1_4_orphaned_published:
     Title: Grandchild1.1.4
-    Parent: =>Page.child1_1_published
+    Parent: =>SilverStripe\CMS\Model\SiteTree.child1_1_published
   parent2:
     Title: Parent2
   child2_1_published_orphaned:
     Title: Child2.1
-    Parent: =>Page.parent2
+    Parent: =>SilverStripe\CMS\Model\SiteTree.parent2


### PR DESCRIPTION
Rescues https://github.com/silverstripe/silverstripe-cms/pull/2160/

Note that I've swapped out `::create()` syntax for using the `new` keyword, which is preferred for all tests that don't explicitly need to rely on `Injector`.

## Parent issue
- https://github.com/silverstripe/silverstripe-framework/issues/10350