### PR TITLE
FIX Loosen config order to allow "after: '*'" in framework

### DIFF
--- a/_config/version.yml
+++ b/_config/version.yml
@@ -1,6 +1,6 @@
 ---
 Name: cmsversion
-After: 'framework/*'
+After: 'framework/coreconfig'
 ---
 SilverStripe\Core\Manifest\VersionProvider:
   modules:


### PR DESCRIPTION
There's only one block of config that this affects, which is the `coreconfig` block inside framework. Having `After: 'framework/*'` is stopping us from using `After: '*'` in framework.