### PR TITLE
POC DO NOT MERGE - Make CMSMain work with other models

### DIFF
--- a/code/Controllers/CMSPageEditController.php
+++ b/code/Controllers/CMSPageEditController.php
@@ -2,10 +2,8 @@
 
 namespace SilverStripe\CMS\Controllers;
 
-use Page;
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\CampaignAdmin\AddToCampaignHandler;
-use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
@@ -57,7 +55,7 @@ class CMSPageEditController extends CMSMain
     public function addtocampaign(array $data, Form $form): HTTPResponse
     {
         $id = $data['ID'];
-        $record = \Page::get()->byID($id);
+        $record = $this->getTreeClass()::get()->byID($id);
 
         $handler = AddToCampaignHandler::create($this, $record);
         $response = $handler->addToCampaign($record, $data);
@@ -96,14 +94,14 @@ class CMSPageEditController extends CMSMain
     public function getAddToCampaignForm($id)
     {
         // Get record-specific fields
-        $record = SiteTree::get()->byID($id);
+        $record = $this->getTreeClass()::get()->byID($id);
 
         if (!$record) {
             $this->httpError(404, _t(
                 __CLASS__ . '.ErrorNotFound',
                 'That {Type} couldn\'t be found',
                 '',
-                ['Type' => Page::singleton()->i18n_singular_name()]
+                ['Type' => $this->getTreeClass()::singleton()->i18n_singular_name()]
             ));
             return null;
         }
@@ -112,7 +110,7 @@ class CMSPageEditController extends CMSMain
                 __CLASS__.'.ErrorItemPermissionDenied',
                 'It seems you don\'t have the necessary permissions to add {ObjectTitle} to a campaign',
                 '',
-                ['ObjectTitle' => Page::singleton()->i18n_singular_name()]
+                ['ObjectTitle' => $this->getTreeClass()::singleton()->i18n_singular_name()]
             ));
             return null;
         }

--- a/code/Controllers/CMSPageSettingsController.php
+++ b/code/Controllers/CMSPageSettingsController.php
@@ -18,8 +18,12 @@ class CMSPageSettingsController extends CMSMain
     public function getEditForm($id = null, $fields = null)
     {
         $record = $this->getRecord($id ?: $this->currentPageID());
-
-        return parent::getEditForm($id, ($record) ? $record->getSettingsFields() : null);
+        if ($record && $record->hasMethod('getSettingsFields')) {
+            $fields = $record->getSettingsFields();
+        } else {
+            $fields = null;
+        }
+        return parent::getEditForm($id, $fields);
     }
 
     public function getTabIdentifier()

--- a/code/Controllers/CMSPagesController.php
+++ b/code/Controllers/CMSPagesController.php
@@ -2,7 +2,6 @@
 
 namespace SilverStripe\CMS\Controllers;
 
