### PR TITLE
ENH Don't use deprecated method doRevertTo()

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -2076,7 +2076,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         }
 
         if ($version) {
-            $record->doRollbackTo($version);
+            $record->rollbackRecursive($version);
             $message = _t(
                 __CLASS__ . '.ROLLEDBACKVERSIONv2',
                 "Rolled back to version #{version}.",

--- a/tests/php/Controllers/CMSSiteTreeFilterTest.php
+++ b/tests/php/Controllers/CMSSiteTreeFilterTest.php
@@ -110,7 +110,7 @@ class CMSSiteTreeFilterTest extends SapphireTest
         $changedPage->Title = 'Changed 2';
         $changedPage->write();
         $changedPage->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
-        $changedPage->doRollbackTo($changedPageVersion);
+        $changedPage->rollbackRecursive($changedPageVersion);
 
         $f = new CMSSiteTreeFilter_ChangedPages(['Term' => 'Changed']);
         $results = $f->pagesIncluded();


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/runs/8126807057?check_suite_focus=true
> SilverStripe\CMS\Tests\Controllers\CMSSiteTreeFilterTest::testChangedPagesFilter
BadMethodCallException: Object->__call(): the method 'doRollbackTo' does not exist on 'SilverStripe\CMS\Model\SiteTree'

Targetting `4` because we want to stop using deprecated code in `4` across the board anyway - so this avoids a duplication of the same work being done.

After merging the PR merge up so we can re-run CMS 5 builds.

## Parent issue
- https://github.com/silverstripeltd/product-issues/issues/591