### PR TITLE
FIX: Page anchors should not contain shortcode ids

### DIFF
--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -2672,8 +2672,8 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         // Force live sort order to match stage sort order
         $sql = sprintf(
             'UPDATE "%2$s"
-			SET "Sort" = (SELECT "%1$s"."Sort" FROM "%1$s" WHERE "%2$s"."ID" = "%1$s"."ID")
-			WHERE EXISTS (SELECT "%1$s"."Sort" FROM "%1$s" WHERE "%2$s"."ID" = "%1$s"."ID") AND "ParentID" = ?',
+            SET "Sort" = (SELECT "%1$s"."Sort" FROM "%1$s" WHERE "%2$s"."ID" = "%1$s"."ID")
+            WHERE EXISTS (SELECT "%1$s"."Sort" FROM "%1$s" WHERE "%2$s"."ID" = "%1$s"."ID") AND "ParentID" = ?',
             $this->baseTable(),
             $this->stageTable($this->baseTable(), Versioned::LIVE)
         );
@@ -3434,9 +3434,22 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      */
     public function getAnchorsOnPage()
     {
+        $content = $this->Content ?? '';
+        
+        // Shortcodes may contain name/id attributes, they mess up the parsing below
+        // we replace them with their content first
+        // Note: We don't use ShortcodeParser::parse() here as that would execute the shortcodes
+        // which may have performance and side effects
+        $tags = ShortcodeParser::get_active()->extractTags($content);
+        
+        // replace any tags found with their content
+        foreach ($tags as $tag) {
+            $content = str_replace($tag['text'], $tag['content'], $content);
+        }
+
         $parseSuccess = preg_match_all(
             "/\\s+(name|id)\\s*=\\s*([\"'])([^\\2\\s>]*?)\\2|\\s+(name|id)\\s*=\\s*([^\"']+)[\\s +>]/im",
-            $this->Content ?? '',
+            $content ?? '',
             $matches
         );
 

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -2171,4 +2171,17 @@ class SiteTreeTest extends SapphireTest
         $this->expectNotToPerformAssertions();
         $page->onAfterRevertToLive();
     }
+
+    public function testAnchorsOnPage()
+    {
+        // Make sure Anchors are extracted from content, but shortcode tags are ignored
+        $page = new SiteTree();
+        $page->Content = '<h1 id="heading1">Heading 1</h1><h2 id=heading2>Heading 2</h2>[image src="/assets/sample" id="1" class="ss-htmleditorfield-file image"]';
+        $page->write();
+
+        $anchors = $page->getAnchorsOnPage();
+        $this->assertCount(2, $anchors);
+        $this->assertEquals('heading1', $anchors[0]);
+        $this->assertEquals('heading2', $anchors[1]);
+    }
 }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
The anchor selector of the anchor-link modal in the CMS was picking up IDs from image shortcodes.
see #2837 

## Manual testing steps
* Add an image to a content field on page A
* Try to add an anchor link to page A from another page.
* This list of anchors will contain the ID from the image shortcode

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #2837

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
