### PR TITLE
MNT Update test to suppress deleted version history

### DIFF
--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -611,7 +611,7 @@ class CMSMainTest extends FunctionalTest
         $page12 = $this->objFromFixture(SiteTree::class, 'page12');
         // Deleted
         $page1->doUnpublish();
-        $page1->delete();
+        $page1->suppressDeletedVersion(fn () => $page1->delete());
         // Live and draft
         $page11->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
         // Live only


### PR DESCRIPTION
Follows option 1 in https://github.com/silverstripe/silverstripe-versioned/pull/511#issuecomment-2902905039 - any discussion about whether that is the correct option should be held in that PR, not this one.

Needs that PR to be merged in order for CI to go green.

## Issue

- https://github.com/silverstripe/silverstripe-versioned-admin/issues/402