### PR TITLE
ENH Use new DataList caching

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -742,7 +742,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
 
         // Check record exists in the DB
         /** @var DataObject&Hierarchy $node */
-        $node = DataObject::get_by_id($className, $id);
+        $node = DataObject::get($className)->setUseCache(true)->byID($id);
         if (!$node) {
             $this->httpError(
                 500,
@@ -1255,7 +1255,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
             }
             $record = Versioned::get_version($modelClass, $id, $versionID);
         } else {
-            $record = DataObject::get_by_id($modelClass, $id);
+            $record = DataObject::get($modelClass)->setUseCache(true)->byID($id);
         }
 
         // Then, try getting a record from the live site
@@ -1264,7 +1264,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
             Versioned::set_stage(Versioned::LIVE);
             DataObject::singleton($modelClass)->flushCache();
 
-            $record = DataObject::get_by_id($modelClass, $id);
+            $record = DataObject::get($modelClass)->setUseCache(true)->byID($id);
         }
 
         // Then, try getting a deleted record
@@ -1717,7 +1717,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
         // Existing or new record?
         $id = $data['ID'];
         if (substr($id ?? '', 0, 3) != 'new') {
-            $record = DataObject::get_by_id($className, $id);
+            $record = DataObject::get($className)->setUseCache(true)->byID($id);
             // Check edit permissions
             if ($record && !$record->canEdit()) {
                 return Security::permissionFailure($this);
@@ -1982,7 +1982,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
     public function unpublish(array $data, Form $form): HTTPResponse
     {
         $className = $this->getModelClass();
-        $record = DataObject::get_by_id($className, $data['ID']);
+        $record = DataObject::get($className)->setUseCache(true)->byID($data['ID']);
 
         if (!$record->hasExtension(Versioned::class)) {
             throw new HTTPResponse_Exception(get_class($record) . ' record cannot be unpublished.', 400);

--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -113,7 +113,7 @@ class ContentController extends Controller
         $parent = SiteTree::get_by_link($parentRef);
 
         if (!$parent && is_numeric($parentRef)) {
-            $parent = DataObject::get_by_id(SiteTree::class, $parentRef);
+            $parent = DataObject::get(SiteTree::class)->setUseCache(true)->byID($parentRef);
         }
 
         if ($parent) {

--- a/code/Controllers/ModelAsController.php
+++ b/code/Controllers/ModelAsController.php
@@ -118,12 +118,11 @@ class ModelAsController extends Controller implements NestedController
         }
 
         // Select child page
-        $tableName = DataObject::singleton(SiteTree::class)->baseTable();
-        $conditions = [sprintf('"%s"."URLSegment"', $tableName) => $urlSegment];
+        $conditions = ['URLSegment' => $urlSegment];
         if (SiteTree::config()->get('nested_urls')) {
-            $conditions[] = [sprintf('"%s"."ParentID"', $tableName) => 0];
+            $conditions['ParentID'] = 0;
         }
-        $sitetree = DataObject::get_one(SiteTree::class, $conditions);
+        $sitetree = SiteTree::get()->setUseCache(true)->filter($conditions)->first();
 
         if (!$sitetree) {
             $this->httpError(404, 'The requested page could not be found.');

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -402,11 +402,6 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     public static function get_by_link($link, $cache = true)
     {
-        // Compute the column names with dynamic a dynamic table name
-        $tableName = DataObject::singleton(SiteTree::class)->baseTable();
-        $urlSegmentExpr = sprintf('"%s"."URLSegment"', $tableName);
-        $parentIDExpr = sprintf('"%s"."ParentID"', $tableName);
-
         $link = trim(Director::makeRelative($link) ?? '', '/');
         if ($link === false || $link === null || $link === '') {
             $link = RootURLController::get_homepage_link();
@@ -416,19 +411,17 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
         // Grab the initial root level page to traverse down from.
         $URLSegment = array_shift($parts);
-        $conditions = [$urlSegmentExpr => rawurlencode($URLSegment ?? '')];
+        $conditions = ['URLSegment' => rawurlencode($URLSegment ?? '')];
         if (static::config()->get('nested_urls')) {
-            $conditions[] = [$parentIDExpr => 0];
+            $conditions['ParentID'] = 0;
         }
         /** @var SiteTree $sitetree */
-        $sitetree = DataObject::get_one(SiteTree::class, $conditions, $cache);
+        $sitetree = SiteTree::get()->setUseCache($cache)->filter($conditions)->first();
 
         /// Fall back on a unique URLSegment for b/c.
         if (!$sitetree
             && static::config()->get('nested_urls')
-            && $sitetree = DataObject::get_one(SiteTree::class, [
-                $urlSegmentExpr => $URLSegment
-            ], $cache)
+            && $sitetree = SiteTree::get()->setUseCache($cache)->find('URLSegment', $URLSegment)
         ) {
             return $sitetree;
         }
@@ -457,14 +450,10 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
         // Traverse down the remaining URL segments and grab the relevant SiteTree objects.
         foreach ($parts as $segment) {
-            $next = DataObject::get_one(
-                SiteTree::class,
-                [
-                    $urlSegmentExpr => $segment,
-                    $parentIDExpr => $sitetree->ID
-                ],
-                $cache
-            );
+            $next = SiteTree::get()->setUseCache($cache)->filter([
+                'URLSegment' => $segment,
+                'ParentID' => $sitetree->ID
+            ])->first();
 
             if (!$next) {
                 $parentID = (int) $sitetree->ID;
@@ -541,7 +530,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         }
 
         /** @var SiteTree $page */
-        if (!($page = DataObject::get_by_id(SiteTree::class, $arguments['id']))         // Get the current page by ID.
+        if (!($page = SiteTree::get()->setUseCache(true)->byID($arguments['id']))         // Get the current page by ID.
             && !($page = Versioned::get_latest_version(SiteTree::class, $arguments['id'])) // Attempt link to old version.
         ) {
             return null; // There were no suitable matches at all.
@@ -896,7 +885,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     {
         $parentID = $this->getField("ParentID");
         if ($parentID) {
-            return SiteTree::get_by_id(SiteTree::class, $parentID);
+            return SiteTree::get()->setUseCache(true)->byID($parentID);
         }
         return null;
     }

--- a/code/Model/SiteTreeLinkTracking_Parser.php
+++ b/code/Model/SiteTreeLinkTracking_Parser.php
@@ -61,7 +61,7 @@ class SiteTreeLinkTracking_Parser
             $matches = [];
             if (preg_match('/\[sitetree_link(?:\s*|%20|,)?id=(?<id>[0-9]+)\](#(?<anchor>.*))?/i', $href ?? '', $matches)) {
                 // Check if page link is broken
-                $page = DataObject::get_by_id(SiteTree::class, $matches['id']);
+                $page = SiteTree::get()->setUseCache(true)->byID($matches['id']);
                 if (!$page) {
                     // Page doesn't exist.
                     $broken = true;

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -134,7 +134,7 @@ class VirtualPage extends Page
     public function setCopyContentFromID($val)
     {
         // Sanity check to prevent pages virtualising other virtual pages
-        if ($val && DataObject::get_by_id(SiteTree::class, $val) instanceof VirtualPage) {
+        if ($val && SiteTree::get()->setUseCache(true)->byID($val) instanceof VirtualPage) {
             $val = 0;
         }
         return $this->setField("CopyContentFromID", $val);

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.3",
         "silverstripe/admin": "^3",
-        "silverstripe/framework": "^6",
+        "silverstripe/framework": "^6.1",
         "silverstripe/reports": "^6",
         "silverstripe/siteconfig": "^6",
         "silverstripe/versioned": "^3",

--- a/tests/behat/src/LoginContext.php
+++ b/tests/behat/src/LoginContext.php
@@ -29,8 +29,7 @@ class LoginContext extends BehatLoginContext
         $canEdit = strstr($negative ?? '', 'not') ? false : true;
         // Flush the SiteConfig cache so that siteconfig behat tests that update a
         // SiteConfig DataObject will not be referring to a stale verion of itself
-        // which can happen because SiteConfig::current_site_config() uses DataObject::get_one()
-        // which will caches its result by default
+        // which can happen because SiteConfig::current_site_config() uses a cached query
         SiteConfig::current_site_config()->flushCache();
         if ($canEdit) {
             Assert::assertTrue($page->canEdit($member), 'The member can edit this page');

--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -158,7 +158,7 @@ class CMSMainTest extends FunctionalTest
             $page->Title = "Test $class page";
             $page->write();
             $page->flushCache();
-            $page = DataObject::get_by_id(SiteTree::class, $page->ID);
+            $page = SiteTree::get()->byID($page->ID);
 
             $this->assertTrue($page->getCMSFields() instanceof FieldList);
         }

--- a/tests/php/Controllers/CMSTreeTest.php
+++ b/tests/php/Controllers/CMSTreeTest.php
@@ -71,9 +71,9 @@ class CMSTreeTest extends FunctionalTest
         ];
         $response = $this->post('admin/pages/edit/savetreenode', $data);
         $this->assertEquals(200, $response->getStatusCode());
-        $page2 = DataObject::get_by_id(SiteTree::class, $page2->ID, false);
-        $page31 = DataObject::get_by_id(SiteTree::class, $page31->ID, false);
-        $page32 = DataObject::get_by_id(SiteTree::class, $page32->ID, false);
+        $page2 = SiteTree::get()->byID($page2->ID);
+        $page31 = SiteTree::get()->byID($page31->ID);
+        $page32 = SiteTree::get()->byID($page32->ID);
 
         $this->assertEquals($page3->ID, $page2->ParentID, 'Moved page gets new parent');
         $this->assertEquals(1, $page31->Sort, 'Children pages before insertaion are unaffected');

--- a/tests/php/Model/SiteTreeBrokenLinksTest.php
+++ b/tests/php/Model/SiteTreeBrokenLinksTest.php
@@ -233,10 +233,10 @@ class SiteTreeBrokenLinksTest extends SapphireTest
         $p->delete();
         $p2->flushCache();
         /** @var SiteTree $p2 */
-        $p2 = DataObject::get_by_id(SiteTree::class, $p2->ID);
+        $p2 = SiteTree::get()->byID($p2->ID);
         $rp->flushCache();
         /** @var RedirectorPage $rp */
-        $rp = DataObject::get_by_id(SiteTree::class, $rp->ID);
+        $rp = SiteTree::get()->byID($rp->ID);
         $this->assertEquals(1, $p2->HasBrokenLink);
         $this->assertEquals(1, $rp->HasBrokenLink);
 
@@ -246,9 +246,9 @@ class SiteTreeBrokenLinksTest extends SapphireTest
         $p->doRestoreToStage();
 
         $p2->flushCache();
-        $p2 = DataObject::get_by_id(SiteTree::class, $p2->ID);
+        $p2 = SiteTree::get()->byID($p2->ID);
         $rp->flushCache();
-        $rp = DataObject::get_by_id(SiteTree::class, $rp->ID);
+        $rp = SiteTree::get()->byID($rp->ID);
         $this->assertFalse((bool)$p2->HasBrokenLink);
         $this->assertFalse((bool)$rp->HasBrokenLink);
 
@@ -293,10 +293,10 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
         $page2->flushCache();
         /** @var SiteTree $page2 */
-        $page2 = DataObject::get_by_id(SiteTree::class, $page2->ID);
+        $page2 = SiteTree::get()->byID($page2->ID);
         $redirectorPage->flushCache();
         /** @var RedirectorPage $redirectorPage */
-        $redirectorPage = DataObject::get_by_id(SiteTree::class, $redirectorPage->ID);
+        $redirectorPage = SiteTree::get()->byID($redirectorPage->ID);
         $this->assertEquals(1, $page2->HasBrokenLink);
         $this->assertEquals(1, $redirectorPage->HasBrokenLink);
 
@@ -306,9 +306,9 @@ class SiteTreeBrokenLinksTest extends SapphireTest
         $pageLive->doRevertToLive();
 
         $page2->flushCache();
-        $page2 = DataObject::get_by_id(SiteTree::class, $page2->ID);
+        $page2 = SiteTree::get()->byID($page2->ID);
         $redirectorPage->flushCache();
-        $redirectorPage = DataObject::get_by_id(SiteTree::class, $redirectorPage->ID);
+        $redirectorPage = SiteTree::get()->byID($redirectorPage->ID);
         $this->assertFalse((bool)$page2->HasBrokenLink);
         $this->assertFalse((bool)$redirectorPage->HasBrokenLink);
     }

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -285,6 +285,28 @@ class SiteTreeTest extends SapphireTest
         Versioned::set_reading_mode($oldMode);
     }
 
+    /**
+     * Confirm that cached DataList gets records from SiteTree_Live
+     */
+    public function testCachedListFromLive()
+    {
+        $s = new SiteTree();
+        $s->Title = "V1";
+        $s->URLSegment = "get-one-test-page";
+        $s->write();
+        $s->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
+        $s->Title = "V2";
+        $s->write();
+
+        $oldMode = Versioned::get_reading_mode();
+        Versioned::set_stage(Versioned::LIVE);
+
+        $checkSiteTree = SiteTree::get()->setUseCache(true)->find('URLSegment', 'get-one-test-page');
+        $this->assertEquals("V1", $checkSiteTree->Title);
+
+        Versioned::set_reading_mode($oldMode);
+    }
+
     public function testChidrenOfRootAreTopLevelPages()
     {
         $pages = SiteTree::get();
@@ -410,12 +432,12 @@ class SiteTreeTest extends SapphireTest
         $page = $this->objFromFixture(SiteTree::class, 'about');
         $pageID = $page->ID;
         $page->delete();
-        $this->assertTrue(!DataObject::get_by_id(SiteTree::class, $pageID));
+        $this->assertTrue(!SiteTree::get()->byID($pageID));
 
         $deletedPage = Versioned::get_latest_version(SiteTree::class, $pageID);
         $resultPage = $deletedPage->doRestoreToStage();
 
-        $requeriedPage = DataObject::get_by_id(SiteTree::class, $pageID);
+        $requeriedPage = SiteTree::get()->byID($pageID);
 
         $this->assertEquals($pageID, $resultPage->ID);
         $this->assertEquals($pageID, $requeriedPage->ID);
@@ -438,7 +460,7 @@ class SiteTreeTest extends SapphireTest
         );
 
         Versioned::set_stage(Versioned::DRAFT);
-        $requeriedPage = DataObject::get_by_id(SiteTree::class, $page2ID);
+        $requeriedPage = SiteTree::get()->byID($page2ID);
         $this->assertEquals('Products', $requeriedPage->Title);
         $this->assertInstanceOf(SiteTree::class, $requeriedPage);
     }
@@ -582,9 +604,9 @@ class SiteTreeTest extends SapphireTest
 
         $pageAbout->delete();
 
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageAbout->ID));
-        $this->assertTrue(DataObject::get_by_id(SiteTree::class, $pageStaff->ID) instanceof SiteTree);
-        $this->assertTrue(DataObject::get_by_id(SiteTree::class, $pageStaffDuplicate->ID) instanceof SiteTree);
+        $this->assertNull(SiteTree::get()->byID($pageAbout->ID));
+        $this->assertTrue(SiteTree::get()->byID($pageStaff->ID) instanceof SiteTree);
+        $this->assertTrue(SiteTree::get()->byID($pageStaffDuplicate->ID) instanceof SiteTree);
         Config::modify()->set(SiteTree::class, 'enforce_strict_hierarchy', true);
     }
 
@@ -596,9 +618,9 @@ class SiteTreeTest extends SapphireTest
 
         $pageAbout->delete();
 
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageAbout->ID));
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageStaff->ID));
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageStaffDuplicate->ID));
+        $this->assertNull(SiteTree::get()->byID($pageAbout->ID));
+        $this->assertNull(SiteTree::get()->byID($pageStaff->ID));
+        $this->assertNull(SiteTree::get()->byID($pageStaffDuplicate->ID));
     }
 
     public function testDuplicate()
