### PR TITLE
FIX undefined index error in CMS

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -739,13 +739,15 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     /**
      * Generates a link to edit this page in the CMS.
      *
+     * Implemented here to satisfy the CMSPreviewable interface, but data is intended to be loaded via Extension
+     *
+     * @see SilverStripe\Admin\CMSEditLinkExtension
+     *
      * @return string
      */
     public function CMSEditLink()
     {
-        // This method has to be implemented here to satisfy the CMSPreviewable interface.
-        // See the actual implementation in CMSEditLinkExtension.
-        return $this->extend('CMSEditLink')[0];
+        return $this->extend('CMSEditLink')[0] ?? '';
     }
 
     /**


### PR DESCRIPTION
With the CMS 4.12 update functionality was altered to utilise an Extension to obtain the CMS Edit link for a page, rather than having SiteTree do it internally. Unfortunately the default return case for `extend` (see Extensible) is an _empty_ array. This leaves code potentially referencing an array offset that doesn't exist ([0]). PHP 8 is less forgiving than its predecessors on this kind of behaviour. We should check that the responses from extensions exist before trying to reference them.