### PR TITLE
MNT Fix siteconfig behat test running on kitchen-sink

### DIFF
--- a/tests/behat/src/LoginContext.php
+++ b/tests/behat/src/LoginContext.php
@@ -5,6 +5,7 @@ namespace SilverStripe\CMS\Tests\Behaviour;
 use Page;
 use PHPUnit\Framework\Assert;
 use SilverStripe\BehatExtension\Context\LoginContext as BehatLoginContext;
+use SilverStripe\SiteConfig\SiteConfig;
 
 class LoginContext extends BehatLoginContext
 {
@@ -26,7 +27,11 @@ class LoginContext extends BehatLoginContext
         $password = 'Password!456';
         $member = $this->generateMemberWithPermission($email, $password, $permCode);
         $canEdit = strstr($negative ?? '', 'not') ? false : true;
-
+        // Flush the SiteConfig cache so that siteconfig behat tests that update a
+        // SiteConfig DataObject will not be referring to a stale verion of itself
+        // which can happen because SiteConfig::current_site_config() uses DataObject::get_one()
+        // which will caches its result by default
+        SiteConfig::current_site_config()->flushCache();
         if ($canEdit) {
             Assert::assertTrue($page->canEdit($member), 'The member can edit this page');
         } else {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/272

Replacement for https://github.com/silverstripe/silverstripe-siteconfig/pull/165

Note that silverstripe/siteconfig is a composer requirement of silverstripe/cms