### PR TITLE
MNT Broken builds

### DIFF
--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -2106,8 +2106,8 @@ class SiteTreeTest extends SapphireTest
                 'Multiple attributes are removed'
             ],
             [
-                '<link rel="canonical" href="valid" ;;// somethingdodgy < onmouseover=alert(1)',
-                '<link rel="canonical" href="valid" somethingdodgy="">',
+                '<link rel="canonical" href="valid" ;;// somethingdodgy <onmouseover=alert(1)>',
+                '<link rel="canonical" href="valid" somethingdodgy=""><onmouseover></onmouseover>',
                 'Invalid HTML is converted to valid HTML and parsed'
             ],
         ];


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/659

Fixes `SilverStripe\CMS\Tests\Model\SiteTreeTest::testSanitiseExtraMeta with data set https://github.com/silverstripeltd/product-issues/issues/5 ('<link rel="canonical" href="v...ert(1)', '<link rel="canonical" href="v...gy="">', 'Invalid HTML is converted to ...parsed')
Invalid HTML is converted to valid HTML and parsed`

The HTML parser is different and handles invalid HTML differently.  I've updated the test so that testing that it's removing unsafe (alert="1") attributes on invalid HTML

Broken unit tests are unrelated