### PR TITLE
ENH Don't use deprecated `FieldList::dataFields()`

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1368,7 +1368,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
         }
 
         // Use <button> to allow full jQuery UI styling
-        $actionsFlattened = $actions->dataFields();
+        $actionsFlattened = $actions->getDataFields();
         if ($actionsFlattened) {
             /** @var FormAction $action */
             foreach ($actionsFlattened as $action) {

--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -177,7 +177,7 @@ class CMSMainTest extends FunctionalTest
         $parentPage->doUnpublish();
         $childPage->doUnpublish();
 
-        $actions = $childPage->getCMSActions()->dataFields();
+        $actions = $childPage->getCMSActions()->getDataFields();
         $this->assertArrayHasKey(
             'action_publish',
             $actions,


### PR DESCRIPTION
`composer.json` already required framework 6.2

## Issue

- https://github.com/silverstripe/silverstripe-elemental/issues/445