### PR TITLE
FIX Don't hardcode edit link for virtual page

### DIFF
--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -3,7 +3,6 @@
 namespace SilverStripe\CMS\Model;
 
 use Page;
-use SilverStripe\Admin\AdminRootController;
 use SilverStripe\Core\Convert;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\CMS\Model;
 
 use Page;
+use SilverStripe\Admin\AdminRootController;
 use SilverStripe\Core\Convert;
 use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\FieldList;
@@ -247,7 +248,7 @@ class VirtualPage extends Page
                     'a',
                     [
                         'class' => 'cmsEditlink',
-                        'href' => 'admin/pages/edit/show/' . $this->CopyContentFromID,
+                        'href' => AdminRootController::config()->get('url_base') . '/pages/edit/show/' . $this->CopyContentFromID,
                     ],
                     _t(self::class . '.EditLink', 'edit')
                 );

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -248,7 +248,7 @@ class VirtualPage extends Page
                     'a',
                     [
                         'class' => 'cmsEditlink',
-                        'href' => AdminRootController::config()->get('url_base') . '/pages/edit/show/' . $this->CopyContentFromID,
+                        'href' => AdminRootController::get_admin_route() . '/pages/edit/show/' . $this->CopyContentFromID,
                     ],
                     _t(self::class . '.EditLink', 'edit')
                 );

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -248,7 +248,7 @@ class VirtualPage extends Page
                     'a',
                     [
                         'class' => 'cmsEditlink',
-                        'href' => AdminRootController::get_admin_route() . '/pages/edit/show/' . $this->CopyContentFromID,
+                        'href' => $this->CopyContentFrom()->CMSEditLink(),
                     ],
                     _t(self::class . '.EditLink', 'edit')
                 );


### PR DESCRIPTION
VirtualPage  now uses $this->CopyContentFrom()->CMSEditLink() to generate edit links

Replaces https://github.com/silverstripe/silverstripe-cms/pull/2882

Fixes the following issue: https://github.com/silverstripe/silverstripe-cms/issues/2881