### PR TITLE
ENH Use the new CMSEditLink extension on SiteTree

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -375,6 +375,16 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         return $this->Link('listview');
     }
 
+    /**
+     * Get the link for editing a page.
+     *
+     * @see CMSEditLinkExtension::getCMSEditLinkForManagedDataObject()
+     */
+    public function getCMSEditLinkForManagedDataObject(SiteTree $obj): string
+    {
+        return Controller::join_links(CMSPageEditController::singleton()->Link('show'), $obj->ID);
+    }
+
     public function LinkPageEdit($id = null)
     {
         if (!$id) {

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -4,7 +4,9 @@ namespace SilverStripe\CMS\Model;
 
 use Page;
 use Psr\SimpleCache\CacheInterface;
+use SilverStripe\Admin\CMSEditLinkExtension;
 use SilverStripe\Assets\Shortcodes\FileLinkTracking;
+use SilverStripe\CMS\Controllers\CMSMain;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
 use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\CMS\Controllers\ModelAsController;
@@ -113,7 +115,6 @@ use SilverStripe\View\SSViewer;
  */
 class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvider, CMSPreviewable, Resettable, Flushable, MemberCacheFlusher
 {
-
     /**
      * Indicates what kind of children this page type can have.
      * This can be an array of allowed child classes, or the string "none" -
@@ -216,6 +217,12 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     private static $controller_name = null;
 
     /**
+     * The class of the LeftAndMain controller where this class is managed.
+     * @see CMSEditLinkExtension::getCMSEditOwner()
+     */
+    private static string $cms_edit_owner = CMSMain::class;
+
+    /**
      * You can define the a map of Page namespaces to Controller namespaces here
      * This will apply after the magic of appending Controller, and in order
      * Must be applied to SiteTree config e.g.
@@ -316,6 +323,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         Hierarchy::class,
         Versioned::class,
         InheritedPermissionsExtension::class,
+        CMSEditLinkExtension::class,
     ];
 
     private static $searchable_fields = [
@@ -734,13 +742,10 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     public function CMSEditLink()
     {
-        $link = Controller::join_links(
-            CMSPageEditController::singleton()->Link('show'),
-            $this->ID
-        );
-        return Director::absoluteURL($link);
+        // This method has to be implemented here to satisfy the CMSPreviewable interface.
+        // See the actual implementation in CMSEditLinkExtension.
+        return $this->extend('CMSEditLink')[0];
     }
-
 
     /**
      * Return a CSS identifier generated from this page's link.

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "silverstripe/admin": "^1.9@dev",
+        "silverstripe/admin": "^1.12@dev",
         "silverstripe/campaign-admin": "^1.7@dev",
         "silverstripe/framework": "^4.11",
         "silverstripe/reports": "^4.7@dev",

--- a/tests/php/Model/CMSEditLinkExtensionTest/BelongsToPage.php
+++ b/tests/php/Model/CMSEditLinkExtensionTest/BelongsToPage.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\CMSEditLinkExtensionTest;
+
+use SilverStripe\Admin\CMSEditLinkExtension;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class BelongsToPage extends DataObject implements TestOnly
+{
+    private static $table_name = 'CMSEditLinkTest_BelongsToPage';
+
+    private static $cms_edit_owner = 'Parent';
+
+    private static $db = [
+        'Name' => 'Varchar(25)',
+    ];
+
+    private static $has_one = [
+        'Parent' => SiteTree::class,
+    ];
+
+    private static $extensions = [
+        CMSEditLinkExtension::class,
+    ];
+}

--- a/tests/php/Model/CMSEditLinkExtensionTest/PageWithChild.php
+++ b/tests/php/Model/CMSEditLinkExtensionTest/PageWithChild.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\CMSEditLinkExtensionTest;
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
+
+class PageWithChild extends SiteTree implements TestOnly
+{
+    private static $has_many = [
+        'ChildObjects' => BelongsToPage::class,
+    ];
+
+    public function getCMSFields()
+    {
+        $fields = parent::getCMSFields();
+        $fields->addFieldToTab(
+            'Root.ChildObjects',
+            GridField::create('ChildObjects', 'ChildObjects', $this->ChildObjects(), GridFieldConfig_RelationEditor::create())
+        );
+        return $fields;
+    }
+}

--- a/tests/php/Model/CMSEditLinkExtensionTest/fixtures.yml
+++ b/tests/php/Model/CMSEditLinkExtensionTest/fixtures.yml
@@ -1,0 +1,9 @@
+SilverStripe\CMS\Tests\CMSEditLinkExtensionTest\BelongsToPage:
+  one:
+    Name: 'some name'
+
+SilverStripe\CMS\Tests\CMSEditLinkExtensionTest\PageWithChild:
+  root:
+    Title: 'page has child'
+    ChildObjects:
+      - '=>SilverStripe\CMS\Tests\CMSEditLinkExtensionTest\BelongsToPage.one'

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -10,6 +10,8 @@ use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\CMS\Model\VirtualPage;
 use SilverStripe\CMS\Tests\Controllers\SiteTreeTest_NamespaceMapTestController;
+use SilverStripe\CMS\Tests\CMSEditLinkExtensionTest\BelongsToPage;
+use SilverStripe\CMS\Tests\CMSEditLinkExtensionTest\PageWithChild;
 use SilverStripe\CMS\Tests\Page\SiteTreeTest_NamespaceMapTest;
 use SilverStripe\Control\ContentNegotiator;
 use SilverStripe\Control\Controller;
@@ -40,7 +42,10 @@ use const RESOURCES_DIR;
 
 class SiteTreeTest extends SapphireTest
 {
-    protected static $fixture_file = 'SiteTreeTest.yml';
+    protected static $fixture_file = [
+        'SiteTreeTest.yml',
+        'CMSEditLinkExtensionTest/fixtures.yml',
+    ];
 
     protected static $illegal_extensions = [
         SiteTree::class => [
@@ -58,6 +63,8 @@ class SiteTreeTest extends SapphireTest
         SiteTreeTest_NotRoot::class,
         SiteTreeTest_StageStatusInherit::class,
         SiteTreeTest_DataObject::class,
+        PageWithChild::class,
+        BelongsToPage::class,
     ];
 
     public function reservedSegmentsProvider()
@@ -1985,5 +1992,29 @@ class SiteTreeTest extends SapphireTest
             'retore action has no form when page archived'
         );
         // END ARCHIVED
+    }
+
+    public function testGetCMSEditLinkForManagedDataObject()
+    {
+        $page = $this->objFromFixture(PageWithChild::class, 'root');
+        $child = $this->objFromFixture(BelongsToPage::class, 'one');
+        $this->assertSame(
+            "http://localhost/admin/pages/edit/show/$page->ID/field/ChildObjects/item/$child->ID",
+            $page->getCMSEditLinkForManagedDataObject($child, 'Parent')
+        );
+    }
+
+    public function testCMSEditLink()
+    {
+        $page = $this->objFromFixture(PageWithChild::class, 'root');
+        $child = $this->objFromFixture(BelongsToPage::class, 'one');
+        $this->assertSame(
+            "http://localhost/admin/pages/edit/show/$page->ID",
+            $page->CMSEditLink()
+        );
+        $this->assertSame(
+            "http://localhost/admin/pages/edit/show/$page->ID/field/ChildObjects/item/$child->ID",
+            $child->CMSEditLink()
+        );
     }
 }


### PR DESCRIPTION
Use the new `CMSEditLink` extension from https://github.com/silverstripe/silverstripe-admin/pull/1361 in `SiteTree` - this means a `has_many` relation from some page can set the page as its canonical edit owner and its `CMSEditLink()` method will automatically have a valid URL.

## Note
- CI won't be green until https://github.com/silverstripe/silverstripe-admin/pull/1361 has been merged.

## Related issue
- https://github.com/silverstripe/silverstripe-admin/issues/1354