### PR TITLE
API Remove CMSEditLink implementation, rely on superclass instead.

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1096,7 +1096,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
             $this->pushCrumb(
                 $items,
                 $ancestor->getMenuTitle(),
-                $unlinked ? false : $ancestor->CMSEditLink()
+                $unlinked ? false : $ancestor->getCMSEditLink()
             );
         }
     }
@@ -1710,7 +1710,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
                 /** @var SiteTree $item */
                 $title = sprintf(
                     '<a class="action-detail" href="%s">%s</a>',
-                    $item->CMSEditLink(),
+                    $item->getCMSEditLink(),
                     $item->TreeTitle // returns HTML, does its own escaping
                 );
                 $breadcrumbs = $item->Breadcrumbs(20, true, false, true, '/');
@@ -2103,7 +2103,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
         // Can be used in different contexts: In normal page edit view, in which case the redirect won't have any effect.
         // Or in history view, in which case a revert causes the CMS to re-load the edit view.
         // The X-Pjax header forces a "full" content refresh on redirect.
-        $url = $record->CMSEditLink();
+        $url = $record->getCMSEditLink();
         $this->getResponse()->addHeader('X-ControllerURL', $url);
         $this->getRequest()->addHeader('X-Pjax', 'Content');
         $this->getResponse()->addHeader('X-Pjax', 'Content');
@@ -2220,7 +2220,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
                     ['title' => $newPage->Title]
                 ) ?? '')
             );
-            $url = $newPage->CMSEditLink();
+            $url = $newPage->getCMSEditLink();
             $this->getResponse()->addHeader('X-ControllerURL', $url);
             $this->getRequest()->addHeader('X-Pjax', 'Content');
             $this->getResponse()->addHeader('X-Pjax', 'Content');
@@ -2256,7 +2256,7 @@ class CMSMain extends LeftAndMain implements CurrentPageIdentifier, PermissionPr
                     ['title' => $newPage->Title]
                 ) ?? '')
             );
-            $url = $newPage->CMSEditLink();
+            $url = $newPage->getCMSEditLink();
             $this->getResponse()->addHeader('X-ControllerURL', $url);
             $this->getRequest()->addHeader('X-Pjax', 'Content');
             $this->getResponse()->addHeader('X-Pjax', 'Content');

--- a/code/Controllers/SilverStripeNavigatorItem_CMSLink.php
+++ b/code/Controllers/SilverStripeNavigatorItem_CMSLink.php
@@ -16,7 +16,7 @@ class SilverStripeNavigatorItem_CMSLink extends SilverStripeNavigatorItem
     {
         return sprintf(
             '<a href="%s">%s</a>',
-            $this->record->CMSEditLink(),
+            $this->record->getCMSEditLink(),
             _t('SilverStripe\\CMS\\Controllers\\ContentController.CMS', 'CMS')
         );
     }
@@ -28,7 +28,7 @@ class SilverStripeNavigatorItem_CMSLink extends SilverStripeNavigatorItem
 
     public function getLink()
     {
-        return $this->record->CMSEditLink();
+        return $this->record->getCMSEditLink();
     }
 
     public function isActive()

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -285,7 +285,6 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         'Link' => 'Text',
         'RelativeLink' => 'Text',
         'AbsoluteLink' => 'Text',
-        'CMSEditLink' => 'Text',
         'TreeTitle' => 'HTMLFragment',
         'MetaTags' => 'HTMLFragment',
     ];
@@ -756,20 +755,6 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
         Versioned::set_reading_mode($oldReadingMode);
         return $link;
