### PR TITLE
ENH Update default homepage content

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1599,7 +1599,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             if (!SiteTree::get_by_link($defaultHomepage)) {
                 $homepage = new Page();
                 $homepage->Title = _t(__CLASS__.'.DEFAULTHOMETITLE', 'Home');
-                $homepage->Content = _t(__CLASS__.'.DEFAULTHOMECONTENT2', '<p>Welcome to Silverstripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>For comprehensive information on the Silverstripe CMS, see the <a target="_blank" href="http://docs.silverstripe.org">developer documentation</a>.</p>');
+                $homepage->Content = _t(__CLASS__.'.DEFAULTHOMECONTENT2', '<p>Welcome to Silverstripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>For comprehensive information on Silverstripe CMS, see the <a target="_blank" href="http://docs.silverstripe.org">developer documentation</a>.</p>');
                 $homepage->URLSegment = $defaultHomepage;
                 $homepage->Sort = 1;
                 $homepage->write();

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1599,7 +1599,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
             if (!SiteTree::get_by_link($defaultHomepage)) {
                 $homepage = new Page();
                 $homepage->Title = _t(__CLASS__.'.DEFAULTHOMETITLE', 'Home');
-                $homepage->Content = _t(__CLASS__.'.DEFAULTHOMECONTENT', '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>You can now access the <a href="http://docs.silverstripe.org">developer documentation</a>, or begin the <a href="http://www.silverstripe.org/learn/lessons">SilverStripe lessons</a>.</p>');
+                $homepage->Content = _t(__CLASS__.'.DEFAULTHOMECONTENT2', '<p>Welcome to Silverstripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>For comprehensive information on the Silverstripe CMS, see the <a target="_blank" href="http://docs.silverstripe.org">developer documentation</a>.</p>');
                 $homepage->URLSegment = $defaultHomepage;
                 $homepage->Sort = 1;
                 $homepage->write();

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -194,7 +194,7 @@ en:
     DEFAULTABOUTTITLE: 'About Us'
     DEFAULTCONTACTCONTENT: '<p>You can fill this page out with your own content, or delete it and create your own pages.</p>'
     DEFAULTCONTACTTITLE: 'Contact Us'
-    DEFAULTHOMECONTENT: '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>You can now access the <a href="http://docs.silverstripe.org">developer documentation</a>, or begin the <a href="http://www.silverstripe.org/learn/lessons">SilverStripe lessons</a>.</p>'
+    DEFAULTHOMECONTENT: '<p>Welcome to Silverstripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>You can now access the <a href="http://docs.silverstripe.org">developer documentation</a>, or begin the <a href="http://www.silverstripe.org/learn/lessons">SilverStripe lessons</a>.</p>'
     DEFAULTHOMETITLE: Home
     DEPENDENT_NOTE: 'The following pages depend on this page. This includes virtual pages, redirector pages, and pages with content links.'
     DESCRIPTION: 'Generic content page'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -194,7 +194,8 @@ en:
     DEFAULTABOUTTITLE: 'About Us'
     DEFAULTCONTACTCONTENT: '<p>You can fill this page out with your own content, or delete it and create your own pages.</p>'
     DEFAULTCONTACTTITLE: 'Contact Us'
-    DEFAULTHOMECONTENT: '<p>Welcome to Silverstripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>You can now access the <a href="http://docs.silverstripe.org">developer documentation</a>, or begin the <a href="http://www.silverstripe.org/learn/lessons">SilverStripe lessons</a>.</p>'
+    DEFAULTHOMECONTENT: '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>You can now access the <a href="http://docs.silverstripe.org">developer documentation</a>, or begin the <a href="http://www.silverstripe.org/learn/lessons">SilverStripe lessons</a>.</p>'
+    DEFAULTHOMECONTENT2: '<p>Welcome to Silverstripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>For comprehensive information on the Silverstripe CMS, see the <a target="_blank" href="http://docs.silverstripe.org">developer documentation</a>.</p>'
     DEFAULTHOMETITLE: Home
     DEPENDENT_NOTE: 'The following pages depend on this page. This includes virtual pages, redirector pages, and pages with content links.'
     DESCRIPTION: 'Generic content page'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -195,7 +195,7 @@ en:
     DEFAULTCONTACTCONTENT: '<p>You can fill this page out with your own content, or delete it and create your own pages.</p>'
     DEFAULTCONTACTTITLE: 'Contact Us'
     DEFAULTHOMECONTENT: '<p>Welcome to SilverStripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>You can now access the <a href="http://docs.silverstripe.org">developer documentation</a>, or begin the <a href="http://www.silverstripe.org/learn/lessons">SilverStripe lessons</a>.</p>'
-    DEFAULTHOMECONTENT2: '<p>Welcome to Silverstripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>For comprehensive information on the Silverstripe CMS, see the <a target="_blank" href="http://docs.silverstripe.org">developer documentation</a>.</p>'
+    DEFAULTHOMECONTENT2: '<p>Welcome to Silverstripe! This is the default homepage. You can edit this page by opening <a href="admin/">the CMS</a>.</p><p>For comprehensive information on Silverstripe CMS, see the <a target="_blank" href="http://docs.silverstripe.org">developer documentation</a>.</p>'
     DEFAULTHOMETITLE: Home
     DEPENDENT_NOTE: 'The following pages depend on this page. This includes virtual pages, redirector pages, and pages with content links.'
     DESCRIPTION: 'Generic content page'


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

- Default home content should use "Silverstripe", not the old "SilverStripe"
- External link should target blank
- Developer lessons link should be removed as it points to CMS4 docs

<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