-use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
@@ -37,7 +36,7 @@ class CMSPagesController extends CMSMain
         $this->beforeExtending('updateBreadcrumbs', function (ArrayList $items) {
             //special case for building the breadcrumbs when calling the listchildren Pages ListView action
             if ($parentID = $this->getRequest()->getVar('ParentID')) {
-                $page = SiteTree::get()->byID($parentID);
+                $page = $this->getTreeClass()::get()->byID($parentID);
 
                 //build a reversed list of the parent tree
                 $pages = [];

--- a/templates/BreadcrumbsTemplate.ss
+++ b/templates/BreadcrumbsTemplate.ss
@@ -1,4 +1,20 @@
 <%-- Loop is all on one line to prevent whitespace bug in older versions of IE --%>
 <% if $Pages %>
-	<% loop $Pages %><% if $IsLast %>$MenuTitle.XML<% else %><% if not Up.Unlinked %><a href="$Link" class="breadcrumb-$Pos"><% end_if %>$MenuTitle.XML<% if not Up.Unlinked %></a><% end_if %> $Up.Delimiter.RAW <% end_if %><% end_loop %>
+	<% loop $Pages %>
+        <% if $IsLast %>
+            <% if $hasField('MenuTitle') %>
+                $MenuTitle.XML
+            <% else %>
+                $Title.XML
+            <% end_if %>
+        <% else %>
+            <% if not Up.Unlinked %><a href="$Link" class="breadcrumb-$Pos"><% end_if %>
+            <% if $hasField('MenuTitle') %>
+                $MenuTitle.XML
+            <% else %>
+                $Title.XML
+            <% end_if %>
+            <% if not Up.Unlinked %></a><% end_if %> $Up.Delimiter.RAW
+        <% end_if %>
+    <% end_loop %>
 <% end_if %>

--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_Content.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_Content.ss
@@ -15,11 +15,13 @@
 							<%t SilverStripe\\CMS\\Controllers\\CMSMain.TabContent 'Content' %>
 						</a>
 					</li>
+                    <% if $LinkPageSettings %>
 					<li class="nav-item content-listview<% if $TabIdentifier == 'settings' %> ui-tabs-active<% end_if %>">
 						<a href="$LinkPageSettings" class="nav-link cms-panel-link" title="Form_EditForm" data-href="$LinkPageSettings">
 							<%t SilverStripe\\CMS\\Controllers\\CMSMain.TabSettings 'Settings' %>
 						</a>
 					</li>
+                    <% end_if %>
 					<li class="nav-item content-listview<% if $TabIdentifier == 'history' %> ui-tabs-active<% end_if %>">
 						<a href="$LinkPageHistory" class="nav-link cms-panel-link" title="Form_EditForm" data-href="$LinkPageHistory">
 							<%t SilverStripe\\CMS\\Controllers\\CMSMain.TabHistory 'History' %>

--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_TreeNode.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_TreeNode.ss
@@ -1,6 +1,16 @@
 <li id="record-{$node.ID}" data-id="{$node.ID}" data-pagetype="{$node.ClassName}" class="$markingClasses $extraClass"><ins class="jstree-icon font-icon-right-dir">&nbsp;</ins>
     <a href="{$node.CMSEditLink.ATT}" title="{$Title.ATT}"><ins class="jstree-icon font-icon-drag-handle">&nbsp;</ins>
-        <span class="text">{$node.TreeTitle}</span>
+        <span class="text">
+            <% if $node.hasField('TreeTitle') %>
+                $node.TreeTitle
+            <% else %>
+                <% if $node.hasField('MenuTitle') %>
+                    $node.MenuTitle
+                <% else %>
+                    $node.Title
+                <% end_if %>
+            <% end_if %>
+        </span>
     </a>
     $SubTree
 </li>


### PR DESCRIPTION
This is a proof of concept as part of https://github.com/silverstripe/silverstripe-cms/issues/2933 to see what's needed to make `CMSMain` work with classes that aren't `SiteTree`.

To play around with this, install [silverstripe/taxonomy](https://github.com/silverstripe/silverstripe-taxonomy/) and add the following YAML config to your project:

```yml
SilverStripe\Taxonomy\TaxonomyTerm:
  cms_edit_owner: SilverStripe\CMS\Controllers\CMSMain
  extensions:
    - SilverStripe\Admin\CMSEditLinkExtension

SilverStripe\CMS\Controllers\CMSMain:
  tree_class: SilverStripe\Taxonomy\TaxonomyTerm
```

Your `/admin/pages` will now be working with taxonomy terms, rather than pages.

Theoretically this could work with any `DataObject` class which has `CMSEditLinkExtension` and `Hierarchy` applied.

## What would still need to be done besides this

1. Refactor `CMSPagesController`, `CMSPageEditController`, `CMSPageSettingsController`, `CMSPageHistoryViewerController`, and `CMSPageAddController` so you could have multiple instances of this going at once, e.g. one admin for pages, one for taxonomies, etc - without having to subclass all of these controllers as well.
    - Ideally these wouldn't be subclasses of `LeftAndMain` at all - either this could all be handled in the main `HierarchyModelAdmin` class (see below) or these could all be more generic controllers.
    - Either way they need to not be subclasses of `CMSMain`, but instead get any information they need by calling methods on `CMSMain` (i.e. have the `CMSMain` instance passed to their constructor) or having that information passed through to them via setters or via their constructor.
1. Have this logic all in a superclass called something more generic, like `HierarchyModelAdmin` (which would belong in `silverstripe/admin` along with all appropriate JS), and have `CMSMain` be a subclass of `HierarchyModelAdmin` with its `tree_class` set to `SiteTree`
    - While moving the JS to silverstripe/admin, it'd be worth finding all JS logic that's duplicated and making it so that all works in the same way for `ModelAdmin` and this new class.
1. Obviously we'd need to add in appropriate type checking, make sure the tree class is hierarchical and has a cms edit link.
1. In a few places it'd pay to add early returns when versioned isn't applied to the record
1. This POC does a lot of lazy work to avoid refactoring - e.g. there's a lot of methods now duplicated between `SiteTree` and `CMSMain`. These should go into a new class (probably an extension) that can be applied to any classes that want to live in this admin type. Things like tree title vs menu title vs title, icon, status flags, tree node classes, etc
    - This will end up meaning if you want to add a model to this admin, it must have `Hierarchy`, `CMSPageEditController`, and this new extension. But that also means you can just apply 3 extensions to any model and boom, you're ready to go.
    - Some things like the breadcrumbs for list view shouldn't be on the model - just leave that in the controller or fully template-ify it
    - Some things like status flags should probably have default functionality on the controller but use `invokeWithExtensions` (or just a `hasMethod()` check) to allow the model to update it
1. There's a lot of wording to adjust that assumes this is for pages.
1. Batch actions assume `Versioned` is applied and probably also have other assumptions that make them not work
1. The way search works for `CMSMain` is just completely incompatible with these changes. It has a hardcoded form, and a different code path for the actual search functionality. We should marry up the way `GridFieldFilterHeader` and the filter/search in here work.
    - Probably have a new controller for CMS search. This gets the form using similar logic to the current `GridFieldFilterHeader` logic
    - Current fields in `CMSMain::getSearchForm()` get moved into `SiteTree::searchableFields()`
    - `SiteTree` gets a custom `SearchContext` subclass which leverages `CMSSiteTreeFilter` for the field that uses it (if that's necessary - I haven't looked too deep into the search code path for sitetree)
1. I haven't really looked at all at the history tab - it might need some work. MVP would be to just not show that for anything other than `SiteTree` and handle making it work as a separate effort. 
1. A whole bunch of new unit and behat tests would need to be written
1. The root of the site tree is the site name, which makes sense for pages but doesn't really make sense for much of anything else. Might be worth just removing that root, or making it configurable, or something.

## Stretch goal

Make this handle multiple classes in separate tabs, like `ModelAdmin` does via its `managed_models` config. Then you could still have a single "Taxonomies" CMS section, but it could handle both `TaxonomyTerm` and `TaxonomyType` with this hierarchical style.

Note that `TaxonomyType` isn't hierarchical - so either we'd need to change that, or better yet AAALLL of this logic could just get bundled together with `ModelAdmin`, so you can have for example one tab for managing `TaxonomyTerm` which uses the tree structure, and one tab for managing `TaxonomyType` which uses the normal `ModelAdmin` grid structure.