### PR TITLE
DOC Fix typos with codespell in comments, annotations

### DIFF
--- a/client/src/legacy/CMSMain.EditForm.js
+++ b/client/src/legacy/CMSMain.EditForm.js
@@ -70,7 +70,7 @@ $.entwine('ss', function($){
 		 *
 		 * Update the related fields if appropriate
 		 * (String) title The new title
-		 * (Stirng) origTitle The original title
+		 * (String) origTitle The original title
 		 */
 		updateRelatedFields: function(title, origTitle) {
 			// Update these fields only if their value was originally the same as the title

--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1209,7 +1209,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
         $record->invokeWithExtensions('updateTreeIconClasses', $iconClasses);
         $titleText = $record->getTreeTitle();
         // Hierarchy::getTreeTitle() will call Convert::raw2xml(), though this may have been
-        // overriden by another method that doesn't call this
+        // overridden by another method that doesn't call this
         // Check to see if it was converted first by calling the xml2raw() to before calling
         // raw2xml() to ensure we don't double convert and end up with "&amp;amp;"
         $wasChanged = Convert::xml2raw($titleText) !== $titleText;
@@ -1419,7 +1419,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
 
         $this->extend('updateEditForm', $form);
 
-        // Use custom reqest handler for LeftAndMain requests;
+        // Use custom request handler for LeftAndMain requests;
         // CMS Forms cannot be identified solely by name, but also need ID (and sometimes OtherID)
         $form->setRequestHandler(
             LeftAndMainFormRequestHandler::create($form, [$id])

--- a/code/Controllers/CMSSiteTreeFilter.php
+++ b/code/Controllers/CMSSiteTreeFilter.php
@@ -7,14 +7,14 @@ use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\ORM\DataList;
 
 /**
- * Base class for filtering againt SiteTree for certain statuses (e.g. archived or draft only).
+ * Base class for filtering against SiteTree for certain statuses (e.g. archived or draft only).
  */
 abstract class CMSSiteTreeFilter
 {
     use Injectable;
 
     /**
-     * Returns a sorted array of all implementators of CMSSiteTreeFilter, suitable for use in a dropdown.
+     * Returns a sorted array of all implementers of CMSSiteTreeFilter, suitable for use in a dropdown.
      *
      * @return array<string, CMSSiteTreeFilter>
      */

--- a/code/Controllers/CMSSiteTreeFilter_Search.php
+++ b/code/Controllers/CMSSiteTreeFilter_Search.php
@@ -13,7 +13,7 @@ class CMSSiteTreeFilter_Search extends CMSSiteTreeFilter
     }
 
     /**
-     * Retun an array of maps containing the keys, 'ID' and 'ParentID' for each page to be displayed
+     * Returns an array of maps containing the keys, 'ID' and 'ParentID' for each page to be displayed
      * in the search.
      */
     public function getFilteredPages(DataList $list): DataList

--- a/code/Model/SiteTree.php
+++ b/code/Model/SiteTree.php
@@ -894,7 +894,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
      * Return a string of the form "parent - page" or "grandparent - parent - page" using page titles
      *
      * @param int $level The maximum amount of levels to traverse.
-     * @param string $separator Seperating string
+     * @param string $separator Separating string
      * @return string The resulting string
      */
     public function NestedTitle($level = 2, $separator = " - ")
@@ -1705,7 +1705,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
         $filter = URLSegmentFilter::create();
         $filteredTitle = $filter->filter($title);
 
-        // Fallback to generic page name if path is empty (= no valid, convertable characters)
+        // Fallback to generic page name if path is empty (= no valid, convertible characters)
         if (!$filteredTitle || $filteredTitle == '-' || $filteredTitle == '-1') {
             $filteredTitle = "page-$this->ID";
         }
@@ -1789,7 +1789,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     /**
      * Returns the pages that depend on this page. This includes virtual pages, pages that link to it, etc.
      *
-     * @param bool $includeVirtuals Set to false to exlcude virtual pages.
+     * @param bool $includeVirtuals Set to false to exclude virtual pages.
      * @return ArrayList<SiteTree>
      */
     public function DependentPages($includeVirtuals = true)
@@ -2413,7 +2413,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     }
 
     /**
-     * Update draft dependant pages
+     * Update draft dependent pages
      */
     protected function onAfterRevertToLive()
     {
@@ -2605,7 +2605,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
     /**
      * Find the controller name by our convention of {$ModelClass}Controller
-     * Can be overriden by config variable
+     * Can be overridden by config variable
      *
      * @return string
      */
@@ -2665,7 +2665,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
 
     /**
      * Stops extendCMSFields() being called on getCMSFields(). This is useful when you need access to fields added by
-     * subclasses of SiteTree in a extension. Call before calling parent::getCMSFields(), and reenable afterwards.
+     * subclasses of SiteTree in a extension. Call before calling parent::getCMSFields(), and re-enable afterwards.
      */
     public static function disableCMSFieldsExtensions()
     {
@@ -2787,7 +2787,7 @@ class SiteTree extends DataObject implements PermissionProvider, i18nEntityProvi
     }
 
     /**
-     * Update dependant pages
+     * Update dependent pages
      */
     protected function updateDependentPages()
     {

--- a/code/Model/SiteTreeLinkTracking.php
+++ b/code/Model/SiteTreeLinkTracking.php
@@ -154,7 +154,7 @@ class SiteTreeLinkTracking extends Extension
     }
 
     /**
-     * Scrape the content of a field to detect anly links to local SiteTree pages or files
+     * Scrape the content of a field to detect any links to local SiteTree pages or files
      *
      * @param string $fieldName The name of the field on {@link @owner} to scrape
      * @param bool &$anyBroken Will be flagged to true (by reference) if a link is broken.

--- a/code/Model/VirtualPage.php
+++ b/code/Model/VirtualPage.php
@@ -18,7 +18,7 @@ use SilverStripe\View\HTML;
 
 /**
  * Virtual Page creates an instance of a  page, with the same fields that the original page had, but readonly.
- * This allows you can have a page in mulitple places in the site structure, with different children without
+ * This allows you can have a page in multiple places in the site structure, with different children without
  * duplicating the content.
  *
  * Note: This Only duplicates $db fields and not the $has_one etc..

--- a/tests/behat/src/LoginContext.php
+++ b/tests/behat/src/LoginContext.php
@@ -28,7 +28,7 @@ class LoginContext extends BehatLoginContext
         $member = $this->generateMemberWithPermission($email, $password, $permCode);
         $canEdit = strstr($negative ?? '', 'not') ? false : true;
         // Flush the SiteConfig cache so that siteconfig behat tests that update a
-        // SiteConfig DataObject will not be referring to a stale verion of itself
+        // SiteConfig DataObject will not be referring to a stale version of itself
         // which can happen because SiteConfig::current_site_config() uses a cached query
         SiteConfig::current_site_config()->flushCache();
         if ($canEdit) {

--- a/tests/behat/src/ThemeContext.php
+++ b/tests/behat/src/ThemeContext.php
@@ -87,7 +87,7 @@ class ThemeContext implements Context
     public function cleanThemesAfterScenario()
     {
         // Restore any created/modified files.
-        //  - If modified, revert then to original contnet
+        //  - If modified, revert then to original content
         //  - If created, delete them
         if ($this->restoreFiles) {
             foreach ($this->restoreFiles as $file => $origContent) {

--- a/tests/php/Controllers/ModelAsControllerTest.php
+++ b/tests/php/Controllers/ModelAsControllerTest.php
@@ -301,7 +301,7 @@ class ModelAsControllerTest extends FunctionalTest
         Config::modify()->set(SiteTree::class, 'nested_urls', true);
 
         $draft = new SiteTree();
-        $draft->Title = 'Root Leve Draft Page';
+        $draft->Title = 'Root Level Draft Page';
         $draft->URLSegment = 'root';
         $draft->write();
 

--- a/tests/php/Model/SiteTreeBrokenLinksTest.php
+++ b/tests/php/Model/SiteTreeBrokenLinksTest.php
@@ -262,7 +262,7 @@ class SiteTreeBrokenLinksTest extends SapphireTest
 
     public function testRevertToLiveFixesBrokenLinks()
     {
-        // Create page and virutal page
+        // Create page and virtual page
         $page = new SiteTree();
         $page->Title = "source";
         $page->write();

--- a/tests/php/Model/VirtualPageTest.php
+++ b/tests/php/Model/VirtualPageTest.php
@@ -329,7 +329,7 @@ class VirtualPageTest extends FunctionalTest
 
     public function testUnpublishingSourcePageOfAVirtualPageAlsoUnpublishesVirtualPage()
     {
-        // Create page and virutal page
+        // Create page and virtual page
         $p = new SiteTree();
         $p->Title = "source";
         $p->write();
@@ -361,7 +361,7 @@ class VirtualPageTest extends FunctionalTest
 
     public function testDeletingFromLiveSourcePageOfAVirtualPageAlsoUnpublishesVirtualPage()
     {
-        // Create page and virutal page
+        // Create page and virtual page
         $p = new SiteTree();
         $p->Title = "source";
         $p->write();


### PR DESCRIPTION
## Description
Corrects spelling errors detected by codespell:
- Comments and PHPDoc annotations in core classes
- JavaScript documentation comments  
- Test file comments

No functional changes.

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green