### PR TITLE
API Deprecate constructor which will be removed.

### DIFF
--- a/code/Controllers/CMSSiteTreeFilter.php
+++ b/code/Controllers/CMSSiteTreeFilter.php
@@ -103,9 +103,13 @@ abstract class CMSSiteTreeFilter implements LeftAndMain_SearchFilter
         return $filterMap;
     }
 
+    /**
+     * @deprecated 5.3.1 Will be removed without a constructor to replace it in a future major release.
+     */
     public function __construct($params = null)
     {
         if ($params) {
+            Deprecation::noticeWithNoReplacment('5.3.1', 'Will be removed without a constructor to replace it in a future major release.');
             $this->params = $params;
         }
     }


### PR DESCRIPTION
Constructors with args should be properly deprecated with a warning because otherwise developers may continue to parse arguments in, expecting it them to be used.

## Issue

- https://github.com/silverstripe/.github/issues/409