### PR TITLE
FIX Import Deprecation class

### DIFF
--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -27,6 +27,7 @@ use SilverStripe\Versioned\Versioned;
 use SilverStripe\View\Parsers\URLSegmentFilter;
 use SilverStripe\View\Requirements;
 use SilverStripe\View\SSViewer;
+use SilverStripe\Dev\Deprecation;
 
 /**
  * The most common kind of controller; effectively a controller linked to a {@link DataObject}.


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/320

Fixes https://github.com/silverstripe/silverstripe-framework/actions/runs/11451953139/job/31862038284?pr=11432#step:12:148

`1) SilverStripe\Security\Tests\SecurityTest::testPermissionFailureSetsCorrectFormMessages
Error: Class "SilverStripe\CMS\Controllers\Deprecation" not found /home/runner/work/silverstripe-framework/silverstripe-framework/vendor/silverstripe/cms/code/Controllers/ContentController.php:298`

