### PR TITLE
SS5: move updateRelativeLink hook after concatination

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -696,7 +696,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
         $link = Controller::join_links($base, '/', $action);
 
-        $this->extend('updateRelativeLink', $base, $action, $link);
+        $this->extend('updateRelativeLink', $link, $base, $action);
 
         return $link;
     }

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -688,15 +688,17 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             $base = $this->URLSegment;
         }
 
-        $this->extend('updateRelativeLink', $base, $action);
-
         // Legacy support: If $action === true, retain URLSegment for homepages,
         // but don't append any action
         if ($action === true) {
             $action = null;
         }
 
-        return Controller::join_links($base, '/', $action);
+        $link = Controller::join_links($base, '/', $action);
+
+        $this->extend('updateRelativeLink', $link, $base, $action);
+
+        return $link;
     }
 
     /**

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -696,7 +696,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
         $link = Controller::join_links($base, '/', $action);
 
-        $this->extend('updateRelativeLink', $link, $base, $action);
+        $this->extend('updateRelativeLink', $base, $action, $link);
 
         return $link;
     }

--- a/code/Model/SiteTreeExtension.php
+++ b/code/Model/SiteTreeExtension.php
@@ -77,13 +77,13 @@ abstract class SiteTreeExtension extends DataExtension
      *
      * @param string &$link The URL of this page relative to siteroot including
      * the action
-     * @param string &$base The URL of this page relative to siteroot, not including
+     * @param string $base The URL of this page relative to siteroot, not including
      * the action
-     * @param string|boolean &$action The action or subpage called on this page.
+     * @param string|boolean $action The action or subpage called on this page.
      * (Legacy support) If this is true, then do not reduce the 'home' urlsegment
      * to an empty link
      */
-    public function updateRelativeLink(&$link, &$base, &$action)
+    public function updateRelativeLink(&$link, $base, $action)
     {
     }
 }

--- a/code/Model/SiteTreeExtension.php
+++ b/code/Model/SiteTreeExtension.php
@@ -75,13 +75,15 @@ abstract class SiteTreeExtension extends DataExtension
      * before {@link SiteTree::RelativeLink()} calls {@link Controller::join_links()}
      * on the $base and $action
      *
+     * @param string &$link The URL of this page relative to siteroot including
+     * the action
      * @param string &$base The URL of this page relative to siteroot, not including
      * the action
      * @param string|boolean &$action The action or subpage called on this page.
      * (Legacy support) If this is true, then do not reduce the 'home' urlsegment
      * to an empty link
      */
-    public function updateRelativeLink(&$base, &$action)
+    public function updateRelativeLink(&$link, &$base, &$action)
     {
     }
 }


### PR DESCRIPTION
This is to make the relative actually updatable. 

This picks up https://github.com/silverstripe/silverstripe-cms/pull/2677 again for SS5.