### PR TITLE
fix url segment retrieval if it contains "0" (zero)

### DIFF
--- a/code/Controllers/ModelAsController.php
+++ b/code/Controllers/ModelAsController.php
@@ -119,7 +119,8 @@ class ModelAsController extends Controller implements NestedController
     {
         $request = $this->getRequest();
 
-        if (!$URLSegment = $request->param('URLSegment')) {
+        $URLSegment = (string) $request->param('URLSegment');
+        if ($URLSegment == null || !strlen($URLSegment)) {
             throw new Exception('ModelAsController->getNestedController(): was not passed a URLSegment value.');
         }
 


### PR DESCRIPTION
I had brute force attacks on multiple SS sites lately, trying to get into "/0/licence.txt". I haven't found out what software they were looking for, but a URL segment of "0" (zero) throws an 500 error in SS. This change fixes that.