### PR TITLE
FIX Duplicate page keeps original pages canView and canEdit permission

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -270,6 +270,11 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         'VirtualPages',
     ];
 
+    private static $cascade_duplicates = [
+        'ViewerGroups',
+        'EditorGroups',
+    ];
+
     private static $casting = [
         "Breadcrumbs" => "HTMLFragment",
         "LastEdited" => "Datetime",

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -2112,4 +2112,82 @@ class SiteTreeTest extends SapphireTest
             ],
         ];
     }
+
+    /**
+     * Test permissions on duplicate page
+     * @dataProvider groupWithPermissions
+     * @param string $userName
+     * @param string $action
+     * @param array  $expected
+     * @param string $assertionMessage
+     */
+    public function testDuplicatePageWithGroupPermissions($userName, $action, $assertion, $message)
+    {
+        $originalPage = $this->objFromFixture(SiteTree::class, 'originalpage');
+        $user = $this->objFromFixture(Member::class, $userName);
+        $dupe = $originalPage->duplicate();
+
+        $this->assertEquals($originalPage->Title, $dupe->Title);
+        $this->assertEquals($dupe->CanViewType, 'OnlyTheseUsers');
+        $this->assertEquals($dupe->CanEditType, 'OnlyTheseUsers');
+
+        $this->{$assertion}($dupe->{$action}($user), $message);
+    }
+
+    /**
+     * @return array
+     */
+    public function groupWithPermissions()
+    {
+        return [
+            [
+                'admin',
+                'canView',
+                'assertTrue',
+                'Admin can view page duplicate.',
+            ],
+            [
+                'admin',
+                'canEdit',
+                'assertTrue',
+                'Admin can edit page duplicate.',
+            ],
+            [
+                'editor',
+                'canView',
+                'assertTrue',
+                'Editor can view page duplicate.',
+            ],
+            [
+                'editor',
+                'canEdit',
+                'assertTrue',
+                'Editor can edit page duplicate.',
+            ],
+            [
+                'allsections',
+                'canView',
+                'assertTrue',
+                'User with "allsections" permission can view page duplicate.',
+            ],
+            [
+                'allsections',
+                'canEdit',
+                'assertFalse',
+                'User with "allsections" permission cannot edit page duplicate.',
+            ],
+            [
+                'websiteuser',
+                'canView',
+                'assertFalse',
+                'Websiteuser permission cannot view page duplicate.',
+            ],
+            [
+                'websiteuser',
+                'canEdit',
+                'assertFalse',
+                'Websiteuser permission cannot edit page duplicate.',
+            ],
+        ];
+    }
 }

--- a/tests/php/Model/SiteTreeTest.yml
+++ b/tests/php/Model/SiteTreeTest.yml
@@ -15,6 +15,8 @@ SilverStripe\Security\Group:
     Title: All Section Editors
   securityadmins:
     Title: Security Admins
+  websiteuser:
+    Title: General User
 
 SilverStripe\Security\Permission:
   admins:
@@ -43,6 +45,9 @@ SilverStripe\Security\Member:
     Groups: =>SilverStripe\Security\Group.allsections
   securityadmin:
     Groups: =>SilverStripe\Security\Group.securityadmins
+  websiteuser:
+    FirstName: Websiteuser
+    Groups: =>SilverStripe\Security\Group.websiteuser
 
 SilverStripe\CMS\Model\SiteTree:
   home:
@@ -112,6 +117,12 @@ SilverStripe\CMS\Model\SiteTree:
   breadcrumbs5:
     Title: 'Breadcrumbs 5'
     Parent: =>SilverStripe\CMS\Model\SiteTree.breadcrumbs4
+  originalpage:
+    Title: Original Page for duplicate
+    CanEditType: OnlyTheseUsers
+    CanViewType: OnlyTheseUsers
+    EditorGroups: =>SilverStripe\Security\Group.admins,=>SilverStripe\Security\Group.editors
+    ViewerGroups: =>SilverStripe\Security\Group.admins,=>SilverStripe\Security\Group.editors,=>SilverStripe\Security\Group.allsections
 
 SilverStripe\CMS\Tests\Model\SiteTreeTest_Conflicted:
   parent:


### PR DESCRIPTION
## Description
- Add property `cascade_duplicates` to SiteTree class with specified relation names to duplicate and save against the new clone object. 

## Parent issue
- https://github.com/silverstripe/silverstripe-cms/issues/2609