### PR TITLE
Reset ExtraClass on ViewModeSelector include

### DIFF
--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_EditForm.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_EditForm.ss
@@ -28,7 +28,7 @@
 			</a>
 			<% end_if %>
 
-			<% include SilverStripe\\Admin\\LeftAndMain_ViewModeSelector SelectID="preview-mode-dropdown-in-content" %>
+			<% include SilverStripe\\Admin\\LeftAndMain_ViewModeSelector SelectID="preview-mode-dropdown-in-content", ExtraClass='' %>
 		</div>
 		<% end_if %>
 	</div>


### PR DESCRIPTION
Since silverstripe/silverstripe-admin version 1.11 the include `SilverStripe\\Admin\\LeftAndMain_ViewModeSelector` uses an [ExtraClass parameter](https://github.com/silverstripe/silverstripe-admin/blob/6d1998707d7cb96e888a83053c9d34b09d842ed2/templates/SilverStripe/Admin/Includes/LeftAndMain_ViewModeSelector.ss#L1). When this parameter is not explicitly set it inherits the ExtraClass of the template it's included in. In CMSMain this causes the ViewMode button to stretch.

Replaces #2782

## Parent issue
- https://github.com/silverstripe/silverstripe-admin/issues/1324