### PR TITLE
MNT Fix behat test to account for boolean attrs

### DIFF
--- a/tests/behat/features/create-a-page.feature
+++ b/tests/behat/features/create-a-page.feature
@@ -50,5 +50,5 @@ Feature: Create a page
     And I click on the ".cms-login-status__logout-link" element
     When I am logged in as a member of "EDITOR" group
     And I press the "Add new" button
-    Then I see the "Top level" radio button "disabled" attribute equals "1"
-    And I see the "Under another page" radio button "checked" attribute equals "1"
+    Then I see the "Top level" radio button has boolean attribute "disabled"
+    And I see the "Under another page" radio button has boolean attribute "checked"

--- a/tests/behat/src/FixtureContext.php
+++ b/tests/behat/src/FixtureContext.php
@@ -103,7 +103,7 @@ class FixtureContext extends BehatFixtureContext
     }
 
     /**
-     * Selects the specified radio button
+     * Checks the value of an attribute on the specified radio button
      *
      * @Given /^I see the "([^"]*)" radio button "([^"]*)" attribute equals "([^"]*)"$/
      * @param string $radioLabel
@@ -120,6 +120,33 @@ class FixtureContext extends BehatFixtureContext
         ]);
         Assert::assertNotNull($radioButton);
         Assert::assertEquals($value, $radioButton->getAttribute($attribute));
+    }
+
+    /**
+     * Checks the specified radio button has a specific boolean attribute
+     *
+     * @Given /^I see the "([^"]*)" radio button has boolean attribute "([^"]*)"$/
+     * @param string $radioLabel
+     * @param string $attribute
+     */
+    public function iSeeTheRadioButtonHasBooleanAttribute($radioLabel, $attribute)
+    {
+        /** @var NodeElement $radioButton */
+        $session = $this->getMainContext()->getSession();
+        $radioButton = $session->getPage()->find('named', [
+            'radio',
+            $this->getMainContext()->getXpathEscaper()->escapeLiteral($radioLabel)
+        ]);
+        Assert::assertNotNull($radioButton);
+        Assert::assertTrue(
+            $radioButton->hasAttribute($attribute),
+            "Radio button $radioLabel has no attribute $attribute"
+        );
+        Assert::assertEquals(
+            '',
+            $radioButton->getAttribute($attribute),
+            "$attribute attribute on radio button $radioLabel is not a boolean attribute"
+        );
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/actions/runs/18551366745/job/52879323500

> Then I see the "Top level" radio button "disabled" attribute equals "1"          # SilverStripe\CMS\Tests\Behaviour\FixtureContext::iSeeTheRadioButtonAttributeEquals()
>       Failed asserting that two strings are equal.
>       --- Expected
>       +++ Actual
>       @@ @@
>       -'1'
>       +''

## Issue

- https://github.com/silverstripe/.github/issues/459