### PR TITLE
ENH Records can be made previewable via an extension

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1342,7 +1342,9 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
         // Added in-line to the form, but plucked into different view by LeftAndMain.Preview.js upon load
         /** @skipUpgrade */
-        if ($record instanceof CMSPreviewable && !$fields->fieldByName('SilverStripeNavigator')) {
+        if (($record instanceof CMSPreviewable || $record->has_extension(CMSPreviewable::class))
+            && !$fields->fieldByName('SilverStripeNavigator')
+        ) {
             $navField = new LiteralField('SilverStripeNavigator', $this->getSilverStripeNavigator());
             $navField->setAllowHTML(true);
             $fields->push($navField);
@@ -1393,7 +1395,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         ]);
 
         // Announce the capability so the frontend can decide whether to allow preview or not.
-        if ($record instanceof CMSPreviewable) {
+        if ($record instanceof CMSPreviewable || $record->has_extension(CMSPreviewable::class)) {
             $form->addExtraClass('cms-previewable');
         }
         $form->addExtraClass('fill-height flexbox-area-grow');


### PR DESCRIPTION
Note: There are currently few if any tests for previewable objects - that will come with https://github.com/silverstripe/silverstripe-admin/issues/1306

Requires https://github.com/silverstripe/silverstripe-admin/issues/1362 to be merged in at the same time

See the parent issue for code to test this locally.

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1362