### PR TITLE
ENH Don't add default filterclass if explicitly removed.

### DIFF
--- a/code/Search/SiteTreeSearchContext.php
+++ b/code/Search/SiteTreeSearchContext.php
@@ -19,7 +19,7 @@ class SiteTreeSearchContext extends SearchContext
     {
         $origSearchParams = $searchParams;
         // Set default filter if other params are set
-        if ($searchParams && empty($searchParams['FilterClass'])) {
+        if ($searchParams && empty($searchParams['FilterClass']) && $this->getSearchFields()->dataFieldByName('FilterClass')) {
             $searchParams['FilterClass'] = CMSSiteTreeFilter_Search::class;
         }
         $query = parent::getQuery($searchParams, $sort, $limit, $existingQuery);


### PR DESCRIPTION
It can be advantageous, e.g. with archived admin, to have a pre-defined version filter applied to site tree searching. We can't do that if the default filter class is always applied.

We can signal that we want to use an explicit pre-defined version filter by removing the ability to search by other version filters.

Needed for https://github.com/silverstripe/silverstripe-versioned-admin/pull/431

## Issue

- https://github.com/silverstripe/silverstripe-versioned-admin/issues/228