### PR TITLE
[CVE-2026-54717] Escape page titles in breadcrumbs for page list view

### DIFF
--- a/code/Controllers/CMSMain.php
+++ b/code/Controllers/CMSMain.php
@@ -1646,16 +1646,7 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
                     $this->LinkRecordEdit($item->ID),
                     $this->getRecordTreeMarkup($item) // returns HTML, does its own escaping
                 );
-                $pages = $item->getAncestors();
-                $pageNames = [];
-                foreach ($pages as $page) {
-                    $pageNames[] = $page->MenuTitle ?: $page->Title;
-                }
-                $breadcrumbs = implode('/', $pageNames);
-                if ($breadcrumbs) {
-                    $breadcrumbs .= '/';
-                }
-                return $title . sprintf('<p class="small cms-list__item-breadcrumbs">%s</p>', $breadcrumbs);
+                return $title . $this->getListViewBreadcrumbs($item);
             }
         ]);
 
@@ -1683,6 +1674,26 @@ class CMSMain extends LeftAndMain implements CurrentRecordIdentifier, Permission
 
         $listview->disableSecurityToken();
         return $listview;
+    }
+
+    /**
+     * Build the escaped breadcrumb HTML fragment shown beneath a record's title in the list view.
+     *
+     * The ancestor titles are user-supplied content, so they must be escaped before being placed
+     * into the HTMLFragment to avoid XSS.
+     */
+    private function getListViewBreadcrumbs(DataObject $item): string
+    {
+        /** @var DataObject&Hierarchy $item */
+        $pageNames = [];
+        foreach ($item->getAncestors() as $page) {
+            $pageNames[] = Convert::raw2xml($page->MenuTitle ?: $page->Title);
+        }
+        $breadcrumbs = implode('/', $pageNames);
+        if ($breadcrumbs) {
+            $breadcrumbs .= '/';
+        }
+        return sprintf('<p class="small cms-list__item-breadcrumbs">%s</p>', $breadcrumbs);
     }
 
     /**

--- a/tests/php/Controllers/CMSMainTest.php
+++ b/tests/php/Controllers/CMSMainTest.php
@@ -39,8 +39,6 @@ use SilverStripe\SiteConfig\SiteConfig;
 use SilverStripe\Versioned\RecursivePublishable;
 use SilverStripe\Versioned\Versioned;
 
-use function Embed\html;
-
 class CMSMainTest extends FunctionalTest
 {
     protected static $fixture_file = 'CMSMainTest.yml';
@@ -942,6 +940,55 @@ class CMSMainTest extends FunctionalTest
         $html = $cmsMain->getRecordTreeMarkup($page);
         $actual = strip_tags($html);
         $this->assertSame($expected, $actual);
+    }
+
+    public static function provideGetListViewBreadcrumbs(): array
+    {
+        return [
+            'plain' => [
+                'parentTitle' => 'About Us',
+                'expected' => '<p class="small cms-list__item-breadcrumbs">About Us/</p>',
+            ],
+            'amp' => [
+                'parentTitle' => 'About & Us',
+                'expected' => '<p class="small cms-list__item-breadcrumbs">About &amp; Us/</p>',
+            ],
+            'script-tag' => [
+                'parentTitle' => '<script>alert(1)</script>',
+                'expected' => '<p class="small cms-list__item-breadcrumbs">'
+                    . '&lt;script&gt;alert(1)&lt;/script&gt;/</p>',
+            ],
+            'double-quote' => [
+                'parentTitle' => 'About " Us',
+                'expected' => '<p class="small cms-list__item-breadcrumbs">About &quot; Us/</p>',
+            ],
+        ];
+    }
+
+    #[DataProvider('provideGetListViewBreadcrumbs')]
+    public function testGetListViewBreadcrumbs(string $parentTitle, string $expected): void
+    {
+        $parent = new SiteTree(['Title' => $parentTitle]);
+        $parent->write();
+        $child = new SiteTree(['Title' => 'Child', 'ParentID' => $parent->ID]);
+        $child->write();
+
+        $controller = new CMSMain();
+        $reflectionMethod = new ReflectionMethod($controller, 'getListViewBreadcrumbs');
+        $this->assertSame($expected, $reflectionMethod->invoke($controller, $child));
+    }
+
+    public function testGetListViewBreadcrumbsNoAncestors(): void
+    {
+        $page = new SiteTree(['Title' => 'Top Level']);
+        $page->write();
+
+        $controller = new CMSMain();
+        $reflectionMethod = new ReflectionMethod($controller, 'getListViewBreadcrumbs');
+        $this->assertSame(
+            '<p class="small cms-list__item-breadcrumbs"></p>',
+            $reflectionMethod->invoke($controller, $page)
+        );
     }
 
     public function testGetArchiveWarningMessage(): void


### PR DESCRIPTION
The PHP 8.5 endtoend job1 + job2 failing looks like a sporadic CI failure - the PHP 8.3 endtoend job1 + job2 passed -- will rerun both
