### PR TITLE
FIX Duplicate page keeps original pages canView and canEdit permission

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^8.1",
         "silverstripe/admin": "^2",
         "silverstripe/campaign-admin": "^2",
-        "silverstripe/framework": "^5",
+        "silverstripe/framework": "^5.1",
         "silverstripe/reports": "^5",
         "silverstripe/siteconfig": "^5",
         "silverstripe/versioned": "^2",

--- a/tests/php/Model/SiteTreePermissionsTest.php
+++ b/tests/php/Model/SiteTreePermissionsTest.php
@@ -525,4 +525,66 @@ class SiteTreePermissionsTest extends FunctionalTest
             'to OnlyTheseUsers'
         );
     }
+
+    /**
+     * Test permissions on duplicate page
+     * @dataProvider groupWithPermissions
+     */
+    public function testDuplicatePageWithGroupPermissions(string $userName, string $method, bool $expected)
+    {
+        $originalPage = $this->objFromFixture(SiteTree::class, 'originalpage');
+        $user = $this->objFromFixture(Member::class, $userName);
+        $dupe = $originalPage->duplicate();
+
+        $this->assertEquals($originalPage->Title, $dupe->Title);
+        $this->assertEquals($dupe->CanViewType, 'OnlyTheseUsers');
+        $this->assertEquals($dupe->CanEditType, 'OnlyTheseUsers');
+        $this->assertSame($dupe->{$method}($user), $expected);
+    }
+
+    public function groupWithPermissions(): array
+    {
+        return [
+            'Subadmin can view page duplicate.' => [
+                'subadmin',
+                'canView',
+                true,
+            ],
+            'Subadmin can edit page duplicate.' => [
+                'subadmin',
+                'canEdit',
+                true,
+            ],
+            'Editor can view page duplicate.' => [
+                'editor',
+                'canView',
+                true,
+            ],
+            'Editor can edit page duplicate.' => [
+                'editor',
+                'canEdit',
+                true,
+            ],
+            'User with "allsections" permission can view page duplicate.' => [
+                'allsections',
+                'canView',
+                true,
+            ],
+            'User with "allsections" permission cannot edit page duplicate.' => [
+                'allsections',
+                'canEdit',
+                false,
+            ],
+            'Websiteuser permission cannot view page duplicate.' => [
+                'websiteuser',
+                'canView',
+                false,
+            ],
+            'Websiteuser permission cannot edit page duplicate.' => [
+                'websiteuser',
+                'canEdit',
+                false,
+            ],
+        ];
+    }
 }

--- a/tests/php/Model/SiteTreePermissionsTest.yml
+++ b/tests/php/Model/SiteTreePermissionsTest.yml
@@ -11,6 +11,8 @@ SilverStripe\Security\Permission:
     Code: CMS_ACCESS_CMSMain
   grantaccess:
     Code: SITETREE_GRANT_ACCESS
+  allsections:
+    Code: CMS_ACCESS_LeftAndMain
 SilverStripe\Security\Group:
   subadmingroup:
     Title: Create, edit and delete pages
@@ -20,6 +22,9 @@ SilverStripe\Security\Group:
     Title: Edit existing pages
     Code: editorgroup
     Permissions: =>SilverStripe\Security\Permission.cmsmain2
+  allsectionsgroup:
+    Title: All Section Editors
+    Permissions: =>SilverStripe\Security\Permission.allsections
   websiteusers:
     Title: View certain restricted pages
 SilverStripe\Security\Member:
@@ -31,6 +36,10 @@ SilverStripe\Security\Member:
     Email: editor@test.com
     Password: test
     Groups: =>SilverStripe\Security\Group.editorgroup
+  allsections:
+    Email: allsections@test.com
+    Password: test
+    Groups: =>SilverStripe\Security\Group.allsectionsgroup
   websiteuser:
     Email: websiteuser@test.com
     Password: test
@@ -86,3 +95,9 @@ SilverStripe\CMS\Model\SiteTree:
   draftOnlyPage:
     CanViewType: Anyone
     URLSegment: draft-only
+  originalpage:
+    Title: Original Page for duplicate
+    CanEditType: OnlyTheseUsers
+    CanViewType: OnlyTheseUsers
+    EditorGroups: =>SilverStripe\Security\Group.subadmingroup,=>SilverStripe\Security\Group.editorgroup
+    ViewerGroups: =>SilverStripe\Security\Group.subadmingroup,=>SilverStripe\Security\Group.editorgroup,=>SilverStripe\Security\Group.allsectionsgroup


### PR DESCRIPTION
## Description
- Add property `cascade_duplicates` to SiteTree class with specified relation names to duplicate and save against the new clone object. 

## Parent issue
- https://github.com/silverstripe/silverstripe-cms/issues/2609