### PR TITLE
API Remove deprecated CMSMain::$subitem_class config

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -108,12 +108,6 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
 
     private static $tree_class = SiteTree::class;
 
-    /**
-     * @deprecated 1.13.0 Do not use this options.
-     * @config
-     */
-    private static $subitem_class = Member::class;
-
     private static $session_namespace = self::class;
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';


### PR DESCRIPTION
Parent issue: https://github.com/silverstripe/silverstripe-admin/issues/1358