-    }
-
-    /**
-     * Generates a link to edit this page in the CMS.
-     *
-     * Implemented here to satisfy the CMSPreviewable interface, but data is intended to be loaded via Extension
-     *
-     * @see SilverStripe\Admin\CMSEditLinkExtension
-     *
-     * @return string
-     */
-    public function CMSEditLink()
-    {
-        return $this->extend('CMSEditLink')[0] ?? '';
     }
 
     /**
@@ -1504,7 +1489,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             $tags['cmsEditLink'] = [
                 'attributes' => [
                     'name' => 'x-cms-edit-link',
-                    'content' => $this->CMSEditLink(),
+                    'content' => $this->getCMSEditLink(),
                 ],
             ];
         }
@@ -2157,11 +2142,11 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                                 'Untitled {instanceType}',
                                 ['instanceType' => $item->i18n_singular_name()]
                             );
-                            $tag = $item->hasMethod('CMSEditLink') ? 'a' : 'span';
+                            $tag = $item->hasMethod('getCMSEditLink') ? 'a' : 'span';
                             return sprintf(
                                 '<%s%s class="dependent-content__edit-link %s">%s</%s>',
                                 $tag,
-                                $tag === 'a' ? sprintf(' href="%s"', $item->CMSEditLink()) : '',
+                                $tag === 'a' ? sprintf(' href="%s"', $item->getCMSEditLink()) : '',
                                 $title ? '' : 'dependent-content__edit-link--untitled',
                                 $title ? Convert::raw2xml($title) : $untitled,
                                 $tag

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -258,7 +258,7 @@ class VirtualPage extends Page
                     'a',
                     [
                         'class' => 'cmsEditlink',
-                        'href' => $this->CopyContentFrom()->CMSEditLink(),
+                        'href' => $this->CopyContentFrom()->getCMSEditLink(),
                     ],
                     _t(VirtualPage::class . '.EditLink', 'edit')
                 );

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -1505,7 +1505,7 @@ class SiteTreeTest extends SapphireTest
         $this->assertStringContainsString('<meta name="description" content="The &lt;br /&gt; and &lt;br&gt; tags"', $meta);
         $this->assertStringContainsString('<link rel="canonical" href="http://www.mysite.com/html-and-xml"', $meta);
         $this->assertStringContainsString('<meta name="x-page-id" content="' . $page->ID.'"', $meta);
-        $this->assertStringContainsString('<meta name="x-cms-edit-link" content="' . $page->CMSEditLink().'"', $meta);
+        $this->assertStringContainsString('<meta name="x-cms-edit-link" content="' . $page->getCMSEditLink().'"', $meta);
         $this->assertStringContainsString('<title>HTML &amp; XML</title>', $meta);
 
         // Test without title
@@ -1566,7 +1566,7 @@ class SiteTreeTest extends SapphireTest
             'cmsEditLink' => [
                 'attributes' => [
                     'name' => 'x-cms-edit-link',
-                    'content' => $page->CMSEditLink()
+                    'content' => $page->getCMSEditLink()
                 ]
             ]
         ];
@@ -2084,11 +2084,11 @@ class SiteTreeTest extends SapphireTest
         $child = $this->objFromFixture(BelongsToPage::class, 'one');
         $this->assertSame(
             "http://localhost/admin/pages/edit/show/$page->ID",
-            $page->CMSEditLink()
+            $page->getCMSEditLink()
         );
         $this->assertSame(
             "http://localhost/admin/pages/edit/show/$page->ID/field/ChildObjects/item/$child->ID",
-            $child->CMSEditLink()
+            $child->getCMSEditLink()
         );
     }
 

--- a/tests/php/Model/VirtualPageTest.php
+++ b/tests/php/Model/VirtualPageTest.php
@@ -105,7 +105,7 @@ class VirtualPageTest extends FunctionalTest
         $this->assertStringContainsString('<meta http-equiv="Content-Type" content="text/html; charset='.$charset.'"', $meta);
         $this->assertStringContainsString('<link rel="canonical" href="'.$master->AbsoluteLink().'"', $meta);
         $this->assertStringContainsString('<meta name="x-page-id" content="'.$vp1->ID.'"', $meta);
-        $this->assertStringContainsString('<meta name="x-cms-edit-link" content="'.$vp1->CMSEditLink().'"', $meta);
+        $this->assertStringContainsString('<meta name="x-cms-edit-link" content="'.$vp1->getCMSEditLink().'"', $meta);
         $this->assertStringContainsString('<title>'.$master->Title.'</title>', $meta);
     }
 


### PR DESCRIPTION
Relies on changes made in https://github.com/silverstripe/silverstripe-framework/pull/11338

## Issue
- https://github.com/silverstripe/silverstripe-framework/issues/11258