### PR TITLE
API Deprecate and update code in preparation for CMS 6

### DIFF
--- a/code/Model/RedirectorPage.php
+++ b/code/Model/RedirectorPage.php
@@ -23,7 +23,12 @@ use SilverStripe\Versioned\Versioned;
  */
 class RedirectorPage extends Page
 {
+    /**
+     * @deprecated 5.4.0 use class_description instead.
+     */
     private static $description = 'Redirects requests to another location';
+
+    private static string $class_description = 'Redirects requests to another location';
 
     private static $icon_class = 'font-icon-p-redirect';
 

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -136,6 +136,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      * Used as a cache for `SiteTree::allowedChildren()`
      * Drastically reduces admin page load when there are a lot of page types
      * @var array
+     * @deprecated 5.4.0 will be moved to SilverStripe\ORM\Hierarchy\Hierarchy->cache_allowedChildren
      */
     protected static $_allowedChildren = [];
 
@@ -419,6 +420,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      *
      * @config
      * @var string
+     * @deprecated 5.4.0 use class_description instead.
      */
     private static $description = null;
 
@@ -431,8 +433,14 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      *
      * @config
      * @var string
+     * @deprecated 5.4.0 use base_class_description instead.
      */
     private static $base_description = 'Generic content page';
+
+    /**
+     * Description for Page and SiteTree classes, but not inherited by subclasses.
+     */
+    private static string $base_class_description = 'Generic content page';
 
     /**
      * @var array
@@ -3248,25 +3256,24 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     public function classDescription()
     {
+        // Ensure base class has an appropriate description if not explicitly set,
+        // since we can't set that config for projects.
         $base = in_array(static::class, [Page::class, SiteTree::class]);
         if ($base) {
-            return $this->config()->get('base_description');
+            $baseDescription = static::config()->get('base_class_description');
+            // Fall back to the deprecated config
+            if (!$baseDescription) {
+                $baseDescription = static::config('base_description');
+            }
+            return $baseDescription;
         }
-        return $this->config()->get('description');
-    }
-
-    /**
-     * Get localised description for this page
-     *
-     * @return string|null
-     */
-    public function i18n_classDescription()
-    {
-        $description = $this->classDescription();
-        if ($description) {
-            return _t(static::class.'.DESCRIPTION', $description);
+        // For all other classes, use the direct class_description config
+        $description = parent::classDescription();
+        if (!$description) {
+            // Fall back to the deprecated config
+            $description = static::config()->get('description');
         }
-        return null;
+        return $description;
     }
 
     /**

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -26,7 +26,12 @@ use SilverStripe\View\HTML;
  */
 class VirtualPage extends Page
 {
+    /**
+     * @deprecated 5.4.0 use class_description instead.
+     */
     private static $description = 'Displays the content of another page';
+
+    private static string $class_description = 'Displays the content of another page';
 
     private static $icon_class = 'font-icon-p-virtual';
 

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -149,6 +149,7 @@ en:
     HelpChars: ' Special characters are automatically converted or removed.'
     OK: OK
   SilverStripe\CMS\Model\RedirectorPage:
+    CLASS_DESCRIPTION: 'Redirects to an internal page or an external URL'
     DESCRIPTION: 'Redirects to an internal page or an external URL'
     FILE: File
     HEADER: 'This page will redirect users to another page'
@@ -188,6 +189,7 @@ en:
     BUTTONSAVEPUBLISH: Publish
     BUTTONUNPUBLISH: Unpublish
     BUTTONUNPUBLISHDESC: 'Remove this page from the published site'
+    CLASS_DESCRIPTION: 'Generic content page'
     Comments: Comments
     Content: Content
     DEFAULTABOUTCONTENT: '<p>You can fill this page out with your own content, or delete it and create your own pages.</p>'
@@ -332,6 +334,7 @@ en:
     many_many_LinkTracking: 'Link tracking'
   SilverStripe\CMS\Model\VirtualPage:
     CHOOSE: 'Linked Page'
+    CLASS_DESCRIPTION: 'Displays the content of another page'
     DESCRIPTION: 'Displays the content of another page'
     EditLink: edit
     HEADER: 'This is a virtual page'


### PR DESCRIPTION
Needs https://github.com/silverstripe/silverstripe-framework/pull/11461 for CI to go green - please merge that PR first.

This PR deprecates code that will be removed in https://github.com/silverstripe/silverstripe-cms/pull/3022, and adds the new `class_description` config.

Note that there are a lot of methods in https://github.com/silverstripe/silverstripe-cms/pull/3022 which are being removed from `SiteTree` but are being added to a superclass or to the `Hierarchy` extension in https://github.com/silverstripe/silverstripe-framework/pull/11460. The `Hierarchy` extension is _required_ to be on `SiteTree` for that class and CMSMain to work correctly, so the effect is that the methods are not removed from a downstream developer POV.
Downstream developers can still override the methods in subclasses _and_ call `parent::whatever()` as though the method was directly implemented on `SiteTree`.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947