### PR TITLE
BUG Don't double up the breadcrumb on list views

### DIFF
--- a/code/Controllers/CMSPagesController.php
+++ b/code/Controllers/CMSPagesController.php
@@ -31,35 +31,4 @@ class CMSPagesController extends CMSMain
     {
         return false;
     }
-
-    public function Breadcrumbs($unlinked = false)
-    {
-        $this->beforeExtending('updateBreadcrumbs', function (ArrayList $items) {
-            //special case for building the breadcrumbs when calling the listchildren Pages ListView action
-            if ($parentID = $this->getRequest()->getVar('ParentID')) {
-                $page = SiteTree::get()->byID($parentID);
-
-                //build a reversed list of the parent tree
-                $pages = [];
-                while ($page) {
-                    array_unshift($pages, $page); //add to start of array so that array is in reverse order
-                    $page = $page->Parent;
-                }
-
-                //turns the title and link of the breadcrumbs into template-friendly variables
-                $params = array_filter([
-                    'view' => $this->getRequest()->getVar('view'),
-                    'q' => $this->getRequest()->getVar('q')
-                ]);
-                foreach ($pages as $page) {
-                    $params['ParentID'] = $page->ID;
-                    $item = new stdClass();
-                    $item->Title = $page->Title;
-                    $item->Link = Controller::join_links($this->Link(), '?' . http_build_query($params ?? []));
-                    $items->push(new ArrayData($item));
-                }
-            }
-        });
-        return parent::Breadcrumbs($unlinked);
-    }
 }

--- a/tests/php/Controllers/CMSMainTest.yml
+++ b/tests/php/Controllers/CMSMainTest.yml
@@ -12,6 +12,10 @@ SilverStripe\CMS\Model\SiteTree:
     Title: Page 3.1
     Parent: =>SilverStripe\CMS\Model\SiteTree.page3
     Sort: 1
+  page311:
+    Title: Page 3.1.1
+    Parent: =>SilverStripe\CMS\Model\SiteTree.page31
+    Sort: 1
   page32:
     Title: Page 3.2
     Parent: =>SilverStripe\CMS\Model\SiteTree.page3


### PR DESCRIPTION
## Description
This PR refactors how the CMS breadcrumb is generated.

It fix a bug causing crumbs to be duplicated on the list view.

It also ensures the "Pages" top crumb is always shown on the list view.

It adds missing unit tests.

## Manual testing steps
- Validate that the breadcrumb is still shown correctly:
  - on the page edit form
  - on the list view when access directly
  - on the list view when access via a PJAX
  - on the page search results.
- Validate that crumbs link where you expect them to link.

## Issues
- https://github.com/silverstripe/silverstripe-cms/issues/2974

## Pull request checklist

- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green