### PR TITLE
TLN CopyPaste typos in en.yml plurals

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -153,10 +153,10 @@ en:
     FILE: File
     HEADER: 'This page will redirect users to another page'
     OTHERURL: 'Other website URL'
-    PLURALNAME: 'Base Pages'
+    PLURALNAME: 'Redirector Pages'
     PLURALS:
       one: 'A Redirector Page'
-      other: '{count} Base Pages'
+      other: '{count} Redirector Pages'
     REDIRECTTO: 'Redirect to'
     REDIRECTTOEXTERNAL: 'Another website'
     REDIRECTTOFILE: 'A file on your website'
@@ -336,10 +336,10 @@ en:
     EditLink: edit
     HEADER: 'This is a virtual page'
     HEADERWITHLINK: 'This is a virtual page copying content from "{title}" ({link})'
-    PLURALNAME: 'Base Pages'
+    PLURALNAME: 'Virtual Pages'
     PLURALS:
       one: 'A Virtual Page'
-      other: '{count} Base Pages'
+      other: '{count} Virtual Pages'
     PageTypNotAllowedOnRoot: 'Original page type "{type}" is not allowed on the root level for this virtual page'
     SINGULARNAME: 'Virtual Page'
     db_VersionID: 'Version ID'


### PR DESCRIPTION
I don't have access to the english section on transifex (and rightly so!) so I'm submitting this trivial fix via pull-request.

Silverstripe 4 is affected too.