### PR TITLE
FIX Do not lowercase singular name

### DIFF
--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_ContentToolActions.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_ContentToolActions.ss
@@ -2,7 +2,7 @@
 	<div class="btn-toolbar cms-actions-buttons-row">
         <% if not $TreeIsFiltered %>
             <a class="btn btn-primary cms-content-addpage-button tool-button font-icon-plus" href="$LinkRecordAdd" data-url-addpage="{$LinkRecordAdd('', 'ParentID=%s')}">
-                <%t SilverStripe\Admin\\LeftAndMain.AddNew 'Add new {name}' name=$getRecord('singleton').i18n_singular_name().lowercase %>
+                <%t SilverStripe\Admin\\LeftAndMain.AddNew 'Add new {name}' name=$getRecord('singleton').i18n_singular_name() %>
             </a>
 
             <% if $View == 'Tree' %>

--- a/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_ListView.ss
+++ b/templates/SilverStripe/CMS/Controllers/Includes/CMSMain_ListView.ss
@@ -1,6 +1,6 @@
 <% include SilverStripe\\CMS\\Controllers\\CMSMain_ContentToolActions %>
 
-<div class="ss-dialog cms-page-add-form-dialog cms-dialog-content" id="cms-page-add-form" title="<%t SilverStripe\Admin\\LeftAndMain.AddNew 'Add new {name}' name=$getRecord('singleton').i18n_singular_name().lowercase %>">
+<div class="ss-dialog cms-page-add-form-dialog cms-dialog-content" id="cms-page-add-form" title="<%t SilverStripe\Admin\\LeftAndMain.AddNew 'Add new {name}' name=$getRecord('singleton').i18n_singular_name() %>">
 	$AddForm
 </div>
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-cms/issues/3132

Reason this bug occurs is because [en.yml](https://github.com/silverstripe/silverstripe-cms/blob/6/lang/en.yml#L4) has ` AddNew: 'Add new {name}'`

While  [de.yml](https://github.com/silverstripe/silverstripe-cms/blob/6/lang/de.yml#L4) has `AddNew: '{name} neu hinzufügen'`

So the assumption that we should lowercase the singular name because it's not the first word is a bad assumption.

We don't lowercase the singular name on [GridFieldAddNewButton](https://github.com/silverstripe/silverstripe-framework/blob/6/src/Forms/GridField/GridFieldAddNewButton.php#L65) - so it makes sense that we shouldn't lowercase in these 2x templates

I've also had a look around for any other examples like these where we use the `AddNew` string - I couldn't find any others where we are lowercasing `{name}`