@@ -628,9 +650,9 @@ class SiteTreeTest extends SapphireTest
 
         Versioned::set_stage(Versioned::LIVE);
 
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageAbout->ID));
-        $this->assertTrue(DataObject::get_by_id(SiteTree::class, $pageStaff->ID) instanceof SiteTree);
-        $this->assertTrue(DataObject::get_by_id(SiteTree::class, $pageStaffDuplicate->ID) instanceof SiteTree);
+        $this->assertNull(SiteTree::get()->byID($pageAbout->ID));
+        $this->assertTrue(SiteTree::get()->byID($pageStaff->ID) instanceof SiteTree);
+        $this->assertTrue(SiteTree::get()->byID($pageStaffDuplicate->ID) instanceof SiteTree);
         Versioned::set_stage(Versioned::DRAFT);
         Config::modify()->set(SiteTree::class, 'enforce_strict_hierarchy', true);
     }
@@ -651,9 +673,9 @@ class SiteTreeTest extends SapphireTest
         $parentPage->doUnpublish();
 
         Versioned::set_stage(Versioned::LIVE);
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageAbout->ID));
-        $this->assertTrue(DataObject::get_by_id(SiteTree::class, $pageStaff->ID) instanceof SiteTree);
-        $this->assertTrue(DataObject::get_by_id(SiteTree::class, $pageStaffDuplicate->ID) instanceof SiteTree);
+        $this->assertNull(SiteTree::get()->byID($pageAbout->ID));
+        $this->assertTrue(SiteTree::get()->byID($pageStaff->ID) instanceof SiteTree);
+        $this->assertTrue(SiteTree::get()->byID($pageStaffDuplicate->ID) instanceof SiteTree);
         Versioned::set_stage(Versioned::DRAFT);
         Config::modify()->set(SiteTree::class, 'enforce_strict_hierarchy', true);
     }
