### PR TITLE
FIX Show validation errors for add record form.

### DIFF
--- a/code/Controllers/CMSPageAddController.php
+++ b/code/Controllers/CMSPageAddController.php
@@ -184,14 +184,17 @@ class CMSPageAddController extends CMSPageEditController
         )->setHTMLID('Form_AddForm')->setStrictFormMethodCheck(false);
         $form->setAttribute('data-hints', $this->SiteTreeHints());
         $form->setAttribute('data-childfilter', $this->Link('childfilter'));
+        $form->setAttribute('data-pjax-fragment', 'CurrentForm');
         $form->setValidationResponseCallback(function (ValidationResult $errors) use ($negotiator, $form) {
             $request = $this->getRequest();
             if ($request->isAjax() && $negotiator) {
-                $result = $form->forTemplate();
                 return $negotiator->respond($request, [
-                    'CurrentForm' => function () use ($result) {
-                        return $result;
-                    }
+                    'Content' => function () use ($form) {
+                        return $this->renderWith($this->getTemplatesWithSuffix('_Content'), ['AddForm' => $form]);
+                    },
+                    'CurrentForm' => function () use ($form) {
+                        return $form->forTemplate();
+                    },
                 ]);
             }
             return null;

--- a/tests/behat/features/create-a-page.feature
+++ b/tests/behat/features/create-a-page.feature
@@ -61,3 +61,33 @@ Feature: Create a page
     And I press the "Add new" button
     Then I should see "Virtual Page" in the "#Form_AddForm_PageType div.radio.selected" element
     Then the "Virtual Page" checkbox should be checked
+
+  Scenario: I can create a page using the context menu
+    Given I am logged in as a member of "EDITOR" group
+    When I go to "/admin/pages"
+    And I right click on "MyPage" in the tree
+    And I hover on "Add new page here" in the context menu
+    And I click on "Page" in the context menu
+    Then I should see "New Page" in the tree
+    And I should see an edit page form
+
+  Scenario: Failed validation during page creation shows the validation error
+    Given I add an extension "SilverStripe\CMS\Tests\Behaviour\ValidationFailedAddPageExtension" to the "SilverStripe\CMS\Controllers\CMSPageAddController" class
+    And I am logged in as a member of "EDITOR" group
+    When I go to "/admin/pages"
+    # First use the context menu approach
+    And I right click on "MyPage" in the tree
+    And I hover on "Add new page here" in the context menu
+    And I click on "Page" in the context menu
+    And I should see a "Validation Error" error toast
+    And I should see a "form#Form_AddForm" element
+    And I should see "This field failed validation"
+    Then I should not see an edit page form
+    # Then check we get the same result with normal form submission
+    When I go to "/admin/pages"
+    And I press the "Add new" button
+    And I press the "Create" button
+    And I should see a "Validation Error" error toast
+    And I should see a "form#Form_AddForm" element
+    And I should see "This field failed validation"
+    Then I should not see an edit page form

--- a/tests/behat/src/ValidationFailedAddPageExtension.php
+++ b/tests/behat/src/ValidationFailedAddPageExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace SilverStripe\CMS\Tests\Behaviour;
+
+use SilverStripe\Core\Extension;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\TextField;
+
+/**
+ * Adds a new field to the app records form that forces validation to fail
+ */
+class ValidationFailedAddPageExtension extends Extension implements TestOnly
+{
+    protected function updatePageOptions(FieldList $fields)
+    {
+        $fields->add(new class('ValidationFailureField') extends TextField {
+            public function validate($validator)
+            {
+                $validator->validationError($this->getName(), 'This field failed validation');
+                return false;
+            }
+        });
+    }
+}


### PR DESCRIPTION
This ensures validation errors are displayed in the form for both regular form submission as well as the context menu's form submission.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11943