### PR TITLE
ENH Disable sorting on queries where sort order doesn't matter

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1466,8 +1466,8 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
      */
     protected function collateDescendants($recordIDs, &$collator)
     {
-
-        $children = DataObject::get($this->getModelClass())->filter(['ParentID' => $recordIDs])->column();
+        // Disabling sort improves performance
+        $children = DataObject::get($this->getModelClass())->filter(['ParentID' => $recordIDs])->sort(null)->column('ID');
         if ($children) {
             foreach ($children as $item) {
                 $collator[] = $item;

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -1611,7 +1611,8 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
         // If deleting this page, delete all its children.
         if ($this->isInDB() && SiteTree::config()->get('enforce_strict_hierarchy')) {
-            foreach ($this->AllChildren() as $child) {
+            # Disabling sort improves performance
+            foreach ($this->AllChildren()->sort(null) as $child) {
                 $child->delete();
             }
         }

--- a/tests/php/Model/SiteTreeHTMLEditorFieldTest.php
+++ b/tests/php/Model/SiteTreeHTMLEditorFieldTest.php
@@ -55,8 +55,8 @@ class SiteTreeHTMLEditorFieldTest extends FunctionalTest
         $editor->saveInto($sitetree);
         $sitetree->write();
         $this->assertEquals(
-            [$aboutID => $aboutID],
-            $sitetree->LinkTracking()->getIdList(),
+            [$aboutID],
+            $sitetree->LinkTracking()->column('ID'),
             'Basic link tracking works.'
         );
 
@@ -66,23 +66,23 @@ class SiteTreeHTMLEditorFieldTest extends FunctionalTest
         $editor->saveInto($sitetree);
         $sitetree->write();
         $this->assertEquals(
-            [$aboutID => $aboutID, $contactID => $contactID],
-            $sitetree->LinkTracking()->getIdList(),
+            [$aboutID, $contactID],
+            $sitetree->LinkTracking()->column('ID'),
             'Tracking works on multiple links'
         );
 
         $editor->setValue(null);
         $editor->saveInto($sitetree);
         $sitetree->write();
-        $this->assertEquals([], $sitetree->LinkTracking()->getIdList(), 'Link tracking is removed when links are.');
+        $this->assertEquals([], $sitetree->LinkTracking()->column('ID'), 'Link tracking is removed when links are.');
 
         // Legacy support - old CMS versions added link shortcodes with spaces instead of commas
         $editor->setValue("<a href=\"[sitetree_link id=$aboutID]\">Example Link</a>");
         $editor->saveInto($sitetree);
         $sitetree->write();
         $this->assertEquals(
-            [$aboutID => $aboutID],
-            $sitetree->LinkTracking()->getIdList(),
+            [$aboutID],
+            $sitetree->LinkTracking()->column('ID'),
             'Link tracking with space instead of comma in shortcode works.'
         );
     }


### PR DESCRIPTION
Sorting queries can be slow, especially on large datasets and especially if indexes aren't optimised. We should avoid sorting when the sort order doesn't matter.


## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11833