### PR TITLE
API Add new SiteTree.hide_pagetypes configuration

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -203,10 +203,19 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      * in the cms, set this to the old class name. Eg, if you extended Product
      * to make ImprovedProduct, then you would set $hide_ancestor to Product.
      *
+     * @deprecated 5.2.0 Use hide_pagetypes instead
+     *
      * @config
      * @var string
      */
     private static $hide_ancestor = null;
+
+    /**
+     * Any fully qualified class names added to this array will be hidden in the CMS
+     * when selecting page types, e.g. for creating a new page or changing the type
+     * of an existing page.
+     */
+    private static array $hide_pagetypes = [];
 
     /**
      * You can define the class of the controller that maps to your SiteTree object here if
@@ -538,7 +547,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     }
 
     /**
-     * Return a subclass map of SiteTree that shouldn't be hidden through {@link SiteTree::$hide_ancestor}
+     * Return a subclass map of SiteTree that shouldn't be hidden through {@link SiteTree::$hide_pagetypes}
      *
      * @return array
      */
@@ -551,7 +560,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             unset($classes[$baseClassIndex]);
         }
 
-        $kill_ancestors = [];
+        $kill_ancestors = self::config()->get('hide_pagetypes', Config::UNINHERITED) ?? [];
 
         // figure out if there are any classes we don't want to appear
         foreach ($classes as $class) {

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -1209,6 +1209,13 @@ class SiteTreeTest extends SapphireTest
         $this->assertEquals(3, $p->Version);
     }
 
+    public function testHidePagetypes()
+    {
+        SiteTree::config()->set('hide_pagetypes', ['Page']);
+        $classes = SiteTree::page_type_classes();
+        $this->assertNotContains('Page', $classes);
+    }
+
     public function testPageTypeClasses()
     {
         $classes = SiteTree::page_type_classes();
@@ -1223,6 +1230,11 @@ class SiteTreeTest extends SapphireTest
             $newClasses,
             'Setting hide_ancestor to a boolean (incorrect) value caused a page class to be hidden'
         );
+
+        // Testing what happens if a valid config value is set
+        Config::modify()->set(SiteTreeTest_ClassA::class, 'hide_ancestor', 'Page');
+        $classes = SiteTree::page_type_classes();
+        $this->assertNotContains('Page', $classes);
     }
 
     /**


### PR DESCRIPTION
Allows clearly defining all pagetypes that should be hidden in a single place, instead of having to spread them out across different pagetypes with MyPage.hide_ancestor

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/1805