### PR TITLE
FIX: put current page at top of ClassName dropdown (was broken)

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2744,8 +2744,6 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     protected function getClassDropdown()
     {
         $classes = SiteTree::page_type_classes();
-        $currentClass = null;
-
         $result = [];
         foreach ($classes as $class) {
             $instance = singleton($class);
@@ -2771,20 +2769,15 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
                 }
             }
 
-            $pageTypeName = $instance->i18n_singular_name();
-
-            $currentClass = $class;
-            $result[$class] = $pageTypeName;
+            $result[$class] = $instance->i18n_singular_name();
         }
 
-        // sort alphabetically, and put current on top
+        // Sort alphabetically, and put current on top
         asort($result);
-        if ($currentClass) {
-            $currentPageTypeName = $result[$currentClass];
-            unset($result[$currentClass]);
-            $result = array_reverse($result ?? []);
-            $result[$currentClass] = $currentPageTypeName;
-            $result = array_reverse($result ?? []);
+        if (isset($result[$this->ClassName])) {
+            $currentPageTypeName = $result[$this->ClassName];
+            unset($result[$this->ClassName]);
+            $result = [$this->ClassName => $currentPageTypeName] + $result;
         }
 
         return $result;

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -1280,7 +1280,7 @@ class SiteTreeTest extends SapphireTest
      */
     public function testAllowedChildren($className, $expected, $assertionMessage)
     {
-        $class = new $className;
+        $class = new $className();
         $this->assertEquals($expected, $class->allowedChildren(), $assertionMessage);
     }
 
@@ -1359,6 +1359,9 @@ class SiteTreeTest extends SapphireTest
         );
     }
 
+    /**
+     * @return void
+     */
     public function testClassDropdown()
     {
         $sitetree = new SiteTree();
@@ -1380,7 +1383,18 @@ class SiteTreeTest extends SapphireTest
 
         $this->assertArrayNotHasKey(SiteTreeTest_NotRoot::class, $method->invoke($rootPage));
         $this->assertArrayHasKey(SiteTreeTest_NotRoot::class, $method->invoke($nonRootPage));
-
+        foreach ([SiteTreeTest_ClassA::class, SiteTreeTest_ClassB::class] as $className) {
+            $otherPage = new $className();
+            $otherPage->write();
+            $result = $method->invoke(object: $otherPage);
+            $this->assertEquals(array_key_first($result), $className);
+            // remove the first element as this is not alphabetical
+            array_shift($result);
+            // create a sorted array
+            $resultSorted = $result;
+            asort($resultSorted);
+            $this->assertEquals($result, $resultSorted);
+        }
         Security::setCurrentUser(null);
     }
 


### PR DESCRIPTION
## Description
For the "Page Type" field in the settings tab (main) of a page, the current Page Type is supposed to be on top (see code changed). The code did not actually do that though and instead just placed the "last" entry in the list on top. That does not make any sense so I fixed it. 

## Manual testing steps
Open any SS website, go to the settings of a page and look at the list of Page Type options. You will see they are in alphabetical order, but the last one (e.g. the one that starts with last letter in the alphabet is listed first). The current page type is supposed to be listed first!

## Issues
https://github.com/silverstripe/silverstripe-cms/issues/3005

Also see:
https://github.com/silverstripe/silverstripe-cms/issues/2209
https://github.com/silverstripe/silverstripe-cms/issues/2208

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
