### PR TITLE
API Mark moved classes in silverstripe-admin module as deprecated

### DIFF
--- a/code/Controllers/SilverStripeNavigator.php
+++ b/code/Controllers/SilverStripeNavigator.php
@@ -4,6 +4,7 @@ namespace SilverStripe\CMS\Controllers;
 
 use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\SS_List;
@@ -18,6 +19,9 @@ use SilverStripe\View\ViewableData;
  * New item types can be defined by extending the {@link SilverStripeNavigatorItem} class,
  * for example the "cmsworkflow" module defines a new "future state" item with a date selector
  * to view embargoed data at a future point in time. So the item doesn't always have to be a simple link.
+ *
+ * Class will be moved from `silverstripe/cms` to `silverstripe/admin`
+ * @deprecated 4.13.0 Will be renamed SilverStripe\Admin\Navigator\SilverStripeNavigator
  */
 class SilverStripeNavigator extends ViewableData
 {
@@ -32,6 +36,13 @@ class SilverStripeNavigator extends ViewableData
      */
     public function __construct(CMSPreviewable $record)
     {
+        Deprecation::withNoReplacement(function () {
+            Deprecation::notice(
+                '4.13.0',
+                'Will be renamed SilverStripe\Admin\Navigator\SilverStripeNavigator',
+                Deprecation::SCOPE_CLASS
+            );
+        });
         parent::__construct();
         $this->record = $record;
     }

--- a/code/Controllers/SilverStripeNavigatorItem.php
+++ b/code/Controllers/SilverStripeNavigatorItem.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\CMS\Controllers;
 
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
@@ -12,6 +13,9 @@ use SilverStripe\View\ViewableData;
  * Navigator items are links that appear in the $SilverStripeNavigator bar.
  * To add an item, extend this class - it will be automatically picked up.
  * When instanciating items manually, please ensure to call {@link canView()}.
+ *
+ * Class have been moved from `silverstripe/cms` to `silverstripe/admin` and renamed.
+ * @deprecated Will be renamed SilverStripe\Admin\Navigator\SilverStripeNavigatorItem
  */
 abstract class SilverStripeNavigatorItem extends ViewableData
 {
@@ -24,11 +28,26 @@ abstract class SilverStripeNavigatorItem extends ViewableData
     /** @var string */
     protected $recordLink;
 
-    /**
-     * @param DataObject|CMSPreviewable $record
-     */
     public function __construct(CMSPreviewable $record)
     {
+        Deprecation::withNoReplacement(function () {
+            switch (static::class) {
+                // These classes have their own deprecation notice
+                case 'SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_ArchiveLink':
+                case 'SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_LiveLink':
+                case 'SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_StageLink':
+                case 'SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_Unversioned':
+                // This class is not deprecated and doesn't have a deprecation notice
+                case 'SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_CMSLink':
+                    break;
+                default:
+                    Deprecation::notice(
+                        '4.13.0',
+                        'Will be renamed SilverStripe\Admin\Navigator\SilverStripeNavigatorItem',
+                        Deprecation::SCOPE_CLASS
+                    );
+            }
+        });
         parent::__construct();
         $this->record = $record;
     }

--- a/code/Controllers/SilverStripeNavigatorItem_ArchiveLink.php
+++ b/code/Controllers/SilverStripeNavigatorItem_ArchiveLink.php
@@ -4,13 +4,34 @@ namespace SilverStripe\CMS\Controllers;
 use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Convert;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * Class will be moved from `silverstripe/cms` to `silverstripe/admin`
+ * @deprecated 4.13.0 Will be renamed SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink
+ */
 class SilverStripeNavigatorItem_ArchiveLink extends SilverStripeNavigatorItem
 {
+    /**
+     * @param DataObject|CMSPreviewable $record
+     */
+    public function __construct(CMSPreviewable $record)
+    {
+        Deprecation::withNoReplacement(function () {
+            Deprecation::notice(
+                '4.13.0',
+                'Will be renamed SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_ArchiveLink',
+                Deprecation::SCOPE_CLASS
+            );
+        });
+        parent::__construct($record);
+    }
+
     /** @config */
     private static $priority = 40;
 

--- a/code/Controllers/SilverStripeNavigatorItem_LiveLink.php
+++ b/code/Controllers/SilverStripeNavigatorItem_LiveLink.php
@@ -1,15 +1,32 @@
 <?php
 namespace SilverStripe\CMS\Controllers;
 
-use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * Class will be moved from `silverstripe/cms` to `silverstripe/admin`.
+ * @deprecated 4.13.0 Will be renamed SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink
+ */
 class SilverStripeNavigatorItem_LiveLink extends SilverStripeNavigatorItem
 {
+    public function __construct(CMSPreviewable $record)
+    {
+        Deprecation::withNoReplacement(function () {
+            Deprecation::notice(
+                '4.13.0',
+                'Will be renamed SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_LiveLink',
+                Deprecation::SCOPE_CLASS
+            );
+        });
+        parent::__construct($record);
+    }
+
     /** @config */
     private static $priority = 30;
 

--- a/code/Controllers/SilverStripeNavigatorItem_StageLink.php
+++ b/code/Controllers/SilverStripeNavigatorItem_StageLink.php
@@ -1,17 +1,33 @@
 <?php
 namespace SilverStripe\CMS\Controllers;
 
-use SilverStripe\CMS\Model\RedirectorPage;
 use SilverStripe\Control\Controller;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Convert;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Versioned\Versioned;
 use SiteTreeFutureState;
 
+/**
+ * Class will be moved from `silverstripe/cms` to `silverstripe/admin`.
+ * @deprecated 4.13.0 Will be renamed SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink
+ */
 class SilverStripeNavigatorItem_StageLink extends SilverStripeNavigatorItem
 {
+    public function __construct(CMSPreviewable $record)
+    {
+        Deprecation::withNoReplacement(function () {
+            Deprecation::notice(
+                '4.13.0',
+                'Will be renamed SilverStripe\VersionedAdmin\Navigator\SilverStripeNavigatorItem_StageLink',
+                Deprecation::SCOPE_CLASS
+            );
+        });
+        parent::__construct($record);
+    }
     /** @config */
     private static $priority = 20;
 

--- a/code/Controllers/SilverStripeNavigatorItem_Unversioned.php
+++ b/code/Controllers/SilverStripeNavigatorItem_Unversioned.php
@@ -5,11 +5,29 @@ namespace SilverStripe\CMS\Controllers;
 use SilverStripe\CMS\Controllers\SilverStripeNavigatorItem;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Convert;
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\ORM\CMSPreviewable;
 use SilverStripe\Security\Member;
 use SilverStripe\Versioned\Versioned;
 
+/**
+ * Class will be moved from `silverstripe/cms` to `silverstripe/admin`.
+ * @deprecated 4.13.0 Will be renamed SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned
+ */
 class SilverStripeNavigatorItem_Unversioned extends SilverStripeNavigatorItem
 {
+    public function __construct(CMSPreviewable $record)
+    {
+        Deprecation::withNoReplacement(function () {
+            Deprecation::notice(
+                '4.13.0',
+                'Will be renamed SilverStripe\Admin\Navigator\SilverStripeNavigatorItem_Unversioned',
+                Deprecation::SCOPE_CLASS
+            );
+        });
+        parent::__construct($record);
+    }
+
     public function getHTML()
     {
         $recordLink = Convert::raw2att($this->getLink());


### PR DESCRIPTION
### Description
The following classes have been moved from silverstripe/cms module in silverstripe/admin. They are no longer exist in cms module and were marked as deprecated. Direction, about classes that replace deprecated classes and should be used instead,  was provided.
- SilverStripe\CMS\Controllers\SilverStripeNavigator
- SilverStripe\CMS\Controllers\SilverStripeNavigatorItem
- SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_Unversioned
- SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_ArchiveLink
- SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_LiveLink
- SilverStripe\CMS\Controllers\SilverStripeNavigatorItem_StageLink

### Parent issue
- https://github.com/silverstripeltd/product-issues/issues/699