### PR TITLE
ENH Hide font icons from screen readers

### DIFF
--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_ContentToolActions.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_ContentToolActions.ss
@@ -1,12 +1,14 @@
 <div class="toolbar toolbar--content cms-content-toolbar">
 	<div class="btn-toolbar cms-actions-buttons-row">
         <% if not $TreeIsFiltered %>
-            <a class="btn btn-primary cms-content-addpage-button tool-button font-icon-plus" href="$LinkRecordAdd" data-url-addpage="{$LinkRecordAdd('', 'ParentID=%s')}">
+            <a class="btn btn-primary cms-content-addpage-button tool-button" href="$LinkRecordAdd" data-url-addpage="{$LinkRecordAdd('', 'ParentID=%s')}">
+                <span class="font-icon-plus" aria-hidden="true"></span>
                 <%t SilverStripe\Admin\\LeftAndMain.AddNew 'Add new {name}' name=$getRecord('singleton').i18n_singular_name().lowercase %>
             </a>
 
             <% if $View == 'Tree' %>
-            <button type="button" class="cms-content-batchactions-button btn btn-secondary tool-button font-icon-check-mark-2 btn--last" data-toolid="batch-actions">
+            <button type="button" class="cms-content-batchactions-button btn btn-secondary tool-button btn--last" data-toolid="batch-actions">
+                <span class="font-icon-check-mark-2" aria-hidden="true"></span>
                 <%t SilverStripe\CMS\Controllers\CMSPageHistoryController.MULTISELECT "Batch actions" %>
             </button>
             <% end_if %>

--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_ViewControls.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_ViewControls.ss
@@ -1,18 +1,20 @@
 <div class="view-controls view-controls--{$ViewState}">
     <% if not $TreeIsFiltered %>
         <%-- Change to data-pjax-target="Content-RecordList" to enable in-edit listview --%>
-        <a class="page-view-link btn btn-secondary btn--icon-sm btn--no-text font-icon-tree"
+        <a class="page-view-link btn btn-secondary btn--icon-sm btn--no-text"
             href="$LinkTreeView.ATT"
             data-view="treeview"
             data-pjax-target="$PJAXTarget.ATT"
             title="<%t SilverStripe\CMS\Controllers\CMSMain.TreeView 'Tree View' %>"
-        ></a>
+            aria-label="<%t SilverStripe\CMS\Controllers\CMSMain.TreeView 'Tree View' %>"
+        ><span class="font-icon-tree" aria-hidden="true"></span></a>
 
-        <a class="page-view-link btn btn-secondary btn--icon-sm btn--no-text font-icon-list"
+        <a class="page-view-link btn btn-secondary btn--icon-sm btn--no-text"
             href="$LinkListView.ATT"
             data-view="listview"
             data-pjax-target="$PJAXTarget.ATT"
             title="<%t SilverStripe\CMS\Controllers\CMSMain.ListView 'List View' %>"
-        ></a>
+            aria-label="<%t SilverStripe\CMS\Controllers\CMSMain.ListView 'List View' %>"
+        ><span class="font-icon-list" aria-hidden="true"></span></a>
     <% end_if %>
 </div>


### PR DESCRIPTION
- Hides decorative icons from screen readers (usually by adding an inner `span`)
- In a few places, adds `aria-label` (will be noted with PR comments)

Without the admin PR things look very slightly different, but it's still perfectly usable so I don't think it's worth updating the constraint.

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/1957