### PR TITLE
FIX Only use descendent count for archive message

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1445,9 +1445,6 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
             $descendants = [];
         }
 
-        // Get the IDs of all changeset including at least one of the records.
-        $descendants[] = $record->ID;
-
         if (count($descendants ?? []) > 0) {
             $archiveWarningMsg = $defaultMessage;
         } else {

--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -947,4 +947,26 @@ class CMSMainTest extends FunctionalTest
         $actual = strip_tags($html);
         $this->assertSame($expected, $actual);
     }
+
+    public function testGetArchiveWarningMessage(): void
+    {
+        $controller = new CMSMain();
+        $reflectionMethod = new ReflectionMethod($controller, 'getArchiveWarningMessage');
+        $reflectionMethod->setAccessible(true);
+        $page = new SiteTree(['Title' => 'my page']);
+        $page->write();
+
+        $this->assertSame(
+            'Warning: This record will be unpublished before being sent to the archive.\n\nAre you sure you want to proceed?',
+            $reflectionMethod->invoke($controller, $page)
+        );
+
+        $childPage = new SiteTree(['ParentID' => $page->ID]);
+        $childPage->write();
+
+        $this->assertSame(
+            'Warning: This record and all of its child records will be unpublished before being sent to the archive.\n\nAre you sure you want to proceed?',
+            $reflectionMethod->invoke($controller, $page)
+        );
+    }
 }


### PR DESCRIPTION
The current record shouldn't be counted as a descendant for the dynamic archive message.

## Issue

- https://github.com/silverstripe/silverstripe-cms/issues/3103