### PR TITLE
FIX SiteTree::DependentPages method returns non-SiteTree instance

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2612,8 +2612,10 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
         // Need to update pages linking to this one as no longer broken
         foreach ($stageSelf->DependentPages() as $page) {
-            /** @var SiteTree $page */
-            $page->writeWithoutVersion();
+            if ($page->hasExtension(Versioned::class)) {
+                /** @var Versioned $page */
+                $page->writeWithoutVersion();
+            }
         }
     }
 

--- a/tests/php/Model/SiteTreeTest.yml
+++ b/tests/php/Model/SiteTreeTest.yml
@@ -128,3 +128,7 @@ SilverStripe\CMS\Tests\Model\SiteTreeTest_DataObject:
   relations:
     Title: 'Linked DataObject'
     Pages: =>Page.home,=>Page.about,=>Page.staff
+
+SilverStripe\CMS\Tests\Model\SiteTreeBrokenLinksTest\NotPageObject:
+  object1:
+    Content: 'Everything will be ok'


### PR DESCRIPTION
## Description
Check instance is type of SiteTree before invoke method.
## Parent issue
- https://github.com/silverstripe/silverstripe-cms/issues/2875