@@ -673,9 +695,9 @@ class SiteTreeTest extends SapphireTest
         $parentPage->doUnpublish();
 
         Versioned::set_stage(Versioned::LIVE);
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageAbout->ID));
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageStaff->ID));
-        $this->assertNull(DataObject::get_by_id(SiteTree::class, $pageStaffDuplicate->ID));
+        $this->assertNull(SiteTree::get()->byID($pageAbout->ID));
+        $this->assertNull(SiteTree::get()->byID($pageStaff->ID));
+        $this->assertNull(SiteTree::get()->byID($pageStaffDuplicate->ID));
         Versioned::set_stage(Versioned::DRAFT);
     }
 
@@ -950,9 +972,7 @@ class SiteTreeTest extends SapphireTest
         $this->assertFalse($productPage->isCurrent());
 
         $this->assertTrue(
-            DataObject::get_one(SiteTree::class, [
-                '"SiteTree"."Title"' => 'About Us',
-            ])->isCurrent(),
+            SiteTree::get()->setUseCache(true)->find('Title', 'About Us')->isCurrent(),
             'Assert that isCurrent works on another instance with the same ID.'
         );
 
@@ -1137,11 +1157,11 @@ class SiteTreeTest extends SapphireTest
 
         $sitetree->URLSegment = 'brötchen';
         $sitetree->write();
-        $sitetree = DataObject::get_by_id(SiteTree::class, $sitetree->ID, false);
+        $sitetree = SiteTree::get()->byID($sitetree->ID, false);
         $this->assertEquals($sitetree->URLSegment, rawurlencode('brötchen'));
 
         $sitetree->copyVersionToStage(Versioned::DRAFT, Versioned::LIVE);
-        $sitetree = DataObject::get_by_id(SiteTree::class, $sitetree->ID, false);
+        $sitetree = SiteTree::get()->byID($sitetree->ID, false);
         $this->assertEquals($sitetree->URLSegment, rawurlencode('brötchen'));
         $sitetreeLive = Versioned::get_one_by_stage(
             SiteTree::class,

--- a/tests/php/Model/VirtualPageTest.php
+++ b/tests/php/Model/VirtualPageTest.php
@@ -126,17 +126,17 @@ class VirtualPageTest extends FunctionalTest
         $master->write();
 
         /** @var VirtualPage $vp1 */
-        $vp1 = DataObject::get_by_id(VirtualPage::class, $this->idFromFixture(VirtualPage::class, 'vp1'));
+        $vp1 = $this->objFromFixture(VirtualPage::class, 'vp1');
         /** @var VirtualPage $vp2 */
-        $vp2 = DataObject::get_by_id(VirtualPage::class, $this->idFromFixture(VirtualPage::class, 'vp2'));
+        $vp2 = $this->objFromFixture(VirtualPage::class, 'vp2');
         $this->assertTrue($vp1->publishRecursive());
         $this->assertTrue($vp2->publishRecursive());
 
         $master->publishRecursive();
 
         Versioned::set_stage(Versioned::LIVE);
-        $vp1 = DataObject::get_by_id(VirtualPage::class, $this->idFromFixture(VirtualPage::class, 'vp1'));
-        $vp2 = DataObject::get_by_id(VirtualPage::class, $this->idFromFixture(VirtualPage::class, 'vp2'));
+        $vp1 = $this->objFromFixture(VirtualPage::class, 'vp1');
+        $vp2 = $this->objFromFixture(VirtualPage::class, 'vp2');
 
         $this->assertNotNull($vp1);
         $this->assertNotNull($vp2);
@@ -348,14 +348,14 @@ class VirtualPageTest extends FunctionalTest
 
         // The draft VP still has the CopyContentFromID link
         $vp->flushCache();
-        $vp = DataObject::get_by_id(SiteTree::class, $vpID);
+        $vp = SiteTree::get()->byID($vpID);
         $this->assertEquals($p->ID, $vp->CopyContentFromID);
         $vpLive = Versioned::get_by_stage(SiteTree::class, Versioned::LIVE)->byID($vpID);
         $this->assertNull($vpLive);
         // Delete from draft, ensure virtual page deletion cascades
         $p->delete();
         $vp->flushCache();
-        $vp = DataObject::get_by_id(SiteTree::class, $vpID);
+        $vp = SiteTree::get()->byID($vpID);
         $this->assertNull($vp);
     }
 
@@ -484,7 +484,7 @@ class VirtualPageTest extends FunctionalTest
         $virtual->CopyContentFromID = $page->ID;
         $virtual->write();
 
-        $virtual = DataObject::get_by_id(VirtualPage::class, $virtual->ID, false);
+        $virtual = VirtualPage::get()->byID($virtual->ID);
         $virtual->CopyContentFromID = $notRootPage->ID;
         $virtual->flushCache();
 


### PR DESCRIPTION
Replaces deprecated `DataObject::get_one()` and `DataObject::get_by_id()` in favour of the new DataList query caching.

Tests have been updated to remove caching where it's not relevant to the test.

> [!IMPORTANT]
> Relies on https://github.com/silverstripe/silverstripe-framework/pull/11768
> DO NOT MERGE until that PR has been merged in

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11767
