### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -716,7 +716,6 @@ class CMSMainTest extends FunctionalTest
     {
         $cms = CMSMain::create();
         $reflectionAllowedSubclasses = new ReflectionMethod($cms, 'getAllowedSubClasses');
-        $reflectionAllowedSubclasses->setAccessible(true);
         /** @var Member $user */
         $user = $this->objFromFixture(Member::class, 'rootedituser');
         Security::setCurrentUser($user);
@@ -789,7 +788,6 @@ class CMSMainTest extends FunctionalTest
         // Use injector because CMSMain defines some injectable dependencies
         $cms = CMSMain::create();
         $reflectionMethod = new ReflectionMethod($cms, 'getCreatableSubClasses');
-        $reflectionMethod->setAccessible(true);
 
         $siteTree = new SiteTree();
         $user = $this->objFromFixture(Member::class, 'allcmssectionsuser');
@@ -872,7 +870,6 @@ class CMSMainTest extends FunctionalTest
         // Use injector because CMSMain defines some injectable dependencies
         $cms = CMSMain::create();
         $initReflection = new ReflectionMethod($cms, 'init');
-        $initReflection->setAccessible(true);
         if ($throwsException) {
             $this->expectException(LogicException::class);
         } else {
@@ -903,7 +900,6 @@ class CMSMainTest extends FunctionalTest
             SiteTree::config()->set('tree_children_method', 'mySiteTreeMethod');
         }
         $refl = new ReflectionMethod($cmsMain, 'getTreeAsULPrepopulateOptions');
-        $refl->setAccessible(true);
         $actual = $refl->invoke($cmsMain, SiteTree::class)['childrenMethod'];
         $this->assertSame($expected, $actual);
     }
@@ -952,7 +948,6 @@ class CMSMainTest extends FunctionalTest
     {
         $controller = new CMSMain();
         $reflectionMethod = new ReflectionMethod($controller, 'getArchiveWarningMessage');
-        $reflectionMethod->setAccessible(true);
         $page = new SiteTree(['Title' => 'my page']);
         $page->write();
 

--- a/tests/php/Model/SiteTreeTest.php
+++ b/tests/php/Model/SiteTreeTest.php
@@ -1243,8 +1243,6 @@ class SiteTreeTest extends SapphireTest
     {
         $sitetree = new SiteTree();
         $method = new ReflectionMethod($sitetree, 'getClassDropdown');
-        $method->setAccessible(true);
-
         Security::setCurrentUser(null);
         $this->assertArrayNotHasKey(SiteTreeTest_ClassA::class, $method->invoke($sitetree));
 
@@ -1658,10 +1656,8 @@ class SiteTreeTest extends SapphireTest
         $provider = new EmbedShortcodeProvider();
         $reflector = new \ReflectionClass(EmbedShortcodeProvider::class);
         $method = $reflector->getMethod('getCache');
-        $method->setAccessible(true);
         $cache = $method->invokeArgs($provider, []);
         $method = $reflector->getMethod('deriveCacheKey');
-        $method->setAccessible(true);
         $class = 'leftAlone ss-htmleditorfield-file embed';
         $width = '480';
         $height = '270';
@@ -1957,7 +1953,6 @@ class SiteTreeTest extends SapphireTest
         // Test that method doesn't throw exception
         $this->expectNotToPerformAssertions();
         $method = new ReflectionMethod(SiteTree::class, 'onAfterRevertToLive');
-        $method->setAccessible(true);
         $method->invoke($page);
     }
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.