### PR TITLE
FIX Use absolute URLs for Security login/logout in SilverStripeNavigator

### DIFF
--- a/code/Controllers/ContentController.php
+++ b/code/Controllers/ContentController.php
@@ -334,12 +334,13 @@ class ContentController extends Controller
             if ($member) {
                 $firstname = Convert::raw2xml($member->FirstName);
                 $surname = Convert::raw2xml($member->Surname);
-                $logInMessage = _t(__CLASS__ . '.LOGGEDINAS', 'Logged in as') . " {$firstname} {$surname} - <a href=\"Security/logout\">" . _t(__CLASS__ . '.LOGOUT', 'Log out') . "</a>";
+                $logoutUrl = Convert::raw2att(Security::logout_url());
+                $logInMessage = _t(__CLASS__ . '.LOGGEDINAS', 'Logged in as') . " {$firstname} {$surname} - <a href=\"{$logoutUrl}\">" . _t(__CLASS__ . '.LOGOUT', 'Log out') . "</a>";
             } else {
                 $logInMessage = sprintf(
                     '%s - <a href="%s">%s</a>',
                     _t(__CLASS__ . '.NOTLOGGEDIN', 'Not logged in'),
-                    Security::config()->login_url,
+                    Convert::raw2att(Security::login_url()),
                     _t(__CLASS__ . '.LOGIN', 'Login') . "</a>"
                 );
             }


### PR DESCRIPTION

## Description
When enable_base_tag is false (or removed in future), relative URLs like "Security/logout" resolve incorrectly relative to the current page path. Use Security::logout_url() and Security::login_url() which prepend Director::baseURL() to construct correct absolute URLs.

## Manual testing steps
 * Set enable_base_tag = false
 * Log into the CMS and then go back to the main site (so SilverstripeNavigator displays)
 * Visit a sub-page (so relative links will break)
 * Confirm that the logout link points to example.com/Security/logout, not example.com/subfolder/Security/logout
 * 
## Issues
- #3162

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
