### PR TITLE
ENH Don't emit deprecation warnings for unavoidable API calls

### DIFF
--- a/code/BatchActions/CMSBatchAction_Archive.php
+++ b/code/BatchActions/CMSBatchAction_Archive.php
@@ -5,6 +5,7 @@ namespace SilverStripe\CMS\BatchActions;
 use SilverStripe\ORM\SS_List;
 use SilverStripe\Admin\CMSBatchAction;
 use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * Delete items batch action.
@@ -27,6 +28,7 @@ class CMSBatchAction_Archive extends CMSBatchAction
 
     public function applicablePages($ids)
     {
-        return $this->applicablePagesHelper($ids, 'canArchive');
+        // canArchive() is deprecated, not $this->applicablePagesHelper()
+        return Deprecation::withNoReplacement(fn() => $this->applicablePagesHelper($ids, 'canArchive'));
     }
 }

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -29,6 +29,7 @@ use SilverStripe\Core\Convert;
 use SilverStripe\Core\Environment;
 use SilverStripe\Core\Flushable;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\DateField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldGroup;
@@ -1109,13 +1110,13 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         // Find all ancestors of the provided page
         $ancestors = $page->getAncestors(true);
         $ancestors = array_reverse($ancestors->toArray() ?? []);
-        
+
         //turns the title and link of the breadcrumbs into template-friendly variables
         $params = array_filter([
             'view' => $this->getRequest()->getVar('view'),
             'q' => $this->getRequest()->getVar('q')
         ]);
-        
+
         foreach ($ancestors as $ancestor) {
             // Link back to the list view for the current ancestor
             $params['ParentID'] = $ancestor->ID;
@@ -1997,7 +1998,8 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         if (!$record || !$record->exists()) {
             throw new HTTPResponse_Exception("Bad record ID #$id", 404);
         }
-        if (!$record->canArchive()) {
+        $canArchive = Deprecation::withNoReplacement(fn() => $record->canArchive());
+        if (!$canArchive) {
             return Security::permissionFailure();
         }
 

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -25,6 +25,7 @@ use SilverStripe\Core\Manifest\ModuleResource;
 use SilverStripe\Core\Manifest\ModuleResourceLoader;
 use SilverStripe\Core\Manifest\VersionProvider;
 use SilverStripe\Core\Resettable;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\Forms\CheckboxField;
 use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\DropdownField;
@@ -2567,18 +2568,21 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         }
 
         // If a page is on any stage it can be archived
-        if (($isOnDraft || $isPublished) && $this->canArchive()) {
-            $title = $isPublished
-                ? _t('SilverStripe\\CMS\\Controllers\\CMSMain.UNPUBLISH_AND_ARCHIVE', 'Unpublish and archive')
-                : _t('SilverStripe\\CMS\\Controllers\\CMSMain.ARCHIVE', 'Archive');
-            $moreOptions->push(
-                FormAction::create('archive', $title)
-                    ->addExtraClass('delete btn btn-secondary' . ($this->isHomePage() ? ' homepage-warning' : ''))
-                    ->setDescription(_t(
-                        'SilverStripe\\CMS\\Model\\SiteTree.BUTTONDELETEDESC',
-                        'Remove from draft/live and send to archive'
-                    ))
-            );
+        if (($isOnDraft || $isPublished)) {
+            $canArchive = Deprecation::withNoReplacement(fn() => $this->canArchive());
+            if ($canArchive) {
+                $title = $isPublished
+                    ? _t('SilverStripe\\CMS\\Controllers\\CMSMain.UNPUBLISH_AND_ARCHIVE', 'Unpublish and archive')
+                    : _t('SilverStripe\\CMS\\Controllers\\CMSMain.ARCHIVE', 'Archive');
+                $moreOptions->push(
+                    FormAction::create('archive', $title)
+                        ->addExtraClass('delete btn btn-secondary' . ($this->isHomePage() ? ' homepage-warning' : ''))
+                        ->setDescription(_t(
+                            'SilverStripe\\CMS\\Model\\SiteTree.BUTTONDELETEDESC',
+                            'Remove from draft/live and send to archive'
+                        ))
+                );
+            }
         }
 
         // "save", supports an alternate state that is still clickable, but notifies the user that the action is not needed.


### PR DESCRIPTION
`Versioned::canArchive()` is deprecated in https://github.com/silverstripe/silverstripe-versioned/pull/461

We can't stop calling it directly until CMS 6 because people may have implemented extensions that update the result of this permission check.

## Issue
- https://github.com/silverstripe/silverstripe-versioned/issues/447