### PR TITLE
DOC Remove note about deprecation from comment.

### DIFF
--- a/client/src/styles/legacy/_CMSMain.scss
+++ b/client/src/styles/legacy/_CMSMain.scss
@@ -40,10 +40,6 @@
 }
 
 /**
- * DEPRECATED:
- * .cms-content-tools will be removed in 4.0
- * Use .cms-content-filters instead.
- *
  * Hide certain elements when shown in "sidebar mode"
  */
 .cms-content-tools {


### PR DESCRIPTION
Looks like there was a css class that was MEANT to have been removed, but wasn't and there's no reason to right now. Eventually we'll have to burn the existing styling to the ground, but for now this works and there's no reason to change it.

## Issue
- https://github.com/silverstripe/.github/issues/311