### PR TITLE
FIX: Remove legacy fields which prevent page publish (fixes #2455)

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -300,6 +300,15 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         "Stage",  "Live"
     ];
 
+    /**
+     * Fields which, if changed on their own, won't cause a new version/live record to be created
+     * @var string[]
+     */
+    private static array $fields_ignored_by_versioning = [
+        'HasBrokenFile',
+        'HasBrokenLink',
+    ];
+
     private static $default_sort = "\"Sort\"";
 
     /**
@@ -1692,7 +1701,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         }
 
         // Check to see if we've only altered fields that shouldn't affect versioning
-        $fieldsIgnoredByVersioning = ['HasBrokenLink', 'Status', 'HasBrokenFile', 'ToDo', 'VersionID', 'SaveCount'];
+        $fieldsIgnoredByVersioning = $this->config()->get('fields_ignored_by_versioning') ?? [];
         $changedFields = array_keys($this->getChangedFields(true, 2) ?? []);
 
         // This more rigorous check is inline with the test that write() does to decide whether or not to write to the


### PR DESCRIPTION
## Description

This updates the list of fields which are ignored when deciding whether a new version (and therefore a new live version) should be created. Also made it configurable while I was there.

## Manual testing steps

Create a page type with a field `Status`, save and publish. Then change _only_ the status field and publish again: a new version won’t be written, and the live site won’t update. If you change status and something else, it will.

## Issues

- #2455

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
