### PR TITLE
API Update method signature to match parent class

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,10 +1,5 @@
 <?php
 
-use SilverStripe\Admin\CMSMenu;
-use SilverStripe\CMS\Controllers\CMSMain;
-use SilverStripe\CMS\Controllers\CMSPageAddController;
-use SilverStripe\CMS\Controllers\CMSPageEditController;
-use SilverStripe\CMS\Controllers\CMSPageSettingsController;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Core\Manifest\ModuleLoader;
 use SilverStripe\Forms\HTMLEditor\TinyMCEConfig;
@@ -31,8 +26,3 @@ ShortcodeParser::get('default')->register(
     'sitetree_link',
     [SiteTree::class, 'link_shortcode_handler']
 );
-
-CMSMenu::remove_menu_class(CMSMain::class);
-CMSMenu::remove_menu_class(CMSPageEditController::class);
-CMSMenu::remove_menu_class(CMSPageSettingsController::class);
-CMSMenu::remove_menu_class(CMSPageAddController::class);

--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -32,6 +32,8 @@ class CMSPageAddController extends CMSPageEditController
     private static $menu_title = 'Add page';
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 
+    private static $ignore_menuitem = true;
+
     private static $allowed_actions = [
         'AddForm',
         'doAdd',

--- a/code/Controllers/CMSPageEditController.php
+++ b/code/Controllers/CMSPageEditController.php
@@ -28,6 +28,8 @@ class CMSPageEditController extends CMSMain
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 
+    private static $ignore_menuitem = true;
+
     private static $allowed_actions = [
         'AddToCampaignForm',
     ];

--- a/code/Controllers/CMSPageEditController.php
+++ b/code/Controllers/CMSPageEditController.php
@@ -34,7 +34,7 @@ class CMSPageEditController extends CMSMain
         'AddToCampaignForm',
     ];
 
-    public function getClientConfig()
+    public function getClientConfig(): array
     {
         return ArrayLib::array_merge_recursive(parent::getClientConfig(), [
             'form' => [

--- a/code/Controllers/CMSPageSettingsController.php
+++ b/code/Controllers/CMSPageSettingsController.php
@@ -15,6 +15,8 @@ class CMSPageSettingsController extends CMSMain
 
     private static $required_permission_codes = 'CMS_ACCESS_CMSMain';
 
+    private static $ignore_menuitem = true;
+
     public function getEditForm($id = null, $fields = null)
     {
         $record = $this->getRecord($id ?: $this->currentPageID());


### PR DESCRIPTION
Two commits:

## Commit 1:

Quick tidyup to use the `ignore_menuitem` configuration property instead of removing the menu items at runtime.

## Commit 2:

Reflects changes in https://github.com/silverstripe/silverstripe-admin/pull/1836

## Issue
- https://github.com/silverstripe/silverstripe-admin/issues/1761