### PR TITLE
FIX Don't use call_user_func_array in __call()

### DIFF
--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -483,10 +483,11 @@ class VirtualPage extends Page
      */
     public function __call($method, $args)
     {
-        if (parent::hasMethod($method)) {
+        if (parent::hasMethod($method) || !$this->CopyContentFromID) {
             return parent::__call($method, $args);
         } else {
-            return call_user_func_array([$this->CopyContentFrom(), $method], $args ?? []);
+            $record = $this->CopyContentFrom();
+            return $record->$method(...$args);
         }
     }
 


### PR DESCRIPTION
This goes hand-in-hand with https://github.com/silverstripe/silverstripe-framework/pull/11487 - I had made that change locally but forgot about it 😓

Fixes https://github.com/silverstripe/silverstripe-elemental/actions/runs/12128337221/job/33818161207 and many of the failures in https://github.com/silverstripe/silverstripe-cms/actions/runs/12128338043/
Basically `VirtualPage` couldn't be viewed at all, so that's easy to test.

## Issue
- https://github.com/silverstripe/.github/issues/348