### PR TITLE
MNT Tweak behat test to look for tag with specific attribute itstead of looking for a specifc string in the HTML

### DIFF
--- a/tests/behat/features/edit-a-page.feature
+++ b/tests/behat/features/edit-a-page.feature
@@ -103,11 +103,11 @@ Feature: Edit a page
     And I press the "Publish" button
     And I go to "/about-us"
     # insert from files
-    Then the rendered HTML should contain "<img src=\"/assets/file1.jpg\""
+    Then I should see an "img[src='/assets/file1.jpg']" element
     # link to a file
-    Then the rendered HTML should contain "<a href=\"/assets/file1.jpg\">"
+    Then I should see an "a[href='/assets/file1.jpg']" element
     # media embed
-    Then the rendered HTML should contain "src=\"https://www.youtube.com/embed/ScMzIvxBSi4?feature=oembed\""
+    Then I should see an "iframe[src='https://www.youtube.com/embed/ScMzIvxBSi4?feature=oembed']" element
 
   Scenario: Change page type
     When I click on "About Us" in the tree


### PR DESCRIPTION
This test was failing because it was looking for a very specific string in the HTML. Just checking for a tag with a specific attribute is more reliable because it doesn't depend on the order of parameter.

## Parent issue
- https://github.com/silverstripe/.github/issues/230