### PR TITLE
ENH Add campaign-admin support back in

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -69,6 +69,8 @@ use SilverStripe\Security\PermissionCheckable;
 use SilverStripe\Versioned\RecursivePublishable;
 use SilverStripe\View\Requirements;
 use SilverStripe\View\ThemeResourceLoader;
+use SilverStripe\Versioned\ChangeSetItem;
+use SilverStripe\Versioned\ChangeSet;
 
 /**
  * The main "content" area of the CMS.
@@ -1427,9 +1429,28 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
 
         // Get the IDs of all changeset including at least one of the records.
         $descendants[] = $record->ID;
+        $inChangeSetIDs = ChangeSetItem::get()->filter([
+            'ObjectID' => $descendants,
+            'ObjectClass' => SiteTree::class
+        ])->column('ChangeSetID');
 
-        if (count($descendants ?? []) > 0) {
+        // Count number of affected change set
+        $affectedChangeSetCount = 0;
+        if (count($inChangeSetIDs ?? []) > 0) {
+            $affectedChangeSetCount = ChangeSet::get()
+                ->filter(['ID' => $inChangeSetIDs, 'State' => ChangeSet::STATE_OPEN])
+                ->count();
+        }
+
+        $numCampaigns = ChangeSet::singleton()->i18n_pluralise($affectedChangeSetCount);
+        $numCampaigns = mb_strtolower($numCampaigns ?? '');
+
+        if (count($descendants ?? []) > 0 && $affectedChangeSetCount > 0) {
+            $archiveWarningMsg = _t('SilverStripe\\CMS\\Controllers\\CMSMain.ArchiveWarningWithChildrenAndCampaigns', 'Warning: This page and all of its child pages will be unpublished and automatically removed from their associated {NumCampaigns} before being sent to the archive.\n\nAre you sure you want to proceed?', [ 'NumCampaigns' => $numCampaigns ]);
+        } elseif (count($descendants ?? []) > 0) {
             $archiveWarningMsg = $defaultMessage;
+        } elseif ($affectedChangeSetCount > 0) {
+            $archiveWarningMsg = _t('SilverStripe\\CMS\\Controllers\\CMSMain.ArchiveWarningWithCampaigns', 'Warning: This page will be unpublished and automatically removed from their associated {NumCampaigns} before being sent to the archive.\n\nAre you sure you want to proceed?', [ 'NumCampaigns' => $numCampaigns ]);
         } else {
             $archiveWarningMsg = _t(
                 LeftAndMain::class . '.ArchiveWarning',

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -1690,14 +1690,32 @@ class SiteTreeTest extends SapphireTest
             $actions->fieldByName('ActionMenus.MoreOptions.action_archive'),
             'archive action present for a saved draft page'
         );
+        if (class_exists(AddToCampaignHandler::class)) {
+            $this->assertNotNull(
+                $actions->fieldByName('ActionMenus.MoreOptions.action_addtocampaign'),
+                'addtocampaign action present for a saved draft page'
+            );
+        }
         $this->assertNull(
             $actions->fieldByName('ActionMenus.MoreOptions.action_unpublish'),
             'no unpublish action present for a saved draft page'
         );
+        if (class_exists(AddToCampaignHandler::class)) {
+            $this->assertNotNull(
+                $actions->fieldByName('ActionMenus.MoreOptions.action_addtocampaign'),
+                'addtocampaign action present for a published page'
+            );
+        }
         $this->assertNull(
             $actions->fieldByName('ActionMenus.MoreOptions.action_rollback'),
             'no rollback action present for a saved draft page'
         );
+        if (class_exists(AddToCampaignHandler::class)) {
+            $this->assertNotNull(
+                $actions->fieldByName('ActionMenus.MoreOptions.action_addtocampaign'),
+                'addtocampaign action present for a changed published page'
+            );
+        }
         $this->assertNull(
             $actions->fieldByName('MajorActions.action_restore'),
             'no restore action present for a saved draft page'
@@ -1805,6 +1823,12 @@ class SiteTreeTest extends SapphireTest
             $actions->fieldByName('ActionMenus.MoreOptions.action_archive')->getForm(),
             'archive action has no form when page is draft'
         );
+        if (class_exists(AddToCampaignHandler::class)) {
+            $this->assertEmpty(
+                $actions->fieldByName('ActionMenus.MoreOptions.action_addtocampaign')->getForm(),
+                'addtocampaign action has no form when page is draft'
+            );
+        }
         // END DRAFT
 
         // BEGIN PUBLISHED
@@ -1815,6 +1839,12 @@ class SiteTreeTest extends SapphireTest
             $actions->fieldByName('ActionMenus.MoreOptions.action_rollback')->getForm(),
             'rollback action has no form when page is published'
         );
+        if (class_exists(AddToCampaignHandler::class)) {
+            $this->assertEmpty(
+                $actions->fieldByName('ActionMenus.MoreOptions.action_addtocampaign')->getForm(),
+                'addtocampaign action has no form when page is published'
+            );
+        }
         // END PUBLISHED
 
         // BEGIN DRAFT AFTER PUBLISHED
@@ -1838,6 +1868,12 @@ class SiteTreeTest extends SapphireTest
             $actions->fieldByName('ActionMenus.MoreOptions.action_rollback')->getForm(),
             'rollback action has no form when page is draft after published'
         );
+        if (class_exists(AddToCampaignHandler::class)) {
+            $this->assertEmpty(
+                $actions->fieldByName('ActionMenus.MoreOptions.action_addtocampaign')->getForm(),
+                'addtocampaign action has no form when page is draft after published'
+            );
+        }
         // END DRAFT AFTER PUBLISHED
 
         // BEGIN ARCHIVED


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/895

This contains some of the code that was originally reverted https://github.com/silverstripe/silverstripe-cms/pull/3027 - the rest of it has been moved into campaign-admin