### PR TITLE
MNT Revert erroneous dependency changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "silverstripe/admin": "1.13.x-dev",
-        "silverstripe/campaign-admin": "1.13.x-dev",
-        "silverstripe/framework": "4.13.x-dev",
-        "silverstripe/reports": "4.13.x-dev",
-        "silverstripe/siteconfig": "4.13.x-dev",
-        "silverstripe/versioned": "1.13.x-dev",
-        "silverstripe/versioned-admin": "1.13.x-dev",
+        "silverstripe/admin": "^1.12@dev",
+        "silverstripe/campaign-admin": "^1.7@dev",
+        "silverstripe/framework": "^4.11",
+        "silverstripe/reports": "^4.7@dev",
+        "silverstripe/siteconfig": "^4.7@dev",
+        "silverstripe/versioned": "^1.7@dev",
+        "silverstripe/versioned-admin": "^1.7@dev",
         "silverstripe/vendor-plugin": "^1.0",
         "php": "^7.4 || ^8.0"
     },


### PR DESCRIPTION
Bad logic in cow resulted in many non-recipes having their constraints updated automatically when the beta was released.

See https://github.com/silverstripe/silverstripe-cms/commit/8b574c81c74529df6b8e04a68d954e5db2b2d8a3

## Issue
- https://github.com/silverstripe/.github/issues/33