### PR TITLE
MNT Fix broken behat test in kitchen sink

### DIFF
--- a/tests/behat/features/create-a-page.feature
+++ b/tests/behat/features/create-a-page.feature
@@ -60,7 +60,8 @@ Feature: Create a page
     When I go to "/admin/pages"
     And I press the "Add new" button
     Then I should see "Virtual Page" in the "#Form_AddForm_PageType div.radio.selected" element
-    Then the "Virtual Page" checkbox should be checked
+    # Use the class description when selecting so the subsites virtual page isn't found in kitchen sink
+    Then the "Displays the content of another page" checkbox should be checked
 
   Scenario: I can create a page using the context menu
     Given I am logged in as a member of "EDITOR" group


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-kitchen-sink/actions/runs/21926463287/job/63925185860

> Then the "Virtual Page" checkbox should be checked  # SilverStripe\Framework\Tests\Behaviour\FeatureContext::assertCheckboxChecked()
> Checkbox "Virtual Page" is not checked, but it should be. (Behat\Mink\Exception\ExpectationException)

The "Subsites Virtual Page" is before "Virtual Page" in the list in kitchen sink, so behat was looking at that instead of the correct one since it uses the equivalent of `str_contains()` when looking for fields.

## Issue

- https://github.com/silverstripe/.github/issues/476