### PR TITLE
ENH Ensure report links are escaped

### DIFF
--- a/code/Reports/BrokenLinksReport.php
+++ b/code/Reports/BrokenLinksReport.php
@@ -14,6 +14,7 @@ use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Reports\Report;
 use SilverStripe\Versioned\Versioned;
+use SilverStripe\Core\Convert;
 
 /**
  * Content side-report listing pages with broken links
@@ -140,8 +141,8 @@ class BrokenLinksReport extends Report
                 'title' => _t(__CLASS__ . '.ColumnURL', 'URL'),
                 'formatting' => function ($value, $item) {
                     /** @var SiteTree $item */
-                    $liveLink = $item->AbsoluteLiveLink;
-                    $stageLink = $item->AbsoluteLink();
+                    $liveLink = Convert::raw2xml($item->AbsoluteLiveLink);
+                    $stageLink = Convert::raw2xml($item->AbsoluteLink());
                     return sprintf(
                         '%s <a href="%s">%s</a>',
                         $stageLink,

--- a/tests/php/Reports/BrokenLinksReportTest.php
+++ b/tests/php/Reports/BrokenLinksReportTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Reports;
+
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\CMS\Reports\BrokenLinksReport;
+use SilverStripe\CMS\Model\SiteTree;
+
+class BrokenLinksReportTest extends SapphireTest
+{
+    public function testXssEscaped()
+    {
+        // This is an edge case test as Link and AbsoluteLink need to be overridden in a subclass
+        // for there to be any vulnerability to XSS in the BrokenLinksReport
+        // By default, HTML tags are removed from SiteTree.URLSegment by URLSegmentFilter
+        // during SiteTree::onBeforeWrite() so there is no XSS vulnerability in the default implementation
+        $record = new class() extends SiteTree {
+            public function Link($action = null)
+            {
+                return "<script>alert('xss-link');</script>";
+            }
+
+            public function AbsoluteLink($action = null)
+            {
+                return "<script>alert('xss-abs-link');</script>";
+            }
+        };
+        $report = new BrokenLinksReport();
+        /** @var GridField $gridField */
+        $gridField = $report->getReportField();
+        $this->assertSame(
+            '&lt;script&gt;alert(&#039;xss-abs-link&#039;);&lt;/script&gt; <a href="&lt;script&gt;'
+            . 'alert(&?stage=Stage#039;xss-abs-link&#039;);&lt;/script&gt;">(draft)</a>',
+            $gridField->getColumnContent($record, 'AbsoluteLink')
+        );
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripeltd/product-issues/issues/897

If $siteTree->URLSegment somehow got XSS on to it this would protect against it from showing in the report

We do something similar already on the external links report https://github.com/silverstripe/silverstripe-externallinks/blob/3/src/Reports/BrokenExternalLinksReport.php#L41