### PR TITLE
MNT Update old behat reference to filter button

### DIFF
--- a/tests/behat/features/search-for-a-page.feature
+++ b/tests/behat/features/search-for-a-page.feature
@@ -126,7 +126,7 @@ Feature: Search for a page
   Scenario: Closing the search filter without searching doesn't kick me back to the site tree
     When I click on "About Us" in the tree
     Then I should see an edit page form
-    When I press the "Filter" button
+    When I press the "Open search and filter" button
     Then I should see the "Advanced" button
     When I press the "Close" button
     Then I should not see the "Advanced" button


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-cms/actions/runs/20983681124/job/60532422323

>  Scenario: Closing the search filter without searching doesn't kick me back to the site tree # tests/behat/features/search-for-a-page.feature:126
    When I press the "Filter" button # SilverStripe\BehatExtension\Context\BasicContext::stepIPressTheButton()
      Filter button not found

Also needs https://github.com/silverstripe/silverstripe-admin/pull/2097 for the behat test to go green.

## Issue

- https://github.com/silverstripe/.github/issues/474