### PR TITLE
FIX Use canDelete, not the now-deleted canArchive

### DIFF
--- a/code/BatchActions/CMSBatchAction_Archive.php
+++ b/code/BatchActions/CMSBatchAction_Archive.php
@@ -5,7 +5,6 @@ namespace SilverStripe\CMS\BatchActions;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Admin\CMSBatchAction;
 use SilverStripe\Control\HTTPResponse;
-use SilverStripe\Dev\Deprecation;
 
 /**
  * Delete items batch action.
@@ -28,7 +27,6 @@ class CMSBatchAction_Archive extends CMSBatchAction
 
     public function applicablePages($ids)
     {
-        // canArchive() is deprecated, not $this->applicablePagesHelper()
-        return Deprecation::withNoReplacement(fn() => $this->applicablePagesHelper($ids, 'canArchive'));
+        return $this->applicablePagesHelper($ids, 'canDelete');
     }
 }

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -29,7 +29,6 @@ use SilverStripe\Core\Convert;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\DateField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldGroup;
@@ -1998,8 +1997,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         if (!$record || !$record->exists()) {
             throw new HTTPResponse_Exception("Bad record ID #$id", 404);
         }
-        $canArchive = Deprecation::withNoReplacement(fn() => $record->canArchive());
-        if (!$canArchive) {
+        if (!$record->canDelete()) {
             return Security::permissionFailure();
         }
 

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -25,7 +25,6 @@ use SilverStripe\Core\Manifest\ModuleResource;
 use SilverStripe\Core\Manifest\ModuleResourceLoader;
 use SilverStripe\Core\Manifest\VersionProvider;
 use SilverStripe\Core\Resettable;
-use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\DropdownField;
@@ -2593,21 +2592,18 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         }
 
         // If a page is on any stage it can be archived
-        if (($isOnDraft || $isPublished)) {
-            $canArchive = Deprecation::withNoReplacement(fn() => $this->canArchive());
-            if ($canArchive) {
-                $title = $isPublished
-                    ? _t('SilverStripe\\CMS\\Controllers\\CMSMain.UNPUBLISH_AND_ARCHIVE', 'Unpublish and archive')
-                    : _t('SilverStripe\\CMS\\Controllers\\CMSMain.ARCHIVE', 'Archive');
-                $moreOptions->push(
-                    FormAction::create('archive', $title)
-                        ->addExtraClass('delete btn btn-secondary' . ($this->isHomePage() ? ' homepage-warning' : ''))
-                        ->setDescription(_t(
-                            'SilverStripe\\CMS\\Model\\SiteTree.BUTTONDELETEDESC',
-                            'Remove from draft/live and send to archive'
-                        ))
-                );
-            }
+        if (($isOnDraft || $isPublished) && $this->canDelete()) {
+            $title = $isPublished
+                ? _t('SilverStripe\\CMS\\Controllers\\CMSMain.UNPUBLISH_AND_ARCHIVE', 'Unpublish and archive')
+                : _t('SilverStripe\\CMS\\Controllers\\CMSMain.ARCHIVE', 'Archive');
+            $moreOptions->push(
+                FormAction::create('archive', $title)
+                    ->addExtraClass('delete btn btn-secondary' . ($this->isHomePage() ? ' homepage-warning' : ''))
+                    ->setDescription(_t(
+                        'SilverStripe\\CMS\\Model\\SiteTree.BUTTONDELETEDESC',
+                        'Remove from draft/live and send to archive'
+                    ))
+            );
         }
 
         // "save", supports an alternate state that is still clickable, but notifies the user that the action is not needed.


### PR DESCRIPTION
`canArchive()` is removed in favour of `canDelete()` in https://github.com/silverstripe/silverstripe-versioned/pull/460

## Issue
- https://github.com/silverstripe/silverstripe-versioned/issues/447