### PR TITLE
FIX Cast absoluteUrl() argument to string

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -637,7 +637,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         if ($this->hasMethod('alternateAbsoluteLink')) {
             return $this->alternateAbsoluteLink($action);
         } else {
-            return Director::absoluteURL($this->Link($action));
+            return Director::absoluteURL((string) $this->Link($action));
         }
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/642

Similar to https://github.com/silverstripe/silverstripe-elemental/pull